### PR TITLE
fix: pass blur radius directly to RenderEffect/BlurEffect instead of halving it

### DIFF
--- a/app/src/commonMain/kotlin/demo/screen/InteractiveSliderScreen.kt
+++ b/app/src/commonMain/kotlin/demo/screen/InteractiveSliderScreen.kt
@@ -52,6 +52,7 @@ import demo.component.MaxWidthContainer
 import demo.model.MockUtil
 import demo.model.Poster
 import demo.theme.Dimens
+import kotlin.math.roundToInt
 
 /**
  * Interactive slider screen that allows users to adjust blur radius in real-time.
@@ -187,7 +188,7 @@ internal fun BlurPreviewCard(radius: Int, imageContent: @Composable (Modifier) -
           // The platform converts the blur radius to a Gaussian sigma internally
           // (HWUI: sigma = 0.57735 * radius + 0.5).
           val sigma = 0.57735f * radius + 0.5f
-          "Sigma: ${(sigma * 10).toInt() / 10f}"
+          "Sigma: ${(sigma * 10).roundToInt() / 10f}"
         },
         fontSize = 14.sp,
         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),

--- a/app/src/commonMain/kotlin/demo/screen/InteractiveSliderScreen.kt
+++ b/app/src/commonMain/kotlin/demo/screen/InteractiveSliderScreen.kt
@@ -181,7 +181,14 @@ internal fun BlurPreviewCard(radius: Int, imageContent: @Composable (Modifier) -
       Spacer(modifier = Modifier.height(8.dp))
 
       Text(
-        text = if (radius == 0) "No blur effect" else "Sigma: ${radius / 2.0f}",
+        text = if (radius == 0) {
+          "No blur effect"
+        } else {
+          // The platform converts the blur radius to a Gaussian sigma internally
+          // (HWUI: sigma = 0.57735 * radius + 0.5).
+          val sigma = 0.57735f * radius + 0.5f
+          "Sigma: ${(sigma * 10).toInt() / 10f}"
+        },
         fontSize = 14.sp,
         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
       )

--- a/app/src/commonMain/kotlin/demo/screen/RadiusItemsScreen.kt
+++ b/app/src/commonMain/kotlin/demo/screen/RadiusItemsScreen.kt
@@ -54,6 +54,7 @@ import demo.component.CollapsingAppBarScaffold
 import demo.component.MaxWidthContainer
 import demo.model.MockUtil
 import demo.theme.Dimens
+import kotlin.math.roundToInt
 
 private val radiusList = listOf(0, 5, 10, 15, 20, 25, 30, 40, 50, 75, 100)
 
@@ -168,7 +169,7 @@ internal fun RadiusItemLayout(
             // The platform converts the blur radius to a Gaussian sigma internally
             // (HWUI: sigma = 0.57735 * radius + 0.5).
             val sigma = 0.57735f * radius + 0.5f
-            "Sigma: ${(sigma * 10).toInt() / 10f}"
+            "Sigma: ${(sigma * 10).roundToInt() / 10f}"
           },
           style = MaterialTheme.typography.bodySmall,
           color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),

--- a/app/src/commonMain/kotlin/demo/screen/RadiusItemsScreen.kt
+++ b/app/src/commonMain/kotlin/demo/screen/RadiusItemsScreen.kt
@@ -161,6 +161,18 @@ internal fun RadiusItemLayout(
           style = MaterialTheme.typography.titleMedium,
           color = MaterialTheme.colorScheme.onSurface,
         )
+        Text(
+          text = if (radius == 0) {
+            "No blur"
+          } else {
+            // The platform converts the blur radius to a Gaussian sigma internally
+            // (HWUI: sigma = 0.57735 * radius + 0.5).
+            val sigma = 0.57735f * radius + 0.5f
+            "Sigma: ${(sigma * 10).toInt() / 10f}"
+          },
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+        )
       }
 
       // Toned-down chevron inside a soft circular chip (no more neon arrow).

--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
@@ -420,11 +420,13 @@ private class CloudyBackgroundModifierNode(
       logProgressiveBlurWarningOnce()
     }
 
-    val sigma = snapshot.radius / 2.0f
+    // createBlurEffect expects a blur radius in pixels (HWUI converts to sigma
+    // internally); pass the requested radius through directly.
+    val blurRadius = snapshot.radius.toFloat()
 
     // Create blur effect
     val blurEffect = RenderEffect
-      .createBlurEffect(sigma, sigma, Shader.TileMode.CLAMP)
+      .createBlurEffect(blurRadius, blurRadius, Shader.TileMode.CLAMP)
       .asComposeRenderEffect()
 
     val context = requireGraphicsContext()

--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyRenderEffectStrategy.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyRenderEffectStrategy.kt
@@ -56,11 +56,15 @@ internal object CloudyRenderEffectStrategy : CloudyBlurStrategy {
       return modifier
     }
 
-    val sigma = radius / 2.0f
+    // RenderEffect.createBlurEffect expects a blur *radius* in pixels, not a Gaussian
+    // sigma. HWUI converts it internally (sigma = 0.57735 * radius + 0.5), so the
+    // user-supplied radius is passed through directly to match Modifier.blur and the
+    // legacy CPU path.
+    val blurRadius = radius.toFloat()
 
     return modifier.graphicsLayer {
       renderEffect = RenderEffect
-        .createBlurEffect(sigma, sigma, Shader.TileMode.CLAMP)
+        .createBlurEffect(blurRadius, blurRadius, Shader.TileMode.CLAMP)
         .asComposeRenderEffect()
     }
   }

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/Cloudy.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/Cloudy.kt
@@ -64,7 +64,10 @@ import androidx.compose.ui.Modifier
  * ```
  *
  * @param radius The blur radius in pixels for both the x and y axes. Must be non-negative.
- *               Converted to sigma internally using `sigma = radius / 2.0`.
+ *               The radius is passed through to the platform blur (RenderEffect on API 31+,
+ *               Skia BlurEffect on Skiko targets), which converts it to a Gaussian sigma
+ *               internally (HWUI uses `sigma = 0.57735 * radius + 0.5`). This matches
+ *               `Modifier.blur(radius.dp)` and the legacy CPU path.
  *               On Android API 30 and below, values above 25 use iterative passes.
  * @param enabled If false, disables the blur effect and returns the original modifier.
  * @param onStateChanged Callback invoked when the blur state changes.

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/CloudyBackground.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/CloudyBackground.kt
@@ -105,7 +105,9 @@ public expect fun Modifier.sky(sky: Sky): Modifier
  *
  * @param sky The [Sky] state holder containing the captured background content.
  * @param radius The blur radius in pixels. Must be non-negative.
- *               Converted to sigma using `sigma = radius / 2.0`.
+ *               The radius is passed through to the platform blur (RenderEffect on API 31+,
+ *               Skia BlurEffect on Skiko targets), which converts it to a Gaussian sigma
+ *               internally (HWUI uses `sigma = 0.57735 * radius + 0.5`).
  * @param progressive The progressive blur configuration. Use [CloudyProgressive.None]
  *                    for uniform blur, or [CloudyProgressive.TopToBottom]/[CloudyProgressive.BottomToTop]
  *                    for gradient blur effects. Defaults to [CloudyProgressive.None].

--- a/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/Cloudy.skiko.kt
+++ b/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/Cloudy.skiko.kt
@@ -50,15 +50,17 @@ public actual fun Modifier.cloudy(
     return this
   }
 
-  // Convert radius to sigma: sigma = radius / 2.0
-  val sigma = radius / 2.0f
+  // BlurEffect's radiusX/radiusY are blur *radii* in pixels, not Gaussian sigmas.
+  // Skia performs the radius -> sigma conversion internally, so pass the user-supplied
+  // radius through directly to match Modifier.blur and the Android RenderEffect path.
+  val blurRadius = radius.toFloat()
 
   // Apply GPU-accelerated blur using Skia's BlurEffect
-  // Skia handles large sigma values internally via progressive downsampling
+  // Skia handles large radius values internally via progressive downsampling
   return this.graphicsLayer {
     renderEffect = BlurEffect(
-      radiusX = sigma,
-      radiusY = sigma,
+      radiusX = blurRadius,
+      radiusY = blurRadius,
       edgeTreatment = TileMode.Clamp,
     )
   }

--- a/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/Cloudy.skiko.kt
+++ b/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/Cloudy.skiko.kt
@@ -51,8 +51,9 @@ public actual fun Modifier.cloudy(
   }
 
   // BlurEffect's radiusX/radiusY are blur *radii* in pixels, not Gaussian sigmas.
-  // Skia performs the radius -> sigma conversion internally, so pass the user-supplied
-  // radius through directly to match Modifier.blur and the Android RenderEffect path.
+  // Compose's Skiko backend converts the radius to a sigma internally (using the same
+  // sigma = 0.57735 * radius + 0.5 as HWUI) before handing it to Skia, so pass the
+  // user-supplied radius through directly to match Modifier.blur and the Android path.
   val blurRadius = radius.toFloat()
 
   // Apply GPU-accelerated blur using Skia's BlurEffect

--- a/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/CloudyBackground.skiko.kt
+++ b/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/CloudyBackground.skiko.kt
@@ -309,8 +309,9 @@ private class CloudyBackgroundModifierNode(
   }
 
   private fun ContentDrawScope.drawWithBlurEffect(layer: GraphicsLayer, snapshot: SkySnapshot) {
-    // BlurEffect's radiusX/radiusY are blur radii in pixels (Skia converts to sigma
-    // internally); pass the requested radius through directly.
+    // BlurEffect's radiusX/radiusY are blur radii in pixels; Compose's Skiko backend
+    // converts the radius to a sigma internally (same 0.57735 * radius + 0.5 as HWUI)
+    // before handing it to Skia, so pass the requested radius through directly.
     val blurRadius = snapshot.radius.toFloat()
 
     val context = requireGraphicsContext()

--- a/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/CloudyBackground.skiko.kt
+++ b/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/CloudyBackground.skiko.kt
@@ -309,7 +309,9 @@ private class CloudyBackgroundModifierNode(
   }
 
   private fun ContentDrawScope.drawWithBlurEffect(layer: GraphicsLayer, snapshot: SkySnapshot) {
-    val sigma = snapshot.radius / 2.0f
+    // BlurEffect's radiusX/radiusY are blur radii in pixels (Skia converts to sigma
+    // internally); pass the requested radius through directly.
+    val blurRadius = snapshot.radius.toFloat()
 
     val context = requireGraphicsContext()
     val blurLayer = context.createGraphicsLayer()
@@ -326,8 +328,8 @@ private class CloudyBackgroundModifierNode(
 
       // Apply blur effect using Skia
       blurLayer.renderEffect = BlurEffect(
-        radiusX = sigma,
-        radiusY = sigma,
+        radiusX = blurRadius,
+        radiusY = blurRadius,
         edgeTreatment = TileMode.Clamp,
       )
 


### PR DESCRIPTION
## Summary

`RenderEffect.createBlurEffect()` and Skia's `BlurEffect()` both accept a blur **radius** in pixels — the platform converts it to a Gaussian sigma internally (HWUI: `sigma = 0.57735 * radius + 0.5`).

The previous code divided the user-supplied radius by 2 before passing it in (`sigma = radius / 2.0f`), treating the parameter as a sigma instead. This caused GPU-path blur to be ~50% weaker than requested, and inconsistent with the CPU fallback path (API ≤ 30) which correctly used the full radius.

**Affected call sites (all 4 GPU blur paths):**

- `CloudyRenderEffectStrategy.kt` — Android API 31+ (`Modifier.cloudy`)
- `CloudyBackground.android.kt` — Android API 31+ (`Modifier.cloudy` with `Sky`)
- `Cloudy.skiko.kt` — iOS / macOS / Desktop / WASM (`Modifier.cloudy`)
- `CloudyBackground.skiko.kt` — iOS / macOS / Desktop / WASM (`Modifier.cloudy` with `Sky`)

## Root Cause

```kotlin
// Before (incorrect — radius/2 is not sigma)
val sigma = radius / 2.0f
RenderEffect.createBlurEffect(sigma, sigma, Shader.TileMode.CLAMP)

// After (correct — pass radius directly; platform handles sigma conversion)
val blurRadius = radius.toFloat()
RenderEffect.createBlurEffect(blurRadius, blurRadius, Shader.TileMode.CLAMP)
```

The same incorrect conversion existed in all four GPU blur call sites across Android and Skiko targets.

## Verification

Tested on Galaxy S26 Ultra (API 36) with `radius = 15`:

| | Before | After |
|---|---|---|
| Displayed sigma label | 7.5 | 9.1 |
| Actual HWUI sigma | `0.57735 × 7.5 + 0.5 = 4.83` | `0.57735 × 15 + 0.5 = 9.16` ✓ |
| CPU path (API ≤ 30) | sigma ≈ 9.16 | sigma ≈ 9.16 ✓ (unchanged) |

**Before** (Radius 15, GPU path producing half-strength blur):

<img width="270" height="585" alt="image" src="https://github.com/user-attachments/assets/f7bdea4c-85e3-4e0d-beef-b7165fb2cf31" />

**After** (Radius 15, correct blur strength matching CPU path):

<img width="270" height="585" alt="image" src="https://github.com/user-attachments/assets/16fff633-10c2-4d4b-8007-2bda919216af" />

Also updated the sigma display label in the demo app to show the actual platform-computed sigma (`0.57735 * radius + 0.5`) instead of the incorrect `radius / 2.0f`.

## References

- AOSP `Blur.cpp`: internal formula `sigma = 0.57735 * radius + 0.5`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated blur effect calculations across all platforms for improved consistency and accuracy. Blur radius values now convert to Gaussian sigma using a more precise formula, ensuring uniform blur appearance whether using hardware acceleration or GPU rendering.

* **Documentation**
  * Updated blur parameter documentation to reflect the new calculation method and clarify internal platform conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->