### PR TITLE
refactor: use incrementContentVersion instead of isDirty

### DIFF
--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
@@ -167,9 +167,6 @@ private class SkyModifierNode(var sky: Sky) :
 
     // Share layer with children
     sky.backgroundLayer = layer
-    sky.isDirty = false
-
-    // Always increment version (throttling is handled in CloudyBackgroundModifierNode)
     sky.incrementContentVersion()
 
     // Draw original content to screen

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/Sky.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/Sky.kt
@@ -81,14 +81,6 @@ public class Sky internal constructor() {
   internal var sourceBounds: Rect by mutableStateOf(Rect.Zero)
 
   /**
-   * Dirty flag to trigger re-capture when content changes.
-   * Initially `true` to ensure first capture occurs.
-   *
-   * Set to `false` after capture, and back to `true` via [invalidate].
-   */
-  internal var isDirty: Boolean by mutableStateOf(true)
-
-  /**
    * Content version counter that increments every time the background
    * content is re-captured. Used by child modifiers to detect when
    * cached blur results should be invalidated.
@@ -111,9 +103,9 @@ public class Sky internal constructor() {
    * Invalidates the captured background content.
    *
    * Call this method when the background content changes and needs
-   * to be re-captured for blur rendering. This sets [isDirty] to `true`,
-   * which triggers dependent [Modifier.cloudy] modifiers to re-capture
-   * the background on the next frame.
+   * to be re-captured for blur rendering. This increments [contentVersion],
+   * which triggers dependent [Modifier.cloudy] modifiers to invalidate
+   * their cached blur results.
    *
    * ## Example
    *
@@ -134,7 +126,7 @@ public class Sky internal constructor() {
    * ```
    */
   public fun invalidate() {
-    isDirty = true
+    incrementContentVersion()
   }
 }
 

--- a/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/SkyTest.kt
+++ b/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/SkyTest.kt
@@ -16,8 +16,6 @@
 package com.skydoves.cloudy
 
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.booleans.shouldBeFalse
-import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 
@@ -25,9 +23,9 @@ import io.kotest.matchers.shouldBe
  * Unit tests for [Sky] state holder.
  *
  * Tests verify:
- * - Initial state (backgroundLayer null, isDirty true, bounds zero)
- * - Invalidation behavior
- * - isDirty flag lifecycle
+ * - Initial state (backgroundLayer null, bounds zero, contentVersion 0)
+ * - Invalidation behavior (contentVersion increment)
+ * - contentVersion lifecycle
  */
 internal class SkyTest :
   FunSpec({
@@ -45,34 +43,18 @@ internal class SkyTest :
       sky.sourceBounds.bottom.shouldBe(0f)
     }
 
-    test("Sky should have isDirty true initially") {
-      val sky = Sky()
-      sky.isDirty.shouldBeTrue()
-    }
-
-    test("invalidate() should set isDirty to true") {
-      val sky = Sky()
-      sky.isDirty = false
-
-      sky.invalidate()
-
-      sky.isDirty.shouldBeTrue()
-    }
-
-    test("isDirty should remain false until invalidated") {
-      val sky = Sky()
-      sky.isDirty = false
-
-      sky.isDirty.shouldBeFalse()
-
-      sky.invalidate()
-
-      sky.isDirty.shouldBeTrue()
-    }
-
     test("contentVersion should be 0 initially") {
       val sky = Sky()
       sky.contentVersion.shouldBe(0L)
+    }
+
+    test("invalidate() should increment contentVersion") {
+      val sky = Sky()
+      sky.contentVersion.shouldBe(0L)
+
+      sky.invalidate()
+
+      sky.contentVersion.shouldBe(1L)
     }
 
     test("incrementContentVersion should increment version by 1") {

--- a/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/CloudyBackground.skiko.kt
+++ b/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/CloudyBackground.skiko.kt
@@ -142,7 +142,6 @@ private class SkyModifierNode(var sky: Sky) :
 
     // Share layer with children
     sky.backgroundLayer = layer
-    sky.isDirty = false
     sky.incrementContentVersion()
 
     // Draw original content to screen


### PR DESCRIPTION
### 🎯 Goal

- `isDirty` prop in `Sky` isn't used any code.
- So change impl of `invalidate` function to use `incrementContentVersion`

### ✍️ Explain examples

https://github.com/user-attachments/assets/cb7e31a1-9c22-429a-ba18-045fa4f7a048

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```bash
$ ./gradlew spotlessApply
```

Then dump binary API of this library that is public in sense of Kotlin visibilities and ensures that the public binary API wasn't changed in a way that make this change binary incompatible.

```bash
./gradlew apiDump
```

Please correct any failures before requesting a review.

## Code reviews
All submissions, including submissions by project members, require review. We use GitHub pull requests for this purpose. Consult [GitHub Help](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) for more information on using pull requests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal cache invalidation mechanism for blur rendering to improve performance and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->