### PR TITLE
fix(ci): don't fail screenshot-comment job when no diff artifact exists

### DIFF
--- a/.github/workflows/screenshot-comment.yml
+++ b/.github/workflows/screenshot-comment.yml
@@ -59,7 +59,12 @@ jobs:
         uses: actions/checkout@v6.0.1
         # persist-credentials left default (true): this job pushes the companion branch.
 
+      # continue-on-error: the compare run only uploads this artifact when there were diffs (a
+      # regression). On a clean pass it does not exist, and download-artifact errors on a missing
+      # named artifact -- which must NOT fail the job. The next step then sees no *_compare.png and
+      # treats it as "no differences".
       - name: Download screenshot diff artifact
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: screenshot-diff
@@ -184,7 +189,10 @@ jobs:
         run: |
           git fetch origin --quiet || true
           now=$(date +%s)
-          git branch -r --format='%(refname:lstrip=3)' | grep '^companion_' | while read -r branch; do
+          # `|| true` on grep: with no companion_* branches yet, grep exits 1, which under the
+          # default `bash -e -o pipefail` would fail this step. Absorb it so cleanup is a no-op.
+          branches=$(git branch -r --format='%(refname:lstrip=3)' | grep '^companion_' || true)
+          for branch in $branches; do
             last=$(git log -1 --format=%ct "origin/$branch" 2>/dev/null || echo "$now")
             if [ $((now - last)) -gt 2592000 ]; then   # 30 days
               echo "Deleting stale companion branch: $branch"


### PR DESCRIPTION
## Problem

After #120 merged, the `Screenshot diff comment` workflow runs on every `Screenshot Tests` completion but fails on runs where nothing regressed — e.g. [run 27489898452](https://github.com/skydoves/Cloudy/actions/runs/27489898452) on #121. Two steps fail:

1. **Download screenshot diff artifact** — `Unable to download artifact(s): Artifact not found for name: screenshot-diff`. The compare workflow only uploads `screenshot-diff` when a mismatch produced `*_compare.png`; on a clean pass that artifact does not exist, and `actions/download-artifact` errors on a missing named artifact, aborting the job.
2. **Cleanup outdated companion branches** — exits 1 because `git branch -r | grep '^companion_'` finds no matches, and under the default `bash -e -o pipefail` a non-matching `grep` fails the step.

So every passing PR run shows a red `Screenshot diff comment` job, even though there is nothing to comment.

## Fix

- Add `continue-on-error: true` to the diff-artifact download. When the artifact is absent (clean run), the job continues; the next step finds no `*_compare.png` and treats it as "no differences", which is the intended path.
- Absorb the non-matching `grep` in the cleanup step (`... || true`) so it is a no-op when there are no `companion_*` branches yet.

No behavior change on a regression: the diff artifact is present, downloads normally, and the gallery comment posts as before.

## Testing

- YAML parses.
- Reproduced the cleanup failure locally (`grep` no-match under `-e -o pipefail` exits 1) and confirmed the `|| true` form exits 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD workflow resilience by allowing job continuation when screenshot comparison artifacts are unavailable and preventing failures when no matching remote branches exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->