### PR TITLE
perf(android): capture at scale to fix legacy CPU blur scroll ANR (#44/#33)

### DIFF
--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyLegacyBlurStrategy.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyLegacyBlurStrategy.kt
@@ -20,25 +20,98 @@ import android.graphics.Bitmap
 import android.os.Build
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
-import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.graphics.drawscope.scale
+import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.node.DrawModifierNode
 import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.node.invalidateDraw
 import androidx.compose.ui.node.requireGraphicsContext
 import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import com.skydoves.cloudy.internals.render.RenderScriptToolkit
 import com.skydoves.cloudy.internals.render.iterativeBlur
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.math.max
+import kotlin.math.roundToInt
+
+/**
+ * Trailing idle window used to coalesce capture requests (slider drag / scroll).
+ * A leading capture still fires immediately on an idle -> active transition so the
+ * first change is shown without waiting for the debounce to elapse.
+ */
+private const val CAPTURE_DEBOUNCE_MILLIS: Long = 120L
+
+/**
+ * Upper bound on how many times we re-capture after a fully transparent (not-yet-drawn) capture
+ * before giving up. Caps the retry so a node whose content is genuinely transparent does not
+ * invalidate every frame forever; a handful of frames is enough to cover the lay-out/compose
+ * race for a cell scrolling into a lazy list.
+ */
+private const val MAX_EMPTY_CAPTURE_RETRIES: Int = 5
+
+/**
+ * Resolves the capture/native downscale factor (the "radius -> scale ramp") for a user
+ * radius. Small radii capture at a higher resolution so a thin blur does not visibly
+ * degrade; larger radii tolerate more downscaling for performance. The same factor scales
+ * the native blur radius, so the on-screen blur amount stays consistent with the radius.
+ */
+internal fun blurScaleForRadius(radius: Int): Float = when {
+  radius <= 6 -> 1.0f
+  radius <= 12 -> 0.5f
+  else -> 0.25f
+}
 
 /**
  * Blur strategy for API 30 and below that captures content into a bitmap
- * and applies the native iterative blur.
+ * and applies the native CPU blur.
+ *
+ * ## ANR mitigation pipeline (issues #44 / #33)
+ *
+ * The blur itself already runs off-main on [Dispatchers.Default]. The remaining
+ * input-dispatch ANRs on Android 8.x came from two things this strategy now avoids:
+ *
+ * 1. A *full-res* bitmap readback on the main thread on *every captured frame*. PATH A
+ *    (record-at-scale) records the content into the [GraphicsLayer] at the SMALL capture
+ *    size up front (see below), so [GraphicsLayer.toImageBitmap] reads back an already-small
+ *    bitmap — there is no full-res snapshot and no main-thread [Bitmap.createScaledBitmap].
+ *    The readback is ~16x smaller at captureScale=0.25. It also no longer runs per frame: a
+ *    trailing debounce + in-flight gate coalesce a slider drag / scroll burst into a bounded
+ *    number of (now small) readbacks rather than one per drawn frame.
+ * 2. A capture storm while dragging the radius slider / scrolling. We now coalesce
+ *    requests with a trailing time debounce, an in-flight gate (<=1 running + <=1
+ *    queued), and we never cancel an in-flight capture/blur.
+ *
+ * ## Chosen capture + blur pipeline (PATH A: record-at-scale)
+ *
+ * Instead of recording the layer at the node size and downscaling the readback, we record
+ * the content directly at the capture resolution during the LIVE draw pass: inside [draw] we
+ * call `captureLayer.record(size = small)` and, within that block, `scale(captureScale,
+ * captureScale, pivot = Offset.Zero) { drawContent() }`. The GPU performs the downscale while
+ * it rasters the recorded display list on the render thread, so by the time the coroutine
+ * calls [GraphicsLayer.toImageBitmap] the bitmap is already capture-resolution — no
+ * [Bitmap.createScaledBitmap] on the main thread. The origin pivot ([Offset.Zero]) is load
+ * bearing: the default `center` pivot is computed against the SMALL drawContext size and
+ * shifts the scaled content off-canvas, leaving the corners empty (which
+ * [isTransparentBitmap] then rejects as a "transparent" capture).
+ *
+ * We then run a *plain* [RenderScriptToolkit.blur] on the already-small bitmap with a radius
+ * scaled to the capture ([blurScaleForRadius] ramp), so the native-blur cost still drops with
+ * the radius. This avoids the redundant double-downscale that would happen if we also let
+ * [RenderScriptToolkit.backgroundBlur] re-downscale, while still getting a gamma-correct
+ * native blur. When the scaled radius exceeds the native single-pass limit (25) we fall back
+ * to [iterativeBlur]. The cached blurred bitmap is small, so [draw] upscales it back to the
+ * node size with bilinear filtering on serve.
  */
 internal object CloudyLegacyBlurStrategy : CloudyBlurStrategy {
 
@@ -113,120 +186,243 @@ private class CloudyModifierNode(
   var radius: Int = radius
     private set
 
+  // ---- cache ----
   private var blurredBitmap: PlatformBitmap? = null
   private var cachedBlurRadius: Int = -1
+
+  // ---- in-flight gate (intervention 1) ----
+  // The radius/content the in-flight capture is producing for. When a newer request
+  // arrives while a capture is running we only remember the latest one (<=1 queued);
+  // the running job re-runs ONCE on completion if the queued state differs from what
+  // it just produced, so the final radius/content is always eventually rendered.
   private var isProcessing: Boolean = false
-  private var pendingInvalidateRequest: Boolean = false
+  private var queuedRadius: Int = -1
+  private var queuedContentDirty: Boolean = false
+  private var hasQueuedRequest: Boolean = false
   private var blurJob: Job? = null
   private var contentMayHaveChanged: Boolean = false
+
+  // A capture can come back fully transparent when the node's content is not laid out/drawn
+  // yet on the very first frames it is composed (common for cells scrolling into a lazy list).
+  // That is transient, so we re-capture on the next frame instead of giving up — but bounded,
+  // so a node whose content is genuinely transparent does not invalidate forever.
+  private var emptyCaptureRetries: Int = 0
+
+  // ---- debounce (intervention 4) ----
+  private var debounceJob: Job? = null
+  private var idle: Boolean = true
 
   fun updateRadius(newRadius: Int) {
     if (radius == newRadius) return
     radius = newRadius
-    blurJob?.cancel()
-    blurJob = null
-    isProcessing = false
-    pendingInvalidateRequest = false
     if (cachedBlurRadius != radius) {
       contentMayHaveChanged = true
     }
+    // Do NOT cancel the in-flight capture/blur. Route this request through the same
+    // debounce + gate as content changes so a slider drag coalesces to one capture.
     if (isAttached) {
-      invalidateDraw()
+      scheduleCapture()
     }
   }
 
   fun onUpdate() {
     contentMayHaveChanged = true
+    // A real content change resets the empty-capture retry budget: the next transparent
+    // capture is a fresh lay-out race, not the same one we already gave up on.
+    emptyCaptureRetries = 0
+    if (isAttached) {
+      scheduleCapture()
+    }
+  }
+
+  /**
+   * Coalesces capture requests (intervention 4).
+   *
+   * On an idle -> active transition a leading capture fires immediately so the first
+   * change shows without latency. Either way we (re)arm a trailing timer: while changes
+   * keep arriving it keeps sliding (last-write-wins); after [CAPTURE_DEBOUNCE_MILLIS] of
+   * quiet it fires a trailing capture (so the final radius/content is rendered) and
+   * returns the node to idle (so the next burst again gets an immediate leading capture).
+   * The timer only ever cancels the debounce delay, never an in-flight capture/blur.
+   */
+  private fun scheduleCapture() {
+    val wasIdle = idle
+    idle = false
+    if (wasIdle) {
+      // Leading edge: show the first change immediately.
+      requestCapture()
+    }
+    // Trailing edge: restart the settle timer (slides while changes keep coming).
+    debounceJob?.cancel()
+    debounceJob = coroutineScope.launch(Dispatchers.Main) {
+      delay(CAPTURE_DEBOUNCE_MILLIS)
+      debounceJob = null
+      idle = true
+      // Ensure the last state in the burst is captured (no-op if leading already covered it).
+      requestCapture()
+    }
+  }
+
+  /**
+   * Funnels a debounced request through the in-flight gate (intervention 1).
+   *
+   * If a capture is already running, the request is recorded as the single queued
+   * request (latest wins) and the running job re-runs once on completion. Otherwise a
+   * redraw is requested so [draw] launches the capture.
+   */
+  private fun requestCapture() {
     if (isProcessing) {
-      pendingInvalidateRequest = true
+      queuedRadius = radius
+      queuedContentDirty = contentMayHaveChanged
+      hasQueuedRequest = true
     } else if (isAttached) {
       invalidateDraw()
     }
   }
 
   /**
-   * Draws the modifier's content, applying a blur when requested and managing asynchronous capture, caching, and state callbacks.
+   * Draws the modifier's content, applying a blur when requested and managing asynchronous
+   * scaled capture, caching, gating, debouncing, and state callbacks.
    *
-   * If the configured radius is less than or equal to zero, the content is drawn directly without blur and no state callback is invoked.
-   * When a positive radius is set, a cached blurred bitmap is used when valid; otherwise the current content is captured and an asynchronous CPU blur is scheduled.
-   * During processing the state is reported as Loading; on successful capture the state is reported as Success.Captured with the resulting bitmap; on failure the state is reported as Error.
-   *
-   * The method updates internal cache state, may request redraws, and launches background work to produce blurred results when needed.
+   * If the configured radius is <= 0 the content is drawn directly without blur and no state
+   * callback is invoked. When a positive radius is set, a valid cached blurred bitmap is
+   * upscaled on serve; otherwise the current content is captured at scale and a native CPU
+   * blur is scheduled off-main.
    */
   override fun ContentDrawScope.draw() {
-    val graphicsContext = requireGraphicsContext()
-    val graphicsLayer = graphicsContext.createGraphicsLayer()
-
-    graphicsLayer.record {
-      this@draw.drawContent()
-    }
-
     if (radius <= 0) {
-      drawLayer(graphicsLayer)
-      graphicsContext.releaseGraphicsLayer(graphicsLayer)
+      drawContent()
       return
     }
 
     val cached = blurredBitmap
-    if (cached != null && !cached.bitmap.isRecycled) {
-      drawImage(cached.bitmap.asImageBitmap())
-    } else {
-      drawLayer(graphicsLayer)
-    }
+    val validCache = if (cached != null && !cached.bitmap.isRecycled) cached else null
 
-    if (cached != null && !cached.bitmap.isRecycled &&
-      cachedBlurRadius == radius && !contentMayHaveChanged
+    // Fast path (intervention "2-skip-record"): on a pure cache hit we do NOT record a
+    // throwaway GraphicsLayer. Just upscale the small cached bitmap and return.
+    if (validCache != null && cachedBlurRadius == radius && !contentMayHaveChanged &&
+      !isProcessing
     ) {
-      graphicsContext.releaseGraphicsLayer(graphicsLayer)
-      onStateChanged.invoke(CloudyState.Success.Captured(cached))
+      drawCachedUpscaled(validCache)
+      onStateChanged.invoke(CloudyState.Success.Captured(validCache))
       return
     }
 
-    if (!isProcessing) {
-      isProcessing = true
-      pendingInvalidateRequest = false
-      onStateChanged.invoke(CloudyState.Loading)
-      val currentRadius = radius
-      val node = this@CloudyModifierNode
+    // A capture is already in flight: do NOT record a throwaway GraphicsLayer (the scaled
+    // drawContent() is real GPU work). Just draw interim content and return — the in-flight gate
+    // re-runs the capture on completion if a newer request was queued meanwhile.
+    if (isProcessing) {
+      if (validCache != null) {
+        drawCachedUpscaled(validCache)
+      } else {
+        drawContent()
+      }
+      return
+    }
 
-      blurJob = coroutineScope.launch(Dispatchers.Main) {
+    // We are going to capture. Record ONCE, at the SMALL capture size (PATH A: record-at-scale).
+    //
+    // The capture downscale and the native-blur radius scale are the SAME ramp, so the
+    // on-screen blur amount stays faithful to the requested radius (no quality floor).
+    val nodeWidth = size.width.roundToInt().coerceAtLeast(1)
+    val nodeHeight = size.height.roundToInt().coerceAtLeast(1)
+    val captureScale = blurScaleForRadius(radius)
+    val capturedRadius = radius
+    // The recorded display list is sized to the capture resolution; the GPU does the downscale
+    // while it rasters on the render thread, so toImageBitmap() reads back an already-small
+    // bitmap (no full-res snapshot, no main-thread createScaledBitmap).
+    val captureWidth = max(1, (nodeWidth * captureScale).roundToInt())
+    val captureHeight = max(1, (nodeHeight * captureScale).roundToInt())
+
+    val graphicsContext = requireGraphicsContext()
+    val graphicsLayer = graphicsContext.createGraphicsLayer()
+    graphicsLayer.record(size = IntSize(captureWidth, captureHeight)) {
+      // pivot = Offset.Zero (origin) so the scaled content fills [0, captureW]x[0, captureH]
+      // exactly. The default `center` pivot is computed against the SMALL drawContext size and
+      // shifts the content off-canvas, emptying the corners (which isTransparentBitmap rejects).
+      scale(captureScale, captureScale, pivot = Offset.Zero) {
+        this@draw.drawContent()
+      }
+    }
+
+    // Show the freshest available content while the (new) blur is being produced.
+    //
+    // Self-content blur differs from backdrop blur here. The background/backdrop path can draw
+    // nothing (transparent) on a cold start because the backdrop behind it shows through — there
+    // is no hole. This path blurs the node's OWN content, so drawing nothing leaves a blank hole
+    // (the gray cells when new cells scroll into a LazyVerticalGrid). So:
+    //   - re-blurring WITH a valid (stale) cache: keep serving the stale blur — no flash.
+    //   - first appearance with NO cache: draw the live UNBLURRED content so the cell is never a
+    //     hole; the blur swaps in when ready (PATH A keeps that pre-first-blur window short).
+    if (validCache != null) {
+      drawCachedUpscaled(validCache)
+    } else {
+      // First appearance, no cache yet: draw the live UNBLURRED content (full-res) so the cell
+      // is never a blank hole. The blur swaps in when ready (path A makes that window short).
+      // Must be drawContent() (full-res live canvas), NOT drawLayer(graphicsLayer) — graphicsLayer
+      // is the SMALL capture-only layer (recorded at captureScale); drawing it would be tiny/blurry.
+      drawContent()
+    }
+
+    isProcessing = true
+    hasQueuedRequest = false
+    onStateChanged.invoke(CloudyState.Loading)
+
+    val node = this@CloudyModifierNode
+
+    // start = ATOMIC so the body — and therefore the finally that releases [graphicsLayer] and
+    // resets [isProcessing] — is guaranteed to run even if the node detaches (cancelling
+    // coroutineScope) before this launch dispatches on the main loop. The layer and the
+    // isProcessing flag are allocated/set synchronously above in the live draw pass, so without
+    // ATOMIC a cancel-before-first-dispatch would leak the layer and wedge the gate. With ATOMIC
+    // the body runs, the first suspension point (toImageBitmap) throws CancellationException if
+    // cancelled, and the finally still releases.
+    blurJob =
+      coroutineScope.launch(Dispatchers.Main, start = kotlinx.coroutines.CoroutineStart.ATOMIC) {
         try {
+          // (intervention 2) Materialize the recorded layer via the known-good
+          // GraphicsLayer.toImageBitmap(). PATH A already recorded at the capture resolution,
+          // so this reads back an already-small bitmap directly — no full-res snapshot and no
+          // main-thread createScaledBitmap. The readback is ~16x smaller at captureScale=0.25,
+          // and the debounce + in-flight gate keep even this small readback off the per-frame
+          // path.
           val capturedBitmap: Bitmap = try {
-            graphicsLayer.toImageBitmap().asAndroidBitmap()
+            captureSmallLayer(graphicsLayer)
+          } catch (e: CancellationException) {
+            throw e
           } catch (e: Exception) {
-            if (e is CancellationException) throw e
             onStateChanged.invoke(CloudyState.Error(e))
             return@launch
           }
 
-          val softwareBitmap = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
-            capturedBitmap.config == Bitmap.Config.HARDWARE
-          ) {
-            try {
-              capturedBitmap.copy(Bitmap.Config.ARGB_8888, true)
-            } catch (e: Exception) {
-              onStateChanged.invoke(CloudyState.Error(e))
-              return@launch
+          // (intervention 3) Native blur on the already-small bitmap.
+          //
+          // The capture is already downscaled, so we run a PLAIN RenderScriptToolkit.blur
+          // here (NOT backgroundBlur) to avoid a redundant second downscale. The user
+          // radius is scaled to the capture resolution and clamped to the native single
+          // pass range [1, 25]; anything larger falls back to iterativeBlur.
+          val blurResult: Bitmap? = withContext(Dispatchers.Default) {
+            val output: Bitmap = capturedBitmap.copy(Bitmap.Config.ARGB_8888, true)
+            val scaledRadius = (capturedRadius * captureScale).roundToInt().coerceAtLeast(1)
+            if (scaledRadius <= 25) {
+              RenderScriptToolkit.blur(
+                inputBitmap = capturedBitmap,
+                outputBitmap = output,
+                radius = scaledRadius,
+              )
+            } else {
+              iterativeBlur(
+                androidBitmap = capturedBitmap,
+                outputBitmap = output,
+                radius = scaledRadius,
+              ).await()
             }
-          } else {
-            capturedBitmap
           }
 
-          if (softwareBitmap == null) {
-            onStateChanged.invoke(
-              CloudyState.Error(RuntimeException("Failed to create software bitmap")),
-            )
-            return@launch
-          }
-
-          val blurResult = withContext(Dispatchers.Default) {
-            val outputBitmap: Bitmap =
-              softwareBitmap.toPlatformBitmap().createCompatible().toAndroidBitmap()
-            iterativeBlur(
-              androidBitmap = softwareBitmap,
-              outputBitmap = outputBitmap,
-              radius = currentRadius,
-            ).await()
+          // Free the intermediate capture bitmap now that the native blur has read it. The blur
+          // wrote into a separate `output` bitmap (blurResult), so this does not touch the result.
+          if (!capturedBitmap.isRecycled) {
+            capturedBitmap.recycle()
           }
 
           val result = blurResult?.toPlatformBitmap()
@@ -235,35 +431,101 @@ private class CloudyModifierNode(
           if (node.isAttached) {
             val isEmpty = isTransparentBitmap(result.bitmap)
             if (isEmpty) {
-              isProcessing = false
+              // Transient cold-start: content was not drawn yet when we captured. Retry on the
+              // next frame (bounded) instead of getting stuck unblurred forever — the finally
+              // block below re-invalidates while emptyCaptureRetries is under the cap.
               contentMayHaveChanged = true
+              emptyCaptureRetries++
             } else {
-              cachedBlurRadius = currentRadius
+              emptyCaptureRetries = 0
+              cachedBlurRadius = capturedRadius
               blurredBitmap = result
-              contentMayHaveChanged = false
+              // Content is consistent with what we just produced unless a newer request
+              // was queued while we were running.
+              if (!hasQueuedRequest) {
+                contentMayHaveChanged = false
+              }
               node.invalidateDraw()
               onStateChanged.invoke(CloudyState.Success.Captured(result))
             }
           }
+        } catch (e: CancellationException) {
+          throw e
         } catch (e: Exception) {
-          if (e is CancellationException) throw e
           onStateChanged.invoke(CloudyState.Error(e))
         } finally {
+          // Release the captured GraphicsLayer on EVERY path (no leaks).
           graphicsContext.releaseGraphicsLayer(graphicsLayer)
           isProcessing = false
           blurJob = null
-          if (pendingInvalidateRequest) {
-            pendingInvalidateRequest = false
-            if (node.isAttached) {
-              node.invalidateDraw()
-            }
+          // (intervention 1) Re-run ONCE if the queued state diverged from what we just
+          // produced, so the final radius/content is never dropped.
+          val queuedRerun = hasQueuedRequest &&
+            (queuedRadius != cachedBlurRadius || queuedContentDirty || contentMayHaveChanged)
+          // Retry an empty (not-yet-drawn) capture on the next frame, bounded so a genuinely
+          // transparent node does not invalidate forever.
+          val retryEmpty = emptyCaptureRetries in 1..MAX_EMPTY_CAPTURE_RETRIES
+          hasQueuedRequest = false
+          if ((queuedRerun || retryEmpty) && node.isAttached) {
+            node.invalidateDraw()
           }
         }
       }
-    } else {
-      pendingInvalidateRequest = true
-      graphicsContext.releaseGraphicsLayer(graphicsLayer)
+  }
+
+  /**
+   * Draws the (small) cached blurred bitmap upscaled to the node size with bilinear
+   * filtering so the served frame is not blocky.
+   */
+  private fun ContentDrawScope.drawCachedUpscaled(cached: PlatformBitmap) {
+    drawImage(
+      image = cached.bitmap.asImageBitmap(),
+      srcOffset = IntOffset.Zero,
+      srcSize = IntSize(cached.bitmap.width, cached.bitmap.height),
+      dstOffset = IntOffset.Zero,
+      dstSize = IntSize(size.width.roundToInt(), size.height.roundToInt()),
+      filterQuality = FilterQuality.Low,
+    )
+  }
+
+  /**
+   * Materializes the SMALL recorded [GraphicsLayer] (PATH A: record-at-scale) into a
+   * software ARGB_8888 bitmap.
+   *
+   * The capture goes through [GraphicsLayer.toImageBitmap], which correctly snapshots the
+   * recorded RenderNode (on API 26/27 via an ImageReader-backed software readback; on API 28+
+   * via a hardware [android.graphics.Picture] bitmap). This is the known-good path: unlike
+   * replaying the layer into a software [android.graphics.Canvas] from outside the live draw
+   * pass — which re-executes the recorded `drawContent()` block when there is nothing to draw
+   * and yields a fully transparent capture — `toImageBitmap()` reads back what was actually
+   * recorded.
+   *
+   * Because PATH A already recorded the content at the capture resolution (the layer was
+   * recorded with `record(size = small)` and a `scale(captureScale, .., pivot = Offset.Zero)`
+   * transform during the live draw pass), the readback is already capture-resolution: there is
+   * NO [Bitmap.createScaledBitmap] here, so no full-res downscale runs on the main thread.
+   *
+   * On API 28+ `toImageBitmap()` can return a [Bitmap.Config.HARDWARE] bitmap, which has no
+   * pixel storage accessible to `getPixel`/RenderScript; we copy it to ARGB_8888 first. That
+   * copy is now cheap because the bitmap is already small.
+   */
+  private suspend fun captureSmallLayer(layer: GraphicsLayer): Bitmap {
+    var bmp = layer.toImageBitmap().asAndroidBitmap()
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+      bmp.config == Bitmap.Config.HARDWARE
+    ) {
+      bmp = bmp.copy(Bitmap.Config.ARGB_8888, false)
+        ?: throw RuntimeException("Failed to copy HARDWARE bitmap to ARGB_8888")
     }
+    return bmp
+  }
+
+  override fun onDetach() {
+    debounceJob?.cancel()
+    debounceJob = null
+    blurJob?.cancel()
+    blurJob = null
+    super.onDetach()
   }
 
   /**


### PR DESCRIPTION
## Problem

On Android 8.x (API 26/27) the legacy CPU blur path causes `Input dispatching timed out` ANRs during scroll (#44, #33). The blur kernel already runs off the main thread (`Dispatchers.Default`), so the remaining cost is the per-capture **full-resolution `GraphicsLayer.toImageBitmap()` readback on the main thread** (~8.6 MB for a full-screen node). Under a fast-scrolling list this fires repeatedly and starves input dispatch.

## Change

Capture the content **at the blur's downscale factor** instead of reading back full resolution and downscaling afterward:

- The captured subtree is recorded into a `GraphicsLayer` sized to `node * captureScale`, with `scale(captureScale, captureScale, pivot = Offset.Zero)` applied during the live draw pass. `toImageBitmap()` then reads back an already-small bitmap (~16x fewer bytes at 0.25), and the GPU does the downscale while it rasters on the render thread. No full-resolution main-thread readback, no `createScaledBitmap`.
- Coalesce capture requests: a trailing debounce plus an in-flight gate (at most one running, one queued) so a scroll/slider burst no longer issues a capture per frame, and an in-flight capture is never cancel-restarted.
- Launch the capture coroutine with `CoroutineStart.ATOMIC` so the `GraphicsLayer` is always released and the processing flag always reset, even if the node detaches before the coroutine dispatches.
- On first appearance with no cache yet, draw the live unblurred content rather than nothing, so a scrolled-in cell is never a blank hole while its blur is computed. A stale cache is kept on screen during re-blur.
- Retry (bounded) when a capture comes back fully transparent. A cell scrolling into a lazy list can be captured before its content is laid out; without a retry the node would stay unblurred. The retry is capped so a genuinely transparent node does not invalidate forever, and it does not run while idle.

## Measurements

API 27 emulator, scrolling a 2-column grid of blurred posters, same gesture before/after (`dumpsys gfxinfo`):

https://github.com/user-attachments/assets/a5995aa9-2b50-4f53-a4f1-28498f8eeb51


| | before | after |
|---|---|---|
| janky frames | 24.7% | 20.9% |
| 99th percentile frame | 53 ms | 42 ms |
| missed vsync | 42 | 13 |
| slow UI thread frames | 54 | 41 |
| high input latency | 5 | 1 |

The before run still shows the full-resolution readback as one-off frame spikes over 1 s in the captured video; the after run does not. API 31+ keeps using `RenderEffect`; this only touches the API < 31 path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Performance Improvements**
  * Enhanced blur rendering with smarter caching to reuse previously generated results when settings haven’t changed.
  * Improved performance by capturing and blurring at a smaller resolution, then upscaling as needed with adaptive radius scaling.

* **Bug Fixes**
  * Improved visual stability during rapid updates by coalescing blur requests and retrying when initial captures are fully transparent.
  * Prevented occasional blank frames while the blurred content is being prepared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->