### PR TITLE
Fix RenderThread stack-overflow crash in backdrop blur (sky + cloudy)

### DIFF
--- a/app/src/commonMain/kotlin/demo/Main.kt
+++ b/app/src/commonMain/kotlin/demo/Main.kt
@@ -28,6 +28,7 @@ import androidx.navigation3.ui.NavDisplay
 import demo.screen.BlurAppBarGridScreen
 import demo.screen.GridListScreen
 import demo.screen.InteractiveSliderScreen
+import demo.screen.Issue112BottomNavScreen
 import demo.screen.LiquidGlassDemoScreen
 import demo.screen.MenuHomeScreen
 import demo.screen.ProgressiveBlurDemoScreen
@@ -59,6 +60,7 @@ fun CloudyDemoApp() {
               onInteractiveSliderClick = { backStack.add(Route.InteractiveSlider) },
               onProgressiveBlurClick = { backStack.add(Route.ProgressiveBlur) },
               onLiquidGlassClick = { backStack.add(Route.LiquidGlass) },
+              onIssue112Click = { backStack.add(Route.Issue112BottomNav) },
             )
           }
 
@@ -102,6 +104,12 @@ fun CloudyDemoApp() {
 
           is Route.LiquidGlass -> NavEntry(route) {
             LiquidGlassDemoScreen(
+              onBackClick = { backStack.removeLastOrNull() },
+            )
+          }
+
+          is Route.Issue112BottomNav -> NavEntry(route) {
+            Issue112BottomNavScreen(
               onBackClick = { backStack.removeLastOrNull() },
             )
           }

--- a/app/src/commonMain/kotlin/demo/Route.kt
+++ b/app/src/commonMain/kotlin/demo/Route.kt
@@ -72,4 +72,11 @@ sealed interface Route {
    */
   @Serializable
   data object LiquidGlass : Route
+
+  /**
+   * Reproduction of issue #112: backdrop blur (`Modifier.cloudy(sky)`) on a bottom navigation
+   * bar over a scrolling list, with `Modifier.sky` on the outer container.
+   */
+  @Serializable
+  data object Issue112BottomNav : Route
 }

--- a/app/src/commonMain/kotlin/demo/screen/Issue112BottomNavScreen.kt
+++ b/app/src/commonMain/kotlin/demo/screen/Issue112BottomNavScreen.kt
@@ -1,0 +1,186 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package demo.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.skydoves.cloudy.cloudy
+import com.skydoves.cloudy.rememberSky
+import com.skydoves.cloudy.sky
+import demo.component.CollapsingAppBarScaffold
+import demo.component.MaxWidthContainer
+import demo.theme.Dimens
+
+/**
+ * Reproduction of https://github.com/skydoves/Cloudy/issues/112.
+ *
+ * Layout that crashed (native RenderThread `SIGSEGV` on API 31+):
+ *   - `Modifier.sky(sky)` on the OUTER container that holds a scrolling [LazyColumn].
+ *   - A bottom navigation bar that applies `Modifier.cloudy(sky = sky, ...)` to blur whatever
+ *     scrolls behind it.
+ *
+ * On the pre-fix library this layout builds a cyclic RenderNode graph: the sky capture records
+ * the cloudy overlay (because the overlay is a descendant of the sky container), while the
+ * overlay's blur layer records the sky layer. The two layers reference each other
+ * (skyLayer -> blurLayer -> skyLayer), so `RenderNode::prepareTreeImpl` recurses on the render
+ * thread until the stack overflows. The list auto-scrolls on entry so the crash (or, post-fix,
+ * the smooth blur) is easy to capture without a precisely-timed manual swipe.
+ *
+ * @param onBackClick Callback when the back button is pressed.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun Issue112BottomNavScreen(onBackClick: () -> Unit) {
+  // sky on the OUTER container — the exact placement that triggers #112.
+  val sky = rememberSky()
+  val listState = rememberLazyListState()
+  var selectedTab by remember { mutableIntStateOf(0) }
+
+  // Auto-scroll up and down a few times so the backdrop blur is redrawn continuously while the
+  // screen is being recorded. On the pre-fix library this is when the RenderThread crashes.
+  LaunchedEffect(Unit) {
+    repeat(6) {
+      listState.animateScrollToItem(ITEM_COUNT - 1)
+      listState.animateScrollToItem(0)
+    }
+  }
+
+  CollapsingAppBarScaffold(
+    title = "Issue #112 — BottomNav",
+    onBackClick = onBackClick,
+  ) { paddingValues, _ ->
+    MaxWidthContainer(modifier = Modifier.padding(paddingValues)) {
+      Box(modifier = Modifier.fillMaxSize().sky(sky)) {
+        // Background content captured by sky: a long, scrolling list.
+        LazyColumn(
+          state = listState,
+          modifier = Modifier.fillMaxSize(),
+          verticalArrangement = Arrangement.spacedBy(Dimens.contentPadding),
+          contentPadding = PaddingValues(
+            start = Dimens.contentPadding,
+            end = Dimens.contentPadding,
+            top = Dimens.contentPadding,
+            // Leave room so the last rows can scroll out from under the blurred bottom bar.
+            bottom = BOTTOM_BAR_HEIGHT.dp + Dimens.contentPadding,
+          ),
+        ) {
+          items(ITEM_COUNT) { index ->
+            ColorRow(index)
+          }
+        }
+
+        // Bottom navigation bar: a fixed, blurred backdrop over the scrolling content.
+        Row(
+          modifier = Modifier
+            .align(Alignment.BottomCenter)
+            .fillMaxWidth()
+            .height(BOTTOM_BAR_HEIGHT.dp)
+            .cloudy(sky = sky, radius = 24)
+            .background(Color.White.copy(alpha = 0.15f))
+            .padding(horizontal = 12.dp),
+          horizontalArrangement = Arrangement.SpaceEvenly,
+          verticalAlignment = Alignment.CenterVertically,
+        ) {
+          repeat(TAB_COUNT) { tabIndex ->
+            TabDot(
+              selected = tabIndex == selectedTab,
+              onClick = { selectedTab = tabIndex },
+            )
+          }
+        }
+      }
+    }
+  }
+}
+
+private const val ITEM_COUNT = 60
+private const val TAB_COUNT = 4
+private const val BOTTOM_BAR_HEIGHT = 72
+
+@Composable
+private fun ColorRow(index: Int) {
+  // Alternating colored rows give the blur something high-contrast to sample as it scrolls.
+  val colors = remember {
+    listOf(
+      Color(0xFF1565C0),
+      Color(0xFFC62828),
+      Color(0xFF2E7D32),
+      Color(0xFF6A1B9A),
+      Color(0xFFEF6C00),
+    )
+  }
+  Box(
+    modifier = Modifier
+      .fillMaxWidth()
+      .height(72.dp)
+      .clip(RoundedCornerShape(12.dp))
+      .background(colors[index % colors.size]),
+    contentAlignment = Alignment.CenterStart,
+  ) {
+    Text(
+      text = "Item #$index",
+      modifier = Modifier.padding(start = 16.dp),
+      color = Color.White,
+      fontSize = 16.sp,
+      fontWeight = FontWeight.SemiBold,
+    )
+  }
+}
+
+@Composable
+private fun TabDot(selected: Boolean, onClick: () -> Unit) {
+  Column(
+    horizontalAlignment = Alignment.CenterHorizontally,
+    verticalArrangement = Arrangement.Center,
+    modifier = Modifier.clickable(onClick = onClick),
+  ) {
+    Box(
+      modifier = Modifier
+        .size(if (selected) 28.dp else 22.dp)
+        .clip(CircleShape)
+        .background(if (selected) Color.White else Color.White.copy(alpha = 0.5f)),
+    )
+  }
+}

--- a/app/src/commonMain/kotlin/demo/screen/MenuHomeScreen.kt
+++ b/app/src/commonMain/kotlin/demo/screen/MenuHomeScreen.kt
@@ -41,6 +41,7 @@ import demo.theme.Dimens
  * @param onInteractiveSliderClick Callback when the Interactive Slider demo is selected.
  * @param onProgressiveBlurClick Callback when the Progressive Blur demo is selected.
  * @param onLiquidGlassClick Callback when the Liquid Glass demo is selected.
+ * @param onIssue112Click Callback when the Issue #112 BottomNav repro is selected.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -51,6 +52,7 @@ fun MenuHomeScreen(
   onInteractiveSliderClick: () -> Unit,
   onProgressiveBlurClick: () -> Unit,
   onLiquidGlassClick: () -> Unit,
+  onIssue112Click: () -> Unit,
 ) {
   val posters = remember { MockUtil.getMockPosters() }
 
@@ -107,6 +109,14 @@ fun MenuHomeScreen(
             description = "Interactive glass lens with magnification and chromatic aberration",
             poster = posters[5],
             onClick = onLiquidGlassClick,
+          )
+        }
+        item {
+          MenuCard(
+            title = "Issue #112 — BottomNav",
+            description = "Backdrop blur on a bottom bar over a scrolling list",
+            poster = posters[6],
+            onClick = onIssue112Click,
           )
         }
       }

--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
@@ -160,17 +160,30 @@ private class SkyModifierNode(var sky: Sky) :
       graphicsLayer = it
     }
 
-    // Record content to layer
-    layer.record {
-      this@draw.drawContent()
+    // Record the background into `layer`, the source a descendant `cloudy` overlay samples
+    // and blurs. `isCapturing` is set so the overlay draws nothing during this pass: it must be
+    // ABSENT from the blur source. Otherwise the overlay would draw its blur layer into `layer`,
+    // and that blur layer in turn samples `layer` — a cyclic RenderNode graph that overflows the
+    // render thread stack (https://github.com/skydoves/Cloudy/issues/112).
+    sky.isCapturing = true
+    try {
+      layer.record {
+        this@draw.drawContent()
+      }
+    } finally {
+      sky.isCapturing = false
     }
 
-    // Share layer with children
+    // Publish the captured background for children before the on-screen pass below, so a
+    // descendant overlay reads the up-to-date layer when it draws this frame.
     sky.backgroundLayer = layer
     sky.incrementContentVersion()
 
-    // Draw original content to screen
-    drawLayer(layer)
+    // Draw the subtree to the window. `isCapturing` is now false, so the overlay paints its
+    // blurred backdrop (sampling `layer`, which contains no reference back to the overlay) and
+    // its own foreground here. The blur layer is composited straight to the window canvas, never
+    // into `layer`, so no cycle is formed while the backdrop still renders.
+    drawContent()
   }
 
   override fun onDetach() {
@@ -292,6 +305,16 @@ private class CloudyBackgroundModifierNode(
   }
 
   override fun ContentDrawScope.draw() {
+    // When `sky` is an ancestor of this overlay, the sky's capture pass re-enters this draw
+    // while recording the blur source into `backgroundLayer`. This overlay must be ABSENT from
+    // that source: if it drew here, its blur layer (which samples `backgroundLayer`) would be
+    // recorded into `backgroundLayer`, forming a cyclic RenderNode graph that crashes the render
+    // thread (https://github.com/skydoves/Cloudy/issues/112). Draw nothing during capture; the
+    // overlay paints itself in the sky's on-screen pass, when `isCapturing` is false.
+    if (sky.isCapturing) {
+      return
+    }
+
     val backgroundLayer = sky.backgroundLayer
     if (backgroundLayer == null) {
       onStateChanged(CloudyState.Error(RuntimeException("Background layer not available")))

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/Sky.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/Sky.kt
@@ -81,6 +81,27 @@ public class Sky internal constructor() {
   internal var sourceBounds: Rect by mutableStateOf(Rect.Zero)
 
   /**
+   * `true` while [Modifier.sky] is recording the blur source into [backgroundLayer].
+   *
+   * A backdrop [Modifier.cloudy] overlay is, by design, a descendant of the [Modifier.sky]
+   * container, so the sky's capture pass re-enters the overlay's own draw. If the overlay drew
+   * its backdrop (which samples [backgroundLayer]) during that capture, the recorded display
+   * list of [backgroundLayer] would contain a reference back to itself — a cyclic `RenderNode`
+   * graph that makes the platform render thread recurse until the stack overflows
+   * (see https://github.com/skydoves/Cloudy/issues/112).
+   *
+   * The overlay reads this flag and draws nothing while it is being captured, so it is absent
+   * from the blur source. [Modifier.sky] then draws its subtree to the window in a second pass
+   * with this flag `false`, during which the overlay paints its blurred backdrop (sampling the
+   * now-overlay-free [backgroundLayer]) and its foreground straight to the window canvas. The
+   * blur layer is therefore never recorded into [backgroundLayer], so no cycle can form.
+   *
+   * This is a plain (non-snapshot) field intentionally: capture and the nested overlay draw run
+   * synchronously on the same draw pass, so no recomposition or cross-thread visibility is needed.
+   */
+  internal var isCapturing: Boolean = false
+
+  /**
    * Content version counter that increments every time the background
    * content is re-captured. Used by child modifiers to detect when
    * cached blur results should be invalidated.

--- a/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/CloudyBackground.skiko.kt
+++ b/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/CloudyBackground.skiko.kt
@@ -135,17 +135,30 @@ private class SkyModifierNode(var sky: Sky) :
       graphicsLayer = it
     }
 
-    // Record content to layer
-    layer.record {
-      this@draw.drawContent()
+    // Record the background into `layer`, the source a descendant `cloudy` overlay samples
+    // and blurs. `isCapturing` is set so the overlay draws nothing during this pass: it must be
+    // ABSENT from the blur source. Otherwise the overlay would draw its blur layer into `layer`,
+    // and that blur layer in turn samples `layer` — a cyclic RenderNode/picture graph that
+    // overflows the render thread stack (https://github.com/skydoves/Cloudy/issues/112).
+    sky.isCapturing = true
+    try {
+      layer.record {
+        this@draw.drawContent()
+      }
+    } finally {
+      sky.isCapturing = false
     }
 
-    // Share layer with children
+    // Publish the captured background for children before the on-screen pass below, so a
+    // descendant overlay reads the up-to-date layer when it draws this frame.
     sky.backgroundLayer = layer
     sky.incrementContentVersion()
 
-    // Draw original content to screen
-    drawLayer(layer)
+    // Draw the subtree to the window. `isCapturing` is now false, so the overlay paints its
+    // blurred backdrop (sampling `layer`, which contains no reference back to the overlay) and
+    // its own foreground here. The blur layer is composited straight to the window canvas, never
+    // into `layer`, so no cycle is formed while the backdrop still renders.
+    drawContent()
   }
 
   override fun onDetach() {
@@ -234,6 +247,16 @@ private class CloudyBackgroundModifierNode(
   }
 
   override fun ContentDrawScope.draw() {
+    // When `sky` is an ancestor of this overlay, the sky's capture pass re-enters this draw
+    // while recording the blur source into `backgroundLayer`. This overlay must be ABSENT from
+    // that source: if it drew here, its blur layer (which samples `backgroundLayer`) would be
+    // recorded into `backgroundLayer`, forming a cyclic RenderNode/picture graph that crashes
+    // the render thread (https://github.com/skydoves/Cloudy/issues/112). Draw nothing during
+    // capture; the overlay paints itself in the sky's on-screen pass, when `isCapturing` is false.
+    if (sky.isCapturing) {
+      return
+    }
+
     val backgroundLayer = sky.backgroundLayer
     if (backgroundLayer == null) {
       onStateChanged(CloudyState.Error(RuntimeException("Background layer not available")))


### PR DESCRIPTION
Demo videos (before/after) are attached in a comment below. The crash and the fix were reproduced on a Pixel 9 Pro emulator (API 35).

Fixes #112

## Summary

When `Modifier.sky(sky)` is applied to a container that **contains** a `Modifier.cloudy(sky = ...)` backdrop overlay (for example, a bottom navigation bar over a scrolling `LazyColumn`), the app crashes the moment the screen draws:

```
name: RenderThread  >>> ... <<<
signal 11 (SIGSEGV), code 2 (SEGV_ACCERR)
Cause: stack pointer is close to top of stack; likely stack overflow.
512 total frames
  #00 libhwui.so RenderNode::prepareTreeImpl(...)
  #02 libhwui.so RenderNode::prepareTreeImpl(...)+1460   // recurses
  ... x512
```

The cause is a cyclic `RenderNode` graph: the captured backdrop layer ends up referencing itself, so HWUI's `RenderNode::prepareTreeImpl` recurses until the render-thread stack overflows. Two users reported it on Pixel 6A / Android 36. I reproduced it on a Pixel 9 Pro emulator (API 35), and it crashes on clean `main`.

## Root cause

`SkyModifierNode.draw()` records the sky node's entire subtree into the backdrop layer and publishes it:

```kotlin
layer.record { drawContent() }   // records the whole subtree
sky.backgroundLayer = layer
drawLayer(layer)
```

A backdrop `Modifier.cloudy` overlay is, by design, a descendant of the `Modifier.sky` container (that is how backdrop blur works), so `drawContent()` re-enters the overlay's own draw while recording. The overlay then does:

```kotlin
blurLayer.record { drawLayer(skyLayer) }   // draws the sky layer INTO blurLayer
...
drawLayer(blurLayer)                        // and draws blurLayer back onto the canvas
```

In Compose, a layer drawn inside another layer's `record { }` becomes a hard child in the native `RenderNode` graph. `AndroidGraphicsLayer.draw()` calls `parentLayer?.addSubLayer(this)`, and `GraphicsLayerV29.draw()` emits `recordingCanvas.drawRenderNode(child)` (verified against `androidx.compose.ui:ui-graphics` 1.10.x). That produces two edges:

- `skyLayer` references `blurLayer` (the overlay is part of the recorded sky subtree, and it draws `blurLayer`).
- `blurLayer` references `skyLayer` (the overlay records `skyLayer` into `blurLayer`).

The result is a cycle. The render thread walks it forever, overflows its stack, and gets a `SIGSEGV`.

This explains why the crash depends on where `.sky` sits. With `.sky` on an ancestor of the overlay there is a back-edge, so a cycle forms. With `.sky` on the `LazyColumn` or a sibling (the workaround mentioned in the issue), the overlay is never inside the sky layer's recording, so there is no cycle. The same cyclic structure exists in the skiko backend, so this is a library-wide bug rather than an Android-only one.

## The fix

Break the cycle with a two-pass capture, the approach Haze uses: the backdrop overlay must be absent from the layer it samples.

A new internal flag `Sky.isCapturing` coordinates the two passes within a single draw.

1. **Capture pass.** `SkyModifierNode.draw()` sets `isCapturing = true`, records the subtree into `backgroundLayer`, then resets the flag. While it is set, `CloudyBackgroundModifierNode.draw()` returns early and draws nothing, so the overlay is excluded from `backgroundLayer`. The backdrop layer can no longer reference `blurLayer`.
2. **On-screen pass.** `SkyModifierNode` then draws its subtree to the window via `drawContent()` instead of `drawLayer(layer)`, with `isCapturing = false`. The overlay now paints its blurred backdrop (sampling the overlay-free `backgroundLayer`) and its foreground straight to the window canvas. `blurLayer` is never recorded into `backgroundLayer`, so no cycle can form, and the blur still renders.

`isCapturing` is a plain field rather than a snapshot state on purpose: the capture and the nested overlay draw run synchronously within the same draw pass, so no recomposition or cross-thread visibility is involved.

The change is applied to both backends:

- `cloudy/src/commonMain/.../Sky.kt` adds `internal var isCapturing`.
- `cloudy/src/androidMain/.../CloudyBackground.android.kt` gets the two-pass `SkyModifierNode.draw`; `CloudyBackgroundModifierNode.draw` returns early while capturing.
- `cloudy/src/skikoMain/.../CloudyBackground.skiko.kt` gets the identical change.

Blur radius math and all other behavior are unchanged.

## Verification (on-device, before/after)

Reproduced and verified on a Pixel 9 Pro emulator (API 35) using a demo screen that mirrors the #112 layout: `.sky` on an outer `Box`, a scrolling `LazyColumn`, and a `.cloudy` bottom bar that auto-scrolls the list.

https://github.com/user-attachments/assets/fb98bce4-012a-4f1b-a8bb-bdfb18fbf1eb

I also checked a second screen where `.sky` is on a sibling (the existing Progressive Blur demo) to confirm the non-ancestor case is unaffected.

## Notes for reviewers

- A demo screen ("Issue #112 - BottomNav") is included so the scenario is reproducible from the sample app.
- No automated test is included. This is a native RenderThread stack overflow, and Robolectric (even with native graphics) runs single-threaded with no RenderThread, so it cannot reproduce the crash. An instrumented `connectedAndroidTest` on a real device or emulator could assert that navigating to the backdrop screen does not crash. I'm happy to add one if you want it wired in.
- Separately, `drawWithRenderEffect` allocates and releases a transient blur `GraphicsLayer` every frame. That is a pre-existing efficiency nit, unrelated to this crash, and left untouched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new demonstration screen showcasing a bottom navigation bar with backdrop blur effect positioned over scrolling content.

* **Bug Fixes**
  * Resolved a rendering cycle issue that prevented backdrop blur effects from working correctly on bottom navigation bars overlaying scrollable lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->