### PR TITLE
fix(ci): trim CodeRabbit tone_instructions under 250-char limit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -19,12 +19,11 @@
 language: "en-US"
 early_access: false
 
+# NOTE: CodeRabbit caps tone_instructions at 250 characters — keep this terse.
 tone_instructions: >-
-  Review as a senior Kotlin Multiplatform + Jetpack Compose + Android-graphics engineer.
-  Prioritize correctness, expect/actual parity across platforms, published-API backward
-  compatibility, Android API-level gating, shader (AGSL/SKSL) parity, and native (C++/JNI)
-  memory safety. Never comment on formatting or import ordering — Spotless owns it. Be
-  direct; skip praise.
+  Senior KMP, Compose, and Android-graphics reviewer. Prioritize correctness, expect/actual
+  parity, public-API compatibility, API-level gating, AGSL/SKSL parity, and native C++/JNI
+  memory safety. Never flag formatting; Spotless owns it. Be direct.
 
 reviews:
   profile: "chill"


### PR DESCRIPTION
### 🎯 Goal

CodeRabbit silently fell back to its **default** review settings on every PR because `.coderabbit.yaml` failed to parse. The error surfaces at the top of each automated review (e.g. [#115](https://github.com/skydoves/Cloudy/pull/115#issuecomment-4698405376)):

> `.coderabbit.yaml` has a parsing error
> `Validation error: Too big: expected string to have <=250 characters at "tone_instructions"`

The configured `tone_instructions` was **367 characters**, over CodeRabbit's **250-character** schema cap. While the value was rejected, the whole custom config (the `path_instructions` checklists for `commonMain` API compat, expect/actual parity, AGSL↔SKSL parity, native JNI safety, etc.) was discarded and reviews ran on defaults.

### 🛠 Implementation details

Trimmed `tone_instructions` to **245 characters** without dropping any of the original review priorities:

- correctness
- expect/actual parity
- public-API compatibility
- Android API-level gating
- AGSL/SKSL shader parity
- native C++/JNI memory safety
- "Spotless owns formatting" (don't flag formatting)
- direct tone

Abbreviated "Kotlin Multiplatform + Jetpack Compose" to "KMP, Compose" and tightened the wording to fit the limit. Added a comment above the key noting the 250-char cap so it doesn't regress.

Verified the full document still parses and the value is within the limit:

```
tone_instructions length = 245 / 250 -> OK
reviews.profile          = chill
path_instructions count  = 14
```

### ✍️ Explain examples

```yaml
# NOTE: CodeRabbit caps tone_instructions at 250 characters — keep this terse.
tone_instructions: >-
  Senior KMP, Compose, and Android-graphics reviewer. Prioritize correctness, expect/actual
  parity, public-API compatibility, API-level gating, AGSL/SKSL parity, and native C++/JNI
  memory safety. Never flag formatting; Spotless owns it. Be direct.
```

### Preparing a pull request for review

Config-only change to `.coderabbit.yaml` — no Kotlin/native source touched, so the public binary API is unaffected. `spotlessApply` and `apiDump` have nothing to pick up here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review automation configuration to enhance the consistency and directness of review feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->