### PR TITLE
[CMP] Add Unit Tests for CloudyState, PlatformBitmap

### DIFF
--- a/cloudy/build.gradle.kts
+++ b/cloudy/build.gradle.kts
@@ -114,5 +114,23 @@ kotlin {
       implementation(libs.compose.resources)
       implementation(libs.compose.ui.tooling.preview)
     }
+
+    commonTest.dependencies {
+      implementation(libs.kotlin.test)
+      implementation(libs.kotlinx.coroutines.test)
+    }
+
+    androidUnitTest.dependencies {
+      implementation(libs.kotlin.test)
+      implementation(libs.kotlinx.coroutines.test)
+      implementation(libs.androidx.compose.ui.test)
+      implementation(libs.androidx.compose.ui.test.junit4)
+      implementation(libs.junit4)
+    }
+
+    iosTest.dependencies {
+      implementation(libs.kotlin.test)
+      implementation(libs.kotlinx.coroutines.test)
+    }
   }
 }

--- a/cloudy/build.gradle.kts
+++ b/cloudy/build.gradle.kts
@@ -126,6 +126,8 @@ kotlin {
       implementation(libs.androidx.compose.ui.test)
       implementation(libs.androidx.compose.ui.test.junit4)
       implementation(libs.junit4)
+      implementation(libs.mockito)
+      implementation(libs.mockito.inline)
     }
 
     iosTest.dependencies {

--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/Cloudy.android.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/Cloudy.android.kt
@@ -38,19 +38,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 /**
- * Android implementation of the cloudy modifier that applies blur effects to composables.
- * This is the actual implementation for the expect function declared in commonMain.
- * * For Android 12+ devices in preview mode, it falls back to the platform's blur modifier.
- * For runtime execution, it uses a custom implementation with graphics layers and
- * native iterative blur processing for optimal performance.
- * * The implementation captures the composable content in a graphics layer, applies
- * iterative blur processing using native code, and overlays the result.
- * * @param radius The blur radius in pixels (1-25). Higher values create more blur but take longer to process.
- * @param enabled Whether the blur effect is enabled. When false, returns the original modifier unchanged.
- * @param onStateChanged Callback that receives updates about the blur processing state.
- * @return Modified Modifier with blur effect applied.
- */
-/**
  * Applies a blur effect to the composable using a native iterative blur algorithm.
  *
  * If `enabled` is false, the modifier is not applied. In Android Studio preview mode on Android 12+, the platform's native blur is used for inspection. Otherwise, the modifier captures the composable's content, applies a blur with the specified `radius`, and reports processing state changes via `onStateChanged`.

--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/Cloudy.android.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/Cloudy.android.kt
@@ -16,6 +16,7 @@
 package com.skydoves.cloudy
 
 import android.graphics.Bitmap
+import androidx.annotation.IntRange
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -61,7 +62,7 @@ import kotlinx.coroutines.launch
  */
 @Composable
 public actual fun Modifier.cloudy(
-  radius: Int,
+  @IntRange(from = 0) radius: Int,
   enabled: Boolean,
   onStateChanged: (CloudyState) -> Unit
 ): Modifier {

--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/internals/render/RenderScriptToolkit.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/internals/render/RenderScriptToolkit.kt
@@ -313,11 +313,11 @@ internal fun validateBitmap(
 }
 
 /**
-   * Creates a new bitmap with the same width, height, and configuration as the input bitmap.
-   *
-   * @param inputBitmap The bitmap whose dimensions and configuration are to be matched.
-   * @return A new bitmap instance compatible with the input bitmap.
-   */
+ * Creates a new bitmap with the same width, height, and configuration as the input bitmap.
+ *
+ * @param inputBitmap The bitmap whose dimensions and configuration are to be matched.
+ * @return A new bitmap instance compatible with the input bitmap.
+ */
 internal fun createCompatibleBitmap(inputBitmap: Bitmap) =
   Bitmap.createBitmap(inputBitmap.width, inputBitmap.height, inputBitmap.config!!)
 

--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/internals/render/RenderScriptToolkit.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/internals/render/RenderScriptToolkit.kt
@@ -277,15 +277,14 @@ internal class Rgba3dArray(val values: ByteArray, val sizeX: Int, val sizeY: Int
 }
 
 /**
- * Ensures that the provided bitmap is compatible with RenderScriptToolkit operations.
+ * Validates that a bitmap is compatible with RenderScriptToolkit operations.
  *
- * Validates that the bitmap uses a supported configuration (ARGB_8888, or ALPHA_8 if allowed)
- * and that its row stride matches the expected value for its width and pixel format.
+ * Checks that the bitmap uses a supported configuration (ARGB_8888, or ALPHA_8 if allowed) and that its row stride matches the expected value for its width and pixel format.
  *
- * @param function The name of the calling function, used in error messages.
+ * @param function The name of the calling function, used for error reporting.
  * @param inputBitmap The bitmap to validate.
- * @param alphaAllowed If true, allows ALPHA_8 bitmaps in addition to ARGB_8888.
- * @throws IllegalArgumentException if the bitmap configuration or row stride is invalid.
+ * @param alphaAllowed Whether ALPHA_8 bitmaps are permitted in addition to ARGB_8888.
+ * @throws IllegalArgumentException If the bitmap configuration or row stride is invalid.
  */
 internal fun validateBitmap(
   function: String,
@@ -313,9 +312,9 @@ internal fun validateBitmap(
 }
 
 /**
- * Creates a new bitmap with the same width, height, and configuration as the input bitmap.
+ * Creates a new bitmap with the same dimensions and configuration as the given bitmap.
  *
- * @param inputBitmap The bitmap whose dimensions and configuration are to be matched.
+ * @param inputBitmap The bitmap to match in size and configuration.
  * @return A new bitmap instance compatible with the input bitmap.
  */
 internal fun createCompatibleBitmap(inputBitmap: Bitmap) =

--- a/cloudy/src/androidUnitTest/kotlin/com/skydoves/cloudy/CloudyStateTest.kt
+++ b/cloudy/src/androidUnitTest/kotlin/com/skydoves/cloudy/CloudyStateTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.cloudy
+
+import android.graphics.Bitmap
+import org.junit.Test
+import org.junit.Assert.*
+import org.mockito.Mockito.*
+
+internal class CloudyStateTest {
+
+  @Test
+  fun `Nothing state should be singleton`() {
+    val state1 = CloudyState.Nothing
+    val state2 = CloudyState.Nothing
+    
+    assertSame(state1, state2)
+  }
+
+  @Test
+  fun `Loading state should be singleton`() {
+    val state1 = CloudyState.Loading
+    val state2 = CloudyState.Loading
+    
+    assertSame(state1, state2)
+  }
+
+  @Test
+  fun `Success state should contain bitmap`() {
+    val mockBitmap = createMockPlatformBitmap(100, 100)
+    val state = CloudyState.Success(mockBitmap)
+    
+    assertEquals(mockBitmap, state.bitmap)
+  }
+
+  @Test
+  fun `Success state can contain null bitmap`() {
+    val state = CloudyState.Success(null)
+    
+    assertNull(state.bitmap)
+  }
+
+  @Test
+  fun `Error state should contain throwable`() {
+    val exception = RuntimeException("Test error")
+    val state = CloudyState.Error(exception)
+    
+    assertEquals(exception, state.throwable)
+  }
+
+  @Test
+  fun `Success states with same bitmap should be equal`() {
+    val mockBitmap = createMockPlatformBitmap(100, 100)
+    val state1 = CloudyState.Success(mockBitmap)
+    val state2 = CloudyState.Success(mockBitmap)
+    
+    assertEquals(state1, state2)
+  }
+
+  @Test
+  fun `Success states with different bitmaps should not be equal`() {
+    val mockBitmap1 = createMockPlatformBitmap(100, 100)
+    val mockBitmap2 = createMockPlatformBitmap(200, 200)
+    val state1 = CloudyState.Success(mockBitmap1)
+    val state2 = CloudyState.Success(mockBitmap2)
+    
+    assertNotEquals(state1, state2)
+  }
+
+  @Test
+  fun `Error states with same throwable should be equal`() {
+    val exception = RuntimeException("Test error")
+    val state1 = CloudyState.Error(exception)
+    val state2 = CloudyState.Error(exception)
+    
+    assertEquals(state1, state2)
+  }
+
+  @Test
+  fun `Error states with different throwables should not be equal`() {
+    val exception1 = RuntimeException("Error 1")
+    val exception2 = RuntimeException("Error 2")
+    val state1 = CloudyState.Error(exception1)
+    val state2 = CloudyState.Error(exception2)
+    
+    assertNotEquals(state1, state2)
+  }
+
+  private fun createMockPlatformBitmap(width: Int, height: Int): PlatformBitmap {
+    val mockBitmap = mock(Bitmap::class.java)
+    `when`(mockBitmap.width).thenReturn(width)
+    `when`(mockBitmap.height).thenReturn(height)
+    `when`(mockBitmap.isRecycled).thenReturn(false)
+    `when`(mockBitmap.isMutable).thenReturn(true)
+    
+    return PlatformBitmap(mockBitmap)
+  }
+} 

--- a/cloudy/src/androidUnitTest/kotlin/com/skydoves/cloudy/CloudyStateTest.kt
+++ b/cloudy/src/androidUnitTest/kotlin/com/skydoves/cloudy/CloudyStateTest.kt
@@ -16,9 +16,13 @@
 package com.skydoves.cloudy
 
 import android.graphics.Bitmap
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Test
-import org.junit.Assert.*
-import org.mockito.Mockito.*
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 
 internal class CloudyStateTest {
 
@@ -26,7 +30,7 @@ internal class CloudyStateTest {
   fun `Nothing state should be singleton`() {
     val state1 = CloudyState.Nothing
     val state2 = CloudyState.Nothing
-    
+
     assertSame(state1, state2)
   }
 
@@ -34,7 +38,7 @@ internal class CloudyStateTest {
   fun `Loading state should be singleton`() {
     val state1 = CloudyState.Loading
     val state2 = CloudyState.Loading
-    
+
     assertSame(state1, state2)
   }
 
@@ -42,14 +46,14 @@ internal class CloudyStateTest {
   fun `Success state should contain bitmap`() {
     val mockBitmap = createMockPlatformBitmap(100, 100)
     val state = CloudyState.Success(mockBitmap)
-    
+
     assertEquals(mockBitmap, state.bitmap)
   }
 
   @Test
   fun `Success state can contain null bitmap`() {
     val state = CloudyState.Success(null)
-    
+
     assertNull(state.bitmap)
   }
 
@@ -57,7 +61,7 @@ internal class CloudyStateTest {
   fun `Error state should contain throwable`() {
     val exception = RuntimeException("Test error")
     val state = CloudyState.Error(exception)
-    
+
     assertEquals(exception, state.throwable)
   }
 
@@ -66,7 +70,7 @@ internal class CloudyStateTest {
     val mockBitmap = createMockPlatformBitmap(100, 100)
     val state1 = CloudyState.Success(mockBitmap)
     val state2 = CloudyState.Success(mockBitmap)
-    
+
     assertEquals(state1, state2)
   }
 
@@ -76,7 +80,7 @@ internal class CloudyStateTest {
     val mockBitmap2 = createMockPlatformBitmap(200, 200)
     val state1 = CloudyState.Success(mockBitmap1)
     val state2 = CloudyState.Success(mockBitmap2)
-    
+
     assertNotEquals(state1, state2)
   }
 
@@ -85,7 +89,7 @@ internal class CloudyStateTest {
     val exception = RuntimeException("Test error")
     val state1 = CloudyState.Error(exception)
     val state2 = CloudyState.Error(exception)
-    
+
     assertEquals(state1, state2)
   }
 
@@ -95,7 +99,7 @@ internal class CloudyStateTest {
     val exception2 = RuntimeException("Error 2")
     val state1 = CloudyState.Error(exception1)
     val state2 = CloudyState.Error(exception2)
-    
+
     assertNotEquals(state1, state2)
   }
 
@@ -105,7 +109,7 @@ internal class CloudyStateTest {
     `when`(mockBitmap.height).thenReturn(height)
     `when`(mockBitmap.isRecycled).thenReturn(false)
     `when`(mockBitmap.isMutable).thenReturn(true)
-    
+
     return PlatformBitmap(mockBitmap)
   }
-} 
+}

--- a/cloudy/src/androidUnitTest/kotlin/com/skydoves/cloudy/PlatformBitmapTest.kt
+++ b/cloudy/src/androidUnitTest/kotlin/com/skydoves/cloudy/PlatformBitmapTest.kt
@@ -1,0 +1,198 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.cloudy
+
+import android.graphics.Bitmap
+import org.junit.Test
+import org.junit.Assert.*
+import org.mockito.Mockito.*
+
+internal class PlatformBitmapTest {
+
+  @Test
+  fun `PlatformBitmap should have correct width and height`() {
+    val width = 100
+    val height = 200
+    val mockBitmap = mock(Bitmap::class.java)
+    `when`(mockBitmap.width).thenReturn(width)
+    `when`(mockBitmap.height).thenReturn(height)
+    `when`(mockBitmap.isRecycled).thenReturn(false)
+    `when`(mockBitmap.isMutable).thenReturn(true)
+    
+    val platformBitmap = PlatformBitmap(mockBitmap)
+    
+    assertEquals(width, platformBitmap.width)
+    assertEquals(height, platformBitmap.height)
+  }
+
+  @Test
+  fun `PlatformBitmap should be recyclable when bitmap is mutable`() {
+    val mockBitmap = mock(Bitmap::class.java)
+    `when`(mockBitmap.width).thenReturn(100)
+    `when`(mockBitmap.height).thenReturn(100)
+    `when`(mockBitmap.isRecycled).thenReturn(false)
+    `when`(mockBitmap.isMutable).thenReturn(true)
+    
+    val platformBitmap = PlatformBitmap(mockBitmap)
+    
+    assertTrue(platformBitmap.isRecyclable)
+  }
+
+  @Test
+  fun `PlatformBitmap should not be recyclable when bitmap is recycled`() {
+    val mockBitmap = mock(Bitmap::class.java)
+    `when`(mockBitmap.width).thenReturn(100)
+    `when`(mockBitmap.height).thenReturn(100)
+    `when`(mockBitmap.isRecycled).thenReturn(true)
+    `when`(mockBitmap.isMutable).thenReturn(true)
+    
+    val platformBitmap = PlatformBitmap(mockBitmap)
+    
+    assertFalse(platformBitmap.isRecyclable)
+  }
+
+  @Test
+  fun `PlatformBitmap should not be recyclable when bitmap is immutable`() {
+    val mockBitmap = mock(Bitmap::class.java)
+    `when`(mockBitmap.width).thenReturn(100)
+    `when`(mockBitmap.height).thenReturn(100)
+    `when`(mockBitmap.isRecycled).thenReturn(false)
+    `when`(mockBitmap.isMutable).thenReturn(false)
+    
+    val platformBitmap = PlatformBitmap(mockBitmap)
+    
+    assertFalse(platformBitmap.isRecyclable)
+  }
+
+  @Test
+  fun `createCompatible should create new bitmap with same dimensions`() {
+    val mockOriginalBitmap = mock(Bitmap::class.java)
+    `when`(mockOriginalBitmap.width).thenReturn(100)
+    `when`(mockOriginalBitmap.height).thenReturn(200)
+    `when`(mockOriginalBitmap.config).thenReturn(Bitmap.Config.ARGB_8888)
+    `when`(mockOriginalBitmap.isRecycled).thenReturn(false)
+    `when`(mockOriginalBitmap.isMutable).thenReturn(true)
+    
+    val mockCompatibleBitmap = mock(Bitmap::class.java)
+    `when`(mockCompatibleBitmap.width).thenReturn(100)
+    `when`(mockCompatibleBitmap.height).thenReturn(200)
+    `when`(mockCompatibleBitmap.config).thenReturn(Bitmap.Config.ARGB_8888)
+    `when`(mockCompatibleBitmap.isRecycled).thenReturn(false)
+    `when`(mockCompatibleBitmap.isMutable).thenReturn(true)
+    
+    // Mock Bitmap.createBitmap static method
+    mockStatic(Bitmap::class.java).use { mockedStatic ->
+      mockedStatic.`when`<Bitmap> { Bitmap.createBitmap(100, 200, Bitmap.Config.ARGB_8888) }
+        .thenReturn(mockCompatibleBitmap)
+      
+      val platformBitmap = PlatformBitmap(mockOriginalBitmap)
+      val compatibleBitmap = platformBitmap.createCompatible()
+      
+      assertEquals(platformBitmap.width, compatibleBitmap.width)
+      assertEquals(platformBitmap.height, compatibleBitmap.height)
+      assertNotSame(platformBitmap, compatibleBitmap)
+    }
+  }
+
+  @Test
+  fun `createCompatible should create new bitmap with same config`() {
+    val mockOriginalBitmap = mock(Bitmap::class.java)
+    `when`(mockOriginalBitmap.width).thenReturn(100)
+    `when`(mockOriginalBitmap.height).thenReturn(100)
+    `when`(mockOriginalBitmap.config).thenReturn(Bitmap.Config.RGB_565)
+    `when`(mockOriginalBitmap.isRecycled).thenReturn(false)
+    `when`(mockOriginalBitmap.isMutable).thenReturn(true)
+    
+    val mockCompatibleBitmap = mock(Bitmap::class.java)
+    `when`(mockCompatibleBitmap.width).thenReturn(100)
+    `when`(mockCompatibleBitmap.height).thenReturn(100)
+    `when`(mockCompatibleBitmap.config).thenReturn(Bitmap.Config.RGB_565)
+    `when`(mockCompatibleBitmap.isRecycled).thenReturn(false)
+    `when`(mockCompatibleBitmap.isMutable).thenReturn(true)
+    
+    // Mock Bitmap.createBitmap static method
+    mockStatic(Bitmap::class.java).use { mockedStatic ->
+      mockedStatic.`when`<Bitmap> { Bitmap.createBitmap(100, 100, Bitmap.Config.RGB_565) }
+        .thenReturn(mockCompatibleBitmap)
+      
+      val platformBitmap = PlatformBitmap(mockOriginalBitmap)
+      val compatibleBitmap = platformBitmap.createCompatible()
+      
+      assertEquals(mockOriginalBitmap.config, compatibleBitmap.bitmap.config)
+    }
+  }
+
+  @Test
+  fun `dispose should recycle the underlying bitmap`() {
+    val mockBitmap = mock(Bitmap::class.java)
+    `when`(mockBitmap.width).thenReturn(100)
+    `when`(mockBitmap.height).thenReturn(100)
+    `when`(mockBitmap.isRecycled).thenReturn(false)
+    `when`(mockBitmap.isMutable).thenReturn(true)
+    
+    val platformBitmap = PlatformBitmap(mockBitmap)
+    
+    assertFalse(mockBitmap.isRecycled)
+    
+    platformBitmap.dispose()
+    
+    verify(mockBitmap).recycle()
+  }
+
+  @Test
+  fun `dispose should not throw exception when bitmap is already recycled`() {
+    val mockBitmap = mock(Bitmap::class.java)
+    `when`(mockBitmap.width).thenReturn(100)
+    `when`(mockBitmap.height).thenReturn(100)
+    `when`(mockBitmap.isRecycled).thenReturn(true)
+    `when`(mockBitmap.isMutable).thenReturn(true)
+    
+    val platformBitmap = PlatformBitmap(mockBitmap)
+    
+    platformBitmap.dispose()
+    platformBitmap.dispose() // Should not throw exception
+    
+    verify(mockBitmap, times(0)).recycle() // Already recycled, so recycle() should not be called
+  }
+
+  @Test
+  fun `toPlatformBitmap extension should wrap Bitmap correctly`() {
+    val mockBitmap = mock(Bitmap::class.java)
+    `when`(mockBitmap.width).thenReturn(100)
+    `when`(mockBitmap.height).thenReturn(100)
+    `when`(mockBitmap.isRecycled).thenReturn(false)
+    `when`(mockBitmap.isMutable).thenReturn(true)
+    
+    val platformBitmap = mockBitmap.toPlatformBitmap()
+    
+    assertEquals(mockBitmap, platformBitmap.bitmap)
+    assertEquals(mockBitmap.width, platformBitmap.width)
+    assertEquals(mockBitmap.height, platformBitmap.height)
+  }
+
+  @Test
+  fun `toAndroidBitmap extension should return underlying Bitmap`() {
+    val mockBitmap = mock(Bitmap::class.java)
+    `when`(mockBitmap.width).thenReturn(100)
+    `when`(mockBitmap.height).thenReturn(100)
+    `when`(mockBitmap.isRecycled).thenReturn(false)
+    `when`(mockBitmap.isMutable).thenReturn(true)
+    
+    val platformBitmap = PlatformBitmap(mockBitmap)
+    
+    assertSame(mockBitmap, platformBitmap.toAndroidBitmap())
+  }
+} 

--- a/cloudy/src/androidUnitTest/kotlin/com/skydoves/cloudy/PlatformBitmapTest.kt
+++ b/cloudy/src/androidUnitTest/kotlin/com/skydoves/cloudy/PlatformBitmapTest.kt
@@ -16,9 +16,17 @@
 package com.skydoves.cloudy
 
 import android.graphics.Bitmap
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.junit.Assert.*
-import org.mockito.Mockito.*
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
 
 internal class PlatformBitmapTest {
 
@@ -31,9 +39,9 @@ internal class PlatformBitmapTest {
     `when`(mockBitmap.height).thenReturn(height)
     `when`(mockBitmap.isRecycled).thenReturn(false)
     `when`(mockBitmap.isMutable).thenReturn(true)
-    
+
     val platformBitmap = PlatformBitmap(mockBitmap)
-    
+
     assertEquals(width, platformBitmap.width)
     assertEquals(height, platformBitmap.height)
   }
@@ -45,9 +53,9 @@ internal class PlatformBitmapTest {
     `when`(mockBitmap.height).thenReturn(100)
     `when`(mockBitmap.isRecycled).thenReturn(false)
     `when`(mockBitmap.isMutable).thenReturn(true)
-    
+
     val platformBitmap = PlatformBitmap(mockBitmap)
-    
+
     assertTrue(platformBitmap.isRecyclable)
   }
 
@@ -58,9 +66,9 @@ internal class PlatformBitmapTest {
     `when`(mockBitmap.height).thenReturn(100)
     `when`(mockBitmap.isRecycled).thenReturn(true)
     `when`(mockBitmap.isMutable).thenReturn(true)
-    
+
     val platformBitmap = PlatformBitmap(mockBitmap)
-    
+
     assertFalse(platformBitmap.isRecyclable)
   }
 
@@ -71,9 +79,9 @@ internal class PlatformBitmapTest {
     `when`(mockBitmap.height).thenReturn(100)
     `when`(mockBitmap.isRecycled).thenReturn(false)
     `when`(mockBitmap.isMutable).thenReturn(false)
-    
+
     val platformBitmap = PlatformBitmap(mockBitmap)
-    
+
     assertFalse(platformBitmap.isRecyclable)
   }
 
@@ -85,22 +93,22 @@ internal class PlatformBitmapTest {
     `when`(mockOriginalBitmap.config).thenReturn(Bitmap.Config.ARGB_8888)
     `when`(mockOriginalBitmap.isRecycled).thenReturn(false)
     `when`(mockOriginalBitmap.isMutable).thenReturn(true)
-    
+
     val mockCompatibleBitmap = mock(Bitmap::class.java)
     `when`(mockCompatibleBitmap.width).thenReturn(100)
     `when`(mockCompatibleBitmap.height).thenReturn(200)
     `when`(mockCompatibleBitmap.config).thenReturn(Bitmap.Config.ARGB_8888)
     `when`(mockCompatibleBitmap.isRecycled).thenReturn(false)
     `when`(mockCompatibleBitmap.isMutable).thenReturn(true)
-    
+
     // Mock Bitmap.createBitmap static method
     mockStatic(Bitmap::class.java).use { mockedStatic ->
       mockedStatic.`when`<Bitmap> { Bitmap.createBitmap(100, 200, Bitmap.Config.ARGB_8888) }
         .thenReturn(mockCompatibleBitmap)
-      
+
       val platformBitmap = PlatformBitmap(mockOriginalBitmap)
       val compatibleBitmap = platformBitmap.createCompatible()
-      
+
       assertEquals(platformBitmap.width, compatibleBitmap.width)
       assertEquals(platformBitmap.height, compatibleBitmap.height)
       assertNotSame(platformBitmap, compatibleBitmap)
@@ -115,22 +123,22 @@ internal class PlatformBitmapTest {
     `when`(mockOriginalBitmap.config).thenReturn(Bitmap.Config.RGB_565)
     `when`(mockOriginalBitmap.isRecycled).thenReturn(false)
     `when`(mockOriginalBitmap.isMutable).thenReturn(true)
-    
+
     val mockCompatibleBitmap = mock(Bitmap::class.java)
     `when`(mockCompatibleBitmap.width).thenReturn(100)
     `when`(mockCompatibleBitmap.height).thenReturn(100)
     `when`(mockCompatibleBitmap.config).thenReturn(Bitmap.Config.RGB_565)
     `when`(mockCompatibleBitmap.isRecycled).thenReturn(false)
     `when`(mockCompatibleBitmap.isMutable).thenReturn(true)
-    
+
     // Mock Bitmap.createBitmap static method
     mockStatic(Bitmap::class.java).use { mockedStatic ->
       mockedStatic.`when`<Bitmap> { Bitmap.createBitmap(100, 100, Bitmap.Config.RGB_565) }
         .thenReturn(mockCompatibleBitmap)
-      
+
       val platformBitmap = PlatformBitmap(mockOriginalBitmap)
       val compatibleBitmap = platformBitmap.createCompatible()
-      
+
       assertEquals(mockOriginalBitmap.config, compatibleBitmap.bitmap.config)
     }
   }
@@ -142,13 +150,13 @@ internal class PlatformBitmapTest {
     `when`(mockBitmap.height).thenReturn(100)
     `when`(mockBitmap.isRecycled).thenReturn(false)
     `when`(mockBitmap.isMutable).thenReturn(true)
-    
+
     val platformBitmap = PlatformBitmap(mockBitmap)
-    
+
     assertFalse(mockBitmap.isRecycled)
-    
+
     platformBitmap.dispose()
-    
+
     verify(mockBitmap).recycle()
   }
 
@@ -159,12 +167,12 @@ internal class PlatformBitmapTest {
     `when`(mockBitmap.height).thenReturn(100)
     `when`(mockBitmap.isRecycled).thenReturn(true)
     `when`(mockBitmap.isMutable).thenReturn(true)
-    
+
     val platformBitmap = PlatformBitmap(mockBitmap)
-    
+
     platformBitmap.dispose()
     platformBitmap.dispose() // Should not throw exception
-    
+
     verify(mockBitmap, times(0)).recycle() // Already recycled, so recycle() should not be called
   }
 
@@ -175,9 +183,9 @@ internal class PlatformBitmapTest {
     `when`(mockBitmap.height).thenReturn(100)
     `when`(mockBitmap.isRecycled).thenReturn(false)
     `when`(mockBitmap.isMutable).thenReturn(true)
-    
+
     val platformBitmap = mockBitmap.toPlatformBitmap()
-    
+
     assertEquals(mockBitmap, platformBitmap.bitmap)
     assertEquals(mockBitmap.width, platformBitmap.width)
     assertEquals(mockBitmap.height, platformBitmap.height)
@@ -190,9 +198,9 @@ internal class PlatformBitmapTest {
     `when`(mockBitmap.height).thenReturn(100)
     `when`(mockBitmap.isRecycled).thenReturn(false)
     `when`(mockBitmap.isMutable).thenReturn(true)
-    
+
     val platformBitmap = PlatformBitmap(mockBitmap)
-    
+
     assertSame(mockBitmap, platformBitmap.toAndroidBitmap())
   }
-} 
+}

--- a/cloudy/src/iosTest/kotlin/com/skydoves/cloudy/CloudyStateTest.kt
+++ b/cloudy/src/iosTest/kotlin/com/skydoves/cloudy/CloudyStateTest.kt
@@ -1,10 +1,25 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.skydoves.cloudy
 
+import kotlinx.cinterop.ExperimentalForeignApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlinx.cinterop.ExperimentalForeignApi
 
 internal class CloudyStateTest {
 

--- a/cloudy/src/iosTest/kotlin/com/skydoves/cloudy/CloudyStateTest.kt
+++ b/cloudy/src/iosTest/kotlin/com/skydoves/cloudy/CloudyStateTest.kt
@@ -15,7 +15,6 @@
  */
 package com.skydoves.cloudy
 
-import kotlinx.cinterop.ExperimentalForeignApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -67,18 +66,4 @@ internal class CloudyStateTest {
     val state2 = CloudyState.Success(bitmap2)
     assertFalse(state1 == state2)
   }
-}
-
-@OptIn(ExperimentalForeignApi::class)
-private fun createTestPlatformBitmap(width: Int, height: Int): PlatformBitmap {
-  return PlatformBitmap(createTestUIImage(width, height))
-}
-
-@OptIn(ExperimentalForeignApi::class)
-private fun createTestUIImage(width: Int, height: Int): platform.UIKit.UIImage {
-  val size = platform.CoreGraphics.CGSizeMake(width.toDouble(), height.toDouble())
-  platform.UIKit.UIGraphicsBeginImageContextWithOptions(size, false, 1.0)
-  val image = platform.UIKit.UIGraphicsGetImageFromCurrentImageContext()
-  platform.UIKit.UIGraphicsEndImageContext()
-  return image ?: platform.UIKit.UIImage()
 }

--- a/cloudy/src/iosTest/kotlin/com/skydoves/cloudy/CloudyStateTest.kt
+++ b/cloudy/src/iosTest/kotlin/com/skydoves/cloudy/CloudyStateTest.kt
@@ -1,0 +1,69 @@
+package com.skydoves.cloudy
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.cinterop.ExperimentalForeignApi
+
+internal class CloudyStateTest {
+
+  @Test
+  fun nothingStateShouldBeSingleton() {
+    val state1 = CloudyState.Nothing
+    val state2 = CloudyState.Nothing
+    assertTrue(state1 === state2)
+  }
+
+  @Test
+  fun loadingStateShouldBeSingleton() {
+    val state1 = CloudyState.Loading
+    val state2 = CloudyState.Loading
+    assertTrue(state1 === state2)
+  }
+
+  @Test
+  fun successStateShouldContainBitmap() {
+    val bitmap = createTestPlatformBitmap(100, 100)
+    val state = CloudyState.Success(bitmap)
+    assertEquals(bitmap, state.bitmap)
+  }
+
+  @Test
+  fun errorStateShouldContainThrowable() {
+    val exception = RuntimeException("Test error")
+    val state = CloudyState.Error(exception)
+    assertEquals(exception, state.throwable)
+  }
+
+  @Test
+  fun successStatesWithSameBitmapShouldBeEqual() {
+    val bitmap = createTestPlatformBitmap(100, 100)
+    val state1 = CloudyState.Success(bitmap)
+    val state2 = CloudyState.Success(bitmap)
+    assertEquals(state1, state2)
+  }
+
+  @Test
+  fun successStatesWithDifferentBitmapsShouldNotBeEqual() {
+    val bitmap1 = createTestPlatformBitmap(100, 100)
+    val bitmap2 = createTestPlatformBitmap(200, 200)
+    val state1 = CloudyState.Success(bitmap1)
+    val state2 = CloudyState.Success(bitmap2)
+    assertFalse(state1 == state2)
+  }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun createTestPlatformBitmap(width: Int, height: Int): PlatformBitmap {
+  return PlatformBitmap(createTestUIImage(width, height))
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun createTestUIImage(width: Int, height: Int): platform.UIKit.UIImage {
+  val size = platform.CoreGraphics.CGSizeMake(width.toDouble(), height.toDouble())
+  platform.UIKit.UIGraphicsBeginImageContextWithOptions(size, false, 1.0)
+  val image = platform.UIKit.UIGraphicsGetImageFromCurrentImageContext()
+  platform.UIKit.UIGraphicsEndImageContext()
+  return image ?: platform.UIKit.UIImage()
+}

--- a/cloudy/src/iosTest/kotlin/com/skydoves/cloudy/PlatformBitmapTest.kt
+++ b/cloudy/src/iosTest/kotlin/com/skydoves/cloudy/PlatformBitmapTest.kt
@@ -1,0 +1,60 @@
+package com.skydoves.cloudy
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.cinterop.ExperimentalForeignApi
+
+internal class PlatformBitmapTest {
+
+  @Test
+  fun platformBitmapShouldHaveCorrectWidthAndHeight() {
+    val width = 100
+    val height = 200
+    val bitmap = createTestPlatformBitmap(width, height)
+    assertEquals(width, bitmap.width)
+    assertEquals(height, bitmap.height)
+  }
+
+  @Test
+  fun platformBitmapShouldBeRecyclable() {
+    val bitmap = createTestPlatformBitmap(100, 100)
+    assertTrue(bitmap.isRecyclable)
+  }
+
+  @Test
+  fun createCompatibleShouldCreateNewBitmapWithSameDimensions() {
+    val original = createTestPlatformBitmap(100, 200)
+    val compatible = original.createCompatible()
+    assertEquals(original.width, compatible.width)
+    assertEquals(original.height, compatible.height)
+  }
+
+  @Test
+  fun disposeShouldNotThrowException() {
+    val bitmap = createTestPlatformBitmap(100, 100)
+    bitmap.dispose()
+    bitmap.dispose() // 두 번 호출해도 예외 없어야 함
+  }
+
+  @Test
+  fun toUIImageExtensionShouldReturnUnderlyingUIImage() {
+    val uiImage = createTestUIImage(100, 100)
+    val platformBitmap = PlatformBitmap(uiImage)
+    assertEquals(uiImage, platformBitmap.toUIImage())
+  }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun createTestPlatformBitmap(width: Int, height: Int): PlatformBitmap {
+  return PlatformBitmap(createTestUIImage(width, height))
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun createTestUIImage(width: Int, height: Int): platform.UIKit.UIImage {
+  val size = platform.CoreGraphics.CGSizeMake(width.toDouble(), height.toDouble())
+  platform.UIKit.UIGraphicsBeginImageContextWithOptions(size, false, 1.0)
+  val image = platform.UIKit.UIGraphicsGetImageFromCurrentImageContext()
+  platform.UIKit.UIGraphicsEndImageContext()
+  return image ?: platform.UIKit.UIImage()
+}

--- a/cloudy/src/iosTest/kotlin/com/skydoves/cloudy/PlatformBitmapTest.kt
+++ b/cloudy/src/iosTest/kotlin/com/skydoves/cloudy/PlatformBitmapTest.kt
@@ -1,9 +1,24 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.skydoves.cloudy
 
+import kotlinx.cinterop.ExperimentalForeignApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import kotlinx.cinterop.ExperimentalForeignApi
 
 internal class PlatformBitmapTest {
 

--- a/cloudy/src/iosTest/kotlin/com/skydoves/cloudy/PlatformBitmapTest.kt
+++ b/cloudy/src/iosTest/kotlin/com/skydoves/cloudy/PlatformBitmapTest.kt
@@ -15,7 +15,6 @@
  */
 package com.skydoves.cloudy
 
-import kotlinx.cinterop.ExperimentalForeignApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -49,7 +48,7 @@ internal class PlatformBitmapTest {
   fun disposeShouldNotThrowException() {
     val bitmap = createTestPlatformBitmap(100, 100)
     bitmap.dispose()
-    bitmap.dispose() // 두 번 호출해도 예외 없어야 함
+    bitmap.dispose() // Should not throw exception even when called twice
   }
 
   @Test
@@ -58,18 +57,4 @@ internal class PlatformBitmapTest {
     val platformBitmap = PlatformBitmap(uiImage)
     assertEquals(uiImage, platformBitmap.toUIImage())
   }
-}
-
-@OptIn(ExperimentalForeignApi::class)
-private fun createTestPlatformBitmap(width: Int, height: Int): PlatformBitmap {
-  return PlatformBitmap(createTestUIImage(width, height))
-}
-
-@OptIn(ExperimentalForeignApi::class)
-private fun createTestUIImage(width: Int, height: Int): platform.UIKit.UIImage {
-  val size = platform.CoreGraphics.CGSizeMake(width.toDouble(), height.toDouble())
-  platform.UIKit.UIGraphicsBeginImageContextWithOptions(size, false, 1.0)
-  val image = platform.UIKit.UIGraphicsGetImageFromCurrentImageContext()
-  platform.UIKit.UIGraphicsEndImageContext()
-  return image ?: platform.UIKit.UIImage()
 }

--- a/cloudy/src/iosTest/kotlin/com/skydoves/cloudy/TestUtils.kt
+++ b/cloudy/src/iosTest/kotlin/com/skydoves/cloudy/TestUtils.kt
@@ -19,10 +19,27 @@ package com.skydoves.cloudy
 
 import kotlinx.cinterop.ExperimentalForeignApi
 
+/**
+ * Creates a `PlatformBitmap` of the specified width and height for testing purposes.
+ *
+ * @param width The width of the bitmap in pixels.
+ * @param height The height of the bitmap in pixels.
+ * @return A `PlatformBitmap` instance containing a blank image of the given dimensions.
+ */
 internal fun createTestPlatformBitmap(width: Int, height: Int): PlatformBitmap {
   return PlatformBitmap(createTestUIImage(width, height))
 }
 
+/**
+ * Creates a new `UIImage` with the specified width and height.
+ *
+ * Starts a new image graphics context, captures the resulting image, and returns it.
+ * If image creation fails, returns an empty `UIImage` instance.
+ *
+ * @param width The width of the image in points.
+ * @param height The height of the image in points.
+ * @return A `UIImage` of the specified size, or an empty image if creation fails.
+ */
 internal fun createTestUIImage(width: Int, height: Int): platform.UIKit.UIImage {
   val size = platform.CoreGraphics.CGSizeMake(width.toDouble(), height.toDouble())
   platform.UIKit.UIGraphicsBeginImageContextWithOptions(size, false, 1.0)

--- a/cloudy/src/iosTest/kotlin/com/skydoves/cloudy/TestUtils.kt
+++ b/cloudy/src/iosTest/kotlin/com/skydoves/cloudy/TestUtils.kt
@@ -1,0 +1,32 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.skydoves.cloudy
+
+import kotlinx.cinterop.ExperimentalForeignApi
+
+internal fun createTestPlatformBitmap(width: Int, height: Int): PlatformBitmap {
+  return PlatformBitmap(createTestUIImage(width, height))
+}
+
+internal fun createTestUIImage(width: Int, height: Int): platform.UIKit.UIImage {
+  val size = platform.CoreGraphics.CGSizeMake(width.toDouble(), height.toDouble())
+  platform.UIKit.UIGraphicsBeginImageContextWithOptions(size, false, 1.0)
+  val image = platform.UIKit.UIGraphicsGetImageFromCurrentImageContext()
+  platform.UIKit.UIGraphicsEndImageContext()
+  return image ?: platform.UIKit.UIImage()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,8 @@ androidxUiAutomator = "2.3.0"
 landscapist = "2.5.1"
 composeMultiplatform = "1.8.2"
 spotless = "6.7.0"
+junit4 = "4.13.2"
+kotlinxCoroutinesTest = "1.10.2"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -58,3 +60,8 @@ compose-resources = { group = "org.jetbrains.compose.components", name = "compon
 compose-ui-tooling-preview = { group = "org.jetbrains.compose.components", name = "components-ui-tooling-preview", version.ref = "composeMultiplatform" }
 landscapist-glide = { group = "com.github.skydoves", name = "landscapist-glide", version.ref = "landscapist" }
 landscapist-transformation = { group = "com.github.skydoves", name = "landscapist-transformation", version.ref = "landscapist" }
+kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
+junit4 = { module = "junit:junit", version.ref = "junit4" }
+androidx-compose-ui-test = { group = "androidx.compose.ui", name = "ui-test", version.ref = "androidxCompose" }
+androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "androidxCompose" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,8 @@ composeMultiplatform = "1.8.2"
 spotless = "6.7.0"
 junit4 = "4.13.2"
 kotlinxCoroutinesTest = "1.10.2"
+mockito="5.18.0"
+mockito-inline="5.2.0"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -65,3 +67,5 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 junit4 = { module = "junit:junit", version.ref = "junit4" }
 androidx-compose-ui-test = { group = "androidx.compose.ui", name = "ui-test", version.ref = "androidxCompose" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "androidxCompose" }
+mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockito-inline" }


### PR DESCRIPTION
### 🎯 Goal

- For robust implementation of cloudy, add some unit tests of CloudyState, PlatformBitmap class

### 🛠 Implementation details
Describe the implementation details for this Pull Request.

### ✍️ Explain examples
Explain examples with code for this updates.

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```bash
$ ./gradlew spotlessApply
```

Then dump binary API of this library that is public in sense of Kotlin visibilities and ensures that the public binary API wasn't changed in a way that make this change binary incompatible.

```bash
./gradlew apiDump
```

Please correct any failures before requesting a review.

## Code reviews
All submissions, including submissions by project members, require review. We use GitHub pull requests for this purpose. Consult [GitHub Help](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) for more information on using pull requests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added annotation to enforce non-negative values for the `radius` parameter in the Android modifier.
  
* **Tests**
  * Introduced comprehensive unit tests for `CloudyState` and `PlatformBitmap` on both Android and iOS platforms, covering state management, bitmap operations, and resource handling.

* **Chores**
  * Enhanced build configuration with explicit test dependencies for all supported platforms.
  * Added and updated testing and mocking library versions for improved test management.

* **Style**
  * Updated documentation comment formatting for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->