### PR TITLE
Migrate to macos-latest for the CI machines

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,45 +4,43 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ '*' ]
 
 jobs:
   lint:
     name: Spotless check
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v6.0.1
       - name: Set up JDK
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v5.1.0
         with:
-          distribution: zulu
-          java-version: 17
-      - uses: gradle/gradle-build-action@v3.4.2
+          distribution: 'zulu'
+          java-version: 21
       - name: spotless
         run: ./gradlew spotlessCheck
 
   api_check:
     name: API check
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v6.0.1
       - name: Set up JDK
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v5.1.0
         with:
-          distribution: zulu
-          java-version: 17
-      - uses: gradle/gradle-build-action@v3.4.2
+          distribution: 'zulu'
+          java-version: 21
       - name: API check
         run: ./gradlew apiCheck
 
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v6.0.1
       - name: set up JDK
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v5.1.0
         with:
           distribution: zulu
           java-version: 17

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,27 +7,24 @@ on:
 
 jobs:
   publish:
-    name: Snapshot build and publish
-    runs-on: ubuntu-latest
+    name: Release build and publish
+    runs-on: macos-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v6.0.1
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v5.1.0
         with:
           distribution: 'zulu'
-          java-version: 17
-
-      - name: Grant Permission to Execute Gradle
-        run: chmod +x gradlew
+          java-version: 21
 
       - name: Release build
-        run: ./gradlew assemble --scan
+        run: ./gradlew assemble --scan -x :benchmark-landscapist:pixel6api31Setup -x :benchmark-landscapist:pixel6api31NonMinifiedReleaseAndroidTest -x :benchmark-landscapist:collectNonMinifiedReleaseBaselineProfile
 
       - name: Publish to MavenCentral
         run: |
-          ./gradlew publishAllPublicationsToMavenCentral --no-configuration-cache
+          ./gradlew publishAllPublicationsToMavenCentral --no-configuration-cache -x javaDocReleaseGeneration -x :fresco:javaDocReleaseGeneration
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}


### PR DESCRIPTION
Migrate to macos-latest for the CI machines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded CI/CD infrastructure to Java 21 with updated build tool versions for enhanced compatibility and system stability
  * Improved build pipeline reliability and performance through platform infrastructure updates
  * Optimized build process configuration with targeted task exclusions for faster, more efficient builds

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->