### PR TITLE
Optimization attempt [WIP]

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,6 +43,7 @@ android {
 
   buildTypes {
     create("benchmark") {
+      initWith(buildTypes.getByName("release"))
       signingConfig = signingConfigs.getByName("debug")
       matchingFallbacks += listOf("release")
       isDebuggable = false

--- a/app/src/main/kotlin/com/skydoves/cloudydemo/MainActivity.kt
+++ b/app/src/main/kotlin/com/skydoves/cloudydemo/MainActivity.kt
@@ -16,14 +16,33 @@
 package com.skydoves.cloudydemo
 
 import android.os.Bundle
+import android.view.Choreographer
+import android.view.View
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.runtime.Recomposer
 import com.skydoves.cloudydemo.theme.PosterTheme
 
 class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-
+    launchIdlenessTracking()
     setContent { PosterTheme { Main() } }
   }
 }
+
+private fun ComponentActivity.launchIdlenessTracking() {
+  val contentView: View = findViewById(android.R.id.content)
+  val callback: Choreographer.FrameCallback = object : Choreographer.FrameCallback {
+    override fun doFrame(frameTimeNanos: Long) {
+      if (Recomposer.runningRecomposers.value.any { it.hasPendingWork }) {
+        contentView.contentDescription = "COMPOSE-BUSY"
+      } else {
+        contentView.contentDescription = "COMPOSE-IDLE"
+      }
+      Choreographer.getInstance().postFrameCallback(this)
+    }
+  }
+  Choreographer.getInstance().postFrameCallback(callback)
+}
+

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -60,6 +60,7 @@ android {
 }
 
 dependencies {
+  implementation(libs.androidx.test.junit)
   implementation(libs.androidx.test.runner)
   implementation(libs.androidx.test.uiautomator)
   implementation(libs.androidx.benchmark.macro)

--- a/benchmark/src/main/kotlin/com/skydoves/cloudy/benchmark/CloudyBenchmark.kt
+++ b/benchmark/src/main/kotlin/com/skydoves/cloudy/benchmark/CloudyBenchmark.kt
@@ -1,0 +1,45 @@
+package com.skydoves.cloudy.benchmark
+
+import androidx.benchmark.macro.CompilationMode
+import androidx.benchmark.macro.ExperimentalMetricApi
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.TraceSectionMetric
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.Until
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CloudyBenchmark {
+    @get:Rule
+    val benchmarkRule = MacrobenchmarkRule()
+
+    @OptIn(ExperimentalMetricApi::class)
+    @Test
+    fun measureRendering() = benchmarkRule.measureRepeated(
+      packageName = "com.skydoves.cloudydemo",
+      compilationMode = CompilationMode.Full(),
+      metrics = listOf(
+        TraceSectionMetric(sectionName = "blurScope", mode = TraceSectionMetric.Mode.Average),
+        TraceSectionMetric(sectionName = "renderImage", mode = TraceSectionMetric.Mode.Average),
+        TraceSectionMetric(sectionName = "fetchBitmap", mode = TraceSectionMetric.Mode.Average),
+        TraceSectionMetric(sectionName = "iterativeBlur", mode = TraceSectionMetric.Mode.Average),
+        TraceSectionMetric(sectionName = "blur", mode = TraceSectionMetric.Mode.Average),
+        TraceSectionMetric(sectionName = "nativeBlurBitmap", mode = TraceSectionMetric.Mode.Average),
+      ),
+      iterations = 4,
+      startupMode = StartupMode.WARM
+    ) {
+      pressHome()
+      startActivityAndWait()
+      device.awaitComposeIdle()
+    }
+
+  private fun UiDevice.awaitComposeIdle(timeout: Long = 3000) {
+    wait(Until.findObject(By.desc("COMPOSE-IDLE")), timeout)
+  }
+}

--- a/cloudy/build.gradle.kts
+++ b/cloudy/build.gradle.kts
@@ -78,4 +78,5 @@ kotlin {
 dependencies {
   implementation(libs.androidx.compose.ui)
   implementation(libs.androidx.compose.runtime)
+  implementation(libs.androidx.tracing.ktx)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ androidxProfileinstaller = "1.4.1"
 androidxUiAutomator = "2.3.0"
 landscapist = "2.4.2"
 spotless = "6.7.0"
+tracingKtx = "1.3.0-alpha02"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -48,3 +49,4 @@ androidx-test-junit = { group = "androidx.test.ext", name = "junit-ktx", version
 androidx-test-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "androidxUiAutomator" }
 landscapist-glide = { group = "com.github.skydoves", name = "landscapist-glide", version.ref = "landscapist" }
 landscapist-transformation = { group = "com.github.skydoves", name = "landscapist-transformation", version.ref = "landscapist" }
+androidx-tracing-ktx = { module = "androidx.tracing:tracing-ktx", version.ref = "tracingKtx" }


### PR DESCRIPTION
> [!NOTE]  
> This is a draft version of the PR, which I will continue updating during development. Currently, there are several logs and benchmark traces in the code to visualize performance bottlenecks and identify areas needing optimization. These logs and traces will be removed in the final version. 
Please note that the code changes in this PR are not final. These are preliminary modifications aimed at outlining the potential impact of the optimization strategies. The final PR version will include improvements for readability, efficiency, and maintainability.

Related to #43, #44

## Summary

I created a basic benchmark to track key performance metrics. Here are the results:
```
blurScopeAverageMs        18.6
renderImageAverageMs       4.5
fetchBitmapAverageMs       5.9
blurAverageMs              6.2
iterativeBlurAverageMs     8.1
nativeBlurBitmapAverageMs  6.1
```

Perfetto trace to examine the hierarchy and relative cost of each operation
<img width="823" alt="cloudy_metrics1" src="https://github.com/user-attachments/assets/508c58f5-ebf3-43ed-ad9d-cdf14b1a00fa">

`blurScopeAverageMs` represents the total time spent on the entire blurring operation. Currently, this takes about 18ms per frame, which is quite expensive. Given the display's refresh rate of 90Hz on a Pixel 6 I tested on, our frame budget is around 11ms, meaning this blur process is exceeding our budget.

### Analysis

We have a few costly operations, including:
1. **Rendering to Hardware Bitmaps** using `GraphicsLayer` and then **fetching data from GPU memory to CPU**, which is expensive and time-intensive.
2. **Blurring Process** – well optimized with RenderScript Toolkit(ported version) using SIMD and ARM assembly but still costly when run on full-resolution bitmaps.

### Potential Optimizations

#### 1. Move Blurring to a Processing Queue
   To prevent blocking the `onDraw`, we could offload the blurring to a processing queue that continuously updates an output state, drawing the resultant bitmap as needed.

#### 2. Output Bitmap Caching
   Simple caching of the output bitmap has already shown improvements. By reusing the output bitmap instead of recreating it each time, we reduce redundant allocations. To further refine this, we’ll need to monitor the cached bitmap’s configuration and dimensions to ensure they match the input bitmap.

### Benchmark Results with Caching

Initial benchmarking shows improvements with cached output bitmaps:
```
// Performance comparison
blurScopeAverageMs        18.6 ➔ 18.8  🟡 (+0.2) [Minimal regression]
blurAverageMs              6.2 ➔ 5.6  ✅ (-0.6) [Improvement]
iterativeBlurAverageMs     8.1 ➔ 7.3  ✅ (-0.8) [Improvement]
nativeBlurBitmapAverageMs  6.1 ➔ 5.6  ✅ (-0.5) [Improvement]
...
```

### Additional Improvements Under Consideration

- **Input Bitmap Downsampling**: Since blurring is a lossy operation, we could reduce the input bitmap size, especially for higher blur radius, to lower the processing overhead without significant visual impact.

This is an ongoing PR; further updates and optimizations will be documented as development progresses. At least I'll try 😅