### PR TITLE
remove graphicLayer param desc from cloudy kdoc and update ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,34 +112,25 @@ GlideImage(
 
 ## Maintaining Blurring Effect on Responsive Composable
 
-The `Modifier.cloudy` captures the bitmap of the composable node under the hood. If you need to use the cloudy modifier as an item in lists or similar structures, you should provide the same [graphic layer](https://developer.android.com/reference/kotlin/androidx/compose/ui/graphics/layer/GraphicsLayer) to ensure consistent rendering and performance.
+The `Modifier.cloudy` captures the bitmap of the composable node under the hood.
 
 ```kotlin
-val graphicsLayer = rememberGraphicsLayer()
-
 LazyVerticalGrid(
   state = rememberLazyGridState(),
   columns = GridCells.Fixed(2)
 ) {
   itemsIndexed(key = { index, item -> item.id }, items = posters) { index, item ->
-    HomePoster(
-      poster = item,
-      graphicsLayer = graphicsLayer
-    )
+    HomePoster(poster = item)
   }
 }
 
 @Composable
-private fun HomePoster(
-  graphicsLayer: GraphicsLayer = rememberGraphicsLayer(),
-  poster: Poster
-) {
-
+private fun HomePoster(poster: Poster) {
     ConstraintLayout {
       val (image, title, content) = createRefs()
       GlideImage(
         modifier = Modifier
-          .cloudy(radius = 15, graphicsLayer = graphicsLayer)
+          .cloudy(radius = 15)
           .aspectRatio(0.8f)
           .constrainAs(image) {
             centerHorizontallyTo(parent)

--- a/cloudy/src/main/kotlin/com/skydoves/cloudy/CloudyModifierNode.kt
+++ b/cloudy/src/main/kotlin/com/skydoves/cloudy/CloudyModifierNode.kt
@@ -45,9 +45,6 @@ import kotlinx.coroutines.launch
  *
  * @param radius Radius of the blur along both the x and y axis.
  * @param enabled Enabling the blur effects.
- * @param graphicsLayer The graphic layer that records the original content and get the bitmap information.
- * This parameter should be used when you need to remain with the same graphic layer for the dynamically
- * updated Composable functions, such as Lazy Lists.
  * @param onStateChanged Lambda function that will be invoked when the blur process has been updated.
  */
 @Composable


### PR DESCRIPTION
### 🎯 Goal
Update docs
fixes https://github.com/skydoves/Cloudy/issues/73


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified instructions regarding the use of blur effects in responsive composables.
  * Updated example code and documentation to remove references to managing a shared graphics layer.
  * Clarified usage of the blur modifier for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->