### PR TITLE
feat: chromatic overlay material for liquid glass

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,9 +295,36 @@ You can customize the liquid glass effect with various parameters:
 | `contrast` | 1.0f | Light/dark contrast (1.0 = normal) | Approximation |
 | `tint` | Transparent | Optional color tint overlay | Yes |
 | `edge` | 0.2f | Edge lighting width (0 = none) | Yes (as stroke) |
+| `light` | Fixed | Specular light direction (see Motion-driven specular) | No (requires API 33+) |
 | `enabled` | true | Enable/disable the effect | Yes |
 
 > **Note:** On Android 32 and below, the lens refraction effect is not available since it requires `RuntimeShader` (API 33+). The fallback draws a visible lens shape with tint, edge lighting, and color adjustments. For blur effects, use `Modifier.cloudy()` separately.
+
+### Motion-driven specular (experimental)
+
+By default the rim highlight uses a fixed light direction, so output is unchanged from earlier versions. Opt in to **gyro-driven specular** to make the highlight sweep across the glass as the device tilts (à la iOS 26 "lights move in space"):
+
+```kotlin
+@OptIn(ExperimentalLiquidGlassMotion::class)
+@Composable
+fun GlassCard() {
+  // Hoist once and share across items in a list — one call registers one sensor.
+  val light = rememberGyroLightSource(enabled = true)
+
+  Box(
+    modifier = Modifier.liquidGlass(
+      lensCenter = lensCenter,
+      light = light,
+    ),
+  ) { /* ... */ }
+}
+```
+
+- **Opt-in & accessible:** the default is a fixed light (bit-identical to previous releases). When **Reduce Motion** is enabled (Android animator scale `0`, iOS `isReduceMotionEnabled`), the light is frozen and no sensors are registered — observed live.
+- **Platform support:** Android **API 33+** (the fallback path has no shader → no-op), iOS, and any device with a motion sensor. Desktop/Web and sensorless devices keep a static light.
+- **Lists:** call `rememberGyroLightSource()` **once** above the list and pass the result to each item, so a single sensor listener is shared.
+
+> **iOS:** the consuming app's `Info.plist` **must** declare `NSMotionUsageDescription`, or recent iOS terminates the app on the first device-motion read. iOS v1 uses a portrait-oriented projection; landscape is not yet remapped.
 
 ## Find this repository useful? :heart:
 Support it by joining __[stargazers](https://github.com/skydoves/cloudy/stargazers)__ for this repository. :star: <br>

--- a/app/src/commonMain/kotlin/demo/Main.kt
+++ b/app/src/commonMain/kotlin/demo/Main.kt
@@ -28,8 +28,8 @@ import androidx.navigation3.ui.NavDisplay
 import demo.screen.BlurAppBarGridScreen
 import demo.screen.BlurLightScreen
 import demo.screen.GridListScreen
-import demo.screen.InteractiveSliderScreen
 import demo.screen.GyroLightScreen
+import demo.screen.InteractiveSliderScreen
 import demo.screen.Issue112BottomNavScreen
 import demo.screen.LiquidGlassDemoScreen
 import demo.screen.MenuHomeScreen

--- a/app/src/commonMain/kotlin/demo/Main.kt
+++ b/app/src/commonMain/kotlin/demo/Main.kt
@@ -28,6 +28,7 @@ import androidx.navigation3.ui.NavDisplay
 import demo.screen.BlurAppBarGridScreen
 import demo.screen.GridListScreen
 import demo.screen.InteractiveSliderScreen
+import demo.screen.GyroLightScreen
 import demo.screen.Issue112BottomNavScreen
 import demo.screen.LiquidGlassDemoScreen
 import demo.screen.MenuHomeScreen
@@ -61,6 +62,7 @@ fun CloudyDemoApp() {
               onProgressiveBlurClick = { backStack.add(Route.ProgressiveBlur) },
               onLiquidGlassClick = { backStack.add(Route.LiquidGlass) },
               onIssue112Click = { backStack.add(Route.Issue112BottomNav) },
+              onGyroLightClick = { backStack.add(Route.GyroLight) },
             )
           }
 
@@ -110,6 +112,12 @@ fun CloudyDemoApp() {
 
           is Route.Issue112BottomNav -> NavEntry(route) {
             Issue112BottomNavScreen(
+              onBackClick = { backStack.removeLastOrNull() },
+            )
+          }
+
+          is Route.GyroLight -> NavEntry(route) {
+            GyroLightScreen(
               onBackClick = { backStack.removeLastOrNull() },
             )
           }

--- a/app/src/commonMain/kotlin/demo/Main.kt
+++ b/app/src/commonMain/kotlin/demo/Main.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.remember
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.ui.NavDisplay
 import demo.screen.BlurAppBarGridScreen
+import demo.screen.BlurLightScreen
 import demo.screen.GridListScreen
 import demo.screen.InteractiveSliderScreen
 import demo.screen.GyroLightScreen
@@ -65,6 +66,7 @@ fun CloudyDemoApp() {
               onIssue112Click = { backStack.add(Route.Issue112BottomNav) },
               onGyroLightClick = { backStack.add(Route.GyroLight) },
               onTransformLightClick = { backStack.add(Route.TransformLight) },
+              onBlurLightClick = { backStack.add(Route.BlurLight) },
             )
           }
 
@@ -126,6 +128,12 @@ fun CloudyDemoApp() {
 
           is Route.TransformLight -> NavEntry(route) {
             TransformLightScreen(
+              onBackClick = { backStack.removeLastOrNull() },
+            )
+          }
+
+          is Route.BlurLight -> NavEntry(route) {
+            BlurLightScreen(
               onBackClick = { backStack.removeLastOrNull() },
             )
           }

--- a/app/src/commonMain/kotlin/demo/Main.kt
+++ b/app/src/commonMain/kotlin/demo/Main.kt
@@ -27,6 +27,7 @@ import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.ui.NavDisplay
 import demo.screen.BlurAppBarGridScreen
 import demo.screen.BlurLightScreen
+import demo.screen.ChromaticCardScreen
 import demo.screen.GridListScreen
 import demo.screen.GyroLightScreen
 import demo.screen.InteractiveSliderScreen
@@ -67,6 +68,7 @@ fun CloudyDemoApp() {
               onGyroLightClick = { backStack.add(Route.GyroLight) },
               onTransformLightClick = { backStack.add(Route.TransformLight) },
               onBlurLightClick = { backStack.add(Route.BlurLight) },
+              onChromaticCardClick = { backStack.add(Route.ChromaticCard) },
             )
           }
 
@@ -134,6 +136,12 @@ fun CloudyDemoApp() {
 
           is Route.BlurLight -> NavEntry(route) {
             BlurLightScreen(
+              onBackClick = { backStack.removeLastOrNull() },
+            )
+          }
+
+          is Route.ChromaticCard -> NavEntry(route) {
+            ChromaticCardScreen(
               onBackClick = { backStack.removeLastOrNull() },
             )
           }

--- a/app/src/commonMain/kotlin/demo/Main.kt
+++ b/app/src/commonMain/kotlin/demo/Main.kt
@@ -35,6 +35,7 @@ import demo.screen.MenuHomeScreen
 import demo.screen.ProgressiveBlurDemoScreen
 import demo.screen.RadiusDetailScreen
 import demo.screen.RadiusItemsScreen
+import demo.screen.TransformLightScreen
 import demo.theme.PosterTheme
 
 /**
@@ -63,6 +64,7 @@ fun CloudyDemoApp() {
               onLiquidGlassClick = { backStack.add(Route.LiquidGlass) },
               onIssue112Click = { backStack.add(Route.Issue112BottomNav) },
               onGyroLightClick = { backStack.add(Route.GyroLight) },
+              onTransformLightClick = { backStack.add(Route.TransformLight) },
             )
           }
 
@@ -118,6 +120,12 @@ fun CloudyDemoApp() {
 
           is Route.GyroLight -> NavEntry(route) {
             GyroLightScreen(
+              onBackClick = { backStack.removeLastOrNull() },
+            )
+          }
+
+          is Route.TransformLight -> NavEntry(route) {
+            TransformLightScreen(
               onBackClick = { backStack.removeLastOrNull() },
             )
           }

--- a/app/src/commonMain/kotlin/demo/Route.kt
+++ b/app/src/commonMain/kotlin/demo/Route.kt
@@ -85,4 +85,11 @@ sealed interface Route {
    */
   @Serializable
   data object GyroLight : Route
+
+  /**
+   * The transform lighting test screen — the target's own 3D rotation drives the specular
+   * highlight (deterministic, sensor-free; runs on Desktop and Web).
+   */
+  @Serializable
+  data object TransformLight : Route
 }

--- a/app/src/commonMain/kotlin/demo/Route.kt
+++ b/app/src/commonMain/kotlin/demo/Route.kt
@@ -79,4 +79,10 @@ sealed interface Route {
    */
   @Serializable
   data object Issue112BottomNav : Route
+
+  /**
+   * The gyro lighting test screen — isolates the tilt-driven specular highlight.
+   */
+  @Serializable
+  data object GyroLight : Route
 }

--- a/app/src/commonMain/kotlin/demo/Route.kt
+++ b/app/src/commonMain/kotlin/demo/Route.kt
@@ -92,4 +92,11 @@ sealed interface Route {
    */
   @Serializable
   data object TransformLight : Route
+
+  /**
+   * The blur lighting test screen — a moving liquid-glass specular pool rides the blurred
+   * backdrop of a cloudy(sky=…) surface (deterministic, sensor-free).
+   */
+  @Serializable
+  data object BlurLight : Route
 }

--- a/app/src/commonMain/kotlin/demo/Route.kt
+++ b/app/src/commonMain/kotlin/demo/Route.kt
@@ -99,4 +99,11 @@ sealed interface Route {
    */
   @Serializable
   data object BlurLight : Route
+
+  /**
+   * The chromatic card screen — a clean white card carries the iridescent chromatic overlay; tilt
+   * or drag to sweep the rainbow sheen.
+   */
+  @Serializable
+  data object ChromaticCard : Route
 }

--- a/app/src/commonMain/kotlin/demo/screen/BlurLightScreen.kt
+++ b/app/src/commonMain/kotlin/demo/screen/BlurLightScreen.kt
@@ -118,9 +118,10 @@ fun BlurLightScreen(onBackClick: () -> Unit) {
         verticalArrangement = Arrangement.spacedBy(16.dp),
       ) {
         Text(
-          text = "Drag the glass card — or use the sliders. A liquid-glass specular pool rides the " +
-            "blurred backdrop and sweeps with the light direction (no gyroscope). Lower the radius " +
-            "to 0 and the highlight fades with the blur, since there is no blurred backdrop to light.",
+          text = "Drag the glass card — or use the sliders. A liquid-glass specular pool " +
+            "rides the blurred backdrop and sweeps with the light direction (no gyroscope). " +
+            "Lower the radius to 0 and the highlight fades with the blur, since there is no " +
+            "blurred backdrop to light.",
           fontSize = 14.sp,
           color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
           textAlign = TextAlign.Center,

--- a/app/src/commonMain/kotlin/demo/screen/BlurLightScreen.kt
+++ b/app/src/commonMain/kotlin/demo/screen/BlurLightScreen.kt
@@ -82,7 +82,10 @@ import kotlin.math.roundToInt
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BlurLightScreen(onBackClick: () -> Unit) {
-  val poster = remember { MockUtil.getMockPoster() }
+  // A deterministically dark, high-contrast backdrop (Coco — Land of the Dead) so the warm specular
+  // pool reads clearly. getMockPoster() is randomized, which can land on a bright poster where the
+  // SrcOver pool blends in; pick the dark one explicitly for this lighting demo.
+  val poster = remember { MockUtil.getMockPosters()[5] }
   val sky = rememberSky()
 
   // Drives BOTH the specular light direction and the card drag. Read only through deferred lambdas

--- a/app/src/commonMain/kotlin/demo/screen/BlurLightScreen.kt
+++ b/app/src/commonMain/kotlin/demo/screen/BlurLightScreen.kt
@@ -1,0 +1,269 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(com.skydoves.cloudy.ExperimentalLiquidGlassMotion::class)
+
+package demo.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.skydoves.cloudy.cloudy
+import com.skydoves.cloudy.rememberSky
+import com.skydoves.cloudy.rememberTransformLightSource
+import com.skydoves.cloudy.sky
+import com.skydoves.landscapist.ImageOptions
+import com.skydoves.landscapist.coil3.CoilImage
+import demo.component.CollapsingAppBarScaffold
+import demo.component.MaxWidthContainer
+import demo.model.MockUtil
+import demo.theme.Dimens
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+/**
+ * Demo screen for the **blur lighting** effect: a moving liquid-glass specular pool that rides the
+ * *blurred backdrop* of a `Modifier.cloudy(sky = …)` surface. The pool's position is driven by a
+ * deterministic [rememberTransformLightSource] (no gyroscope) — the same `rotationX` / `rotationY`
+ * that you set with the sliders or by dragging the glass card sweep the highlight across the blur.
+ *
+ * Layout mirrors the sibling test screens: a hero `Box` stacks a `sky(sky)`-captured background image
+ * behind a centered glass card carrying `cloudy(sky = …, light = …)`, so the card has real blurred
+ * content to light. Lowering `radius` to 0 removes the blurred backdrop, and the highlight disappears
+ * with it — the documented behavior.
+ *
+ * @param onBackClick Callback when the back button is pressed.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BlurLightScreen(onBackClick: () -> Unit) {
+  val poster = remember { MockUtil.getMockPoster() }
+  val sky = rememberSky()
+
+  // Drives BOTH the specular light direction and the card drag. Read only through deferred lambdas
+  // below — never at composable scope — so a rotation change invalidates the draw without
+  // recomposing this screen.
+  var rotationX by remember { mutableFloatStateOf(0f) }
+  var rotationY by remember { mutableFloatStateOf(0f) }
+  var gain by remember { mutableFloatStateOf(1.2f) }
+  var radius by remember { mutableIntStateOf(25) }
+
+  // Deferred reads keep the holder identity stable: per-frame rotation updates re-emit through
+  // snapshotFlow inside the factory without recomposing here.
+  val light = rememberTransformLightSource(
+    rotationX = { rotationX },
+    rotationY = { rotationY },
+    gain = gain,
+  )
+
+  CollapsingAppBarScaffold(
+    title = "Blur Lighting",
+    onBackClick = onBackClick,
+  ) { paddingValues, _ ->
+    MaxWidthContainer(modifier = Modifier.padding(paddingValues)) {
+      Column(
+        modifier = Modifier
+          .fillMaxSize()
+          .verticalScroll(rememberScrollState())
+          .padding(Dimens.contentPadding),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+      ) {
+        Text(
+          text = "Drag the glass card — or use the sliders. A liquid-glass specular pool rides the " +
+            "blurred backdrop and sweeps with the light direction (no gyroscope). Lower the radius " +
+            "to 0 and the highlight fades with the blur, since there is no blurred backdrop to light.",
+          fontSize = 14.sp,
+          color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+          textAlign = TextAlign.Center,
+        )
+
+        // Hero: the sky-captured background sits BEHIND the cloudy child within the same Box, so the
+        // child has real content to blur. The child is drag-rotatable; the same rx/ry feed the light.
+        Box(
+          modifier = Modifier
+            .fillMaxWidth()
+            .height(360.dp)
+            .clip(RoundedCornerShape(Dimens.itemSpacing)),
+          contentAlignment = Alignment.Center,
+        ) {
+          // Background image captured by sky — the content the glass card blurs.
+          CoilImage(
+            modifier = Modifier
+              .matchParentSize()
+              .sky(sky),
+            imageModel = { poster.image },
+            imageOptions = ImageOptions(contentScale = ContentScale.Crop),
+          )
+
+          // Centered glass card: blurred backdrop + moving specular highlight appear inside this.
+          Box(
+            modifier = Modifier
+              .align(Alignment.Center)
+              .fillMaxWidth(0.7f)
+              .aspectRatio(1f)
+              .clip(RoundedCornerShape(Dimens.itemSpacing))
+              .pointerInput(Unit) {
+                detectDragGestures { _, dragAmount ->
+                  // Horizontal drag yaws (rotationY), vertical drag pitches (rotationX). Clamp to a
+                  // readable range so the highlight stays on the card.
+                  rotationY = (rotationY + dragAmount.x * 0.3f).coerceIn(-60f, 60f)
+                  rotationX = (rotationX - dragAmount.y * 0.3f).coerceIn(-60f, 60f)
+                }
+              }
+              .cloudy(
+                sky = sky,
+                radius = radius,
+                light = light,
+              ),
+          )
+        }
+
+        Card(
+          modifier = Modifier.fillMaxWidth(),
+          elevation = CardDefaults.cardElevation(defaultElevation = Dimens.cardElevation),
+          shape = RoundedCornerShape(Dimens.cardCornerRadius),
+          colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        ) {
+          Column(modifier = Modifier.padding(Dimens.contentPadding)) {
+            SectionLabel("Light direction (degrees)")
+            LabeledSlider(
+              label = "rotationX (pitch) — sweeps the pool up/down",
+              value = rotationX,
+              onValueChange = { rotationX = it },
+              valueRange = -60f..60f,
+            )
+            LabeledSlider(
+              label = "rotationY (yaw) — sweeps the pool left/right",
+              value = rotationY,
+              onValueChange = { rotationY = it },
+              valueRange = -60f..60f,
+            )
+
+            SectionLabel("Light")
+            LabeledSlider(
+              label = "Gain (sweep strength)",
+              value = gain,
+              onValueChange = { gain = it },
+              valueRange = 0.2f..3f,
+            )
+
+            SectionLabel("Backdrop blur")
+            IntSlider(
+              label = "radius (0 = no blurred backdrop, no highlight)",
+              value = radius,
+              onValueChange = { radius = it },
+              valueRange = 0f..25f,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+            Button(
+              modifier = Modifier.fillMaxWidth(),
+              enabled = abs(rotationX) > 0.001f || abs(rotationY) > 0.001f,
+              onClick = {
+                rotationX = 0f
+                rotationY = 0f
+              },
+            ) {
+              Text("Reset to flat")
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun SectionLabel(text: String) {
+  Spacer(modifier = Modifier.height(8.dp))
+  Text(
+    text = text,
+    fontSize = 14.sp,
+    fontWeight = FontWeight.Bold,
+    color = MaterialTheme.colorScheme.onSurface,
+  )
+}
+
+@Composable
+private fun LabeledSlider(
+  label: String,
+  value: Float,
+  onValueChange: (Float) -> Unit,
+  valueRange: ClosedFloatingPointRange<Float>,
+) {
+  Column(modifier = Modifier.fillMaxWidth()) {
+    Text(
+      text = label,
+      fontSize = 13.sp,
+      color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+    )
+    Slider(value = value, onValueChange = onValueChange, valueRange = valueRange)
+  }
+}
+
+@Composable
+private fun IntSlider(
+  label: String,
+  value: Int,
+  onValueChange: (Int) -> Unit,
+  valueRange: ClosedFloatingPointRange<Float>,
+) {
+  Column(modifier = Modifier.fillMaxWidth()) {
+    Text(
+      text = "$label — $value",
+      fontSize = 13.sp,
+      color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+    )
+    Slider(
+      value = value.toFloat(),
+      onValueChange = { onValueChange(it.roundToInt()) },
+      valueRange = valueRange,
+    )
+  }
+}

--- a/app/src/commonMain/kotlin/demo/screen/ChromaticCardScreen.kt
+++ b/app/src/commonMain/kotlin/demo/screen/ChromaticCardScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
@@ -77,10 +78,17 @@ import demo.theme.Dimens
 private enum class MaterialPreset { PureWhite, Holographic, Custom }
 
 /**
- * Focused demo for the chromatic (iridescent) overlay over a clean **white** card — the rainbow
- * sheen reacts to the light, so on a flat white surface you see only the material, not the photo.
- * Tilt the device (or drag the card) to sweep the light. Three material chips switch between the
- * no-op preset, the holographic-foil preset, and a custom overlay tuned by the sliders below.
+ * Which surface sits under the chromatic material. The base changes how the holographic sheen
+ * reads: a white card multiplies (the sheen stays faint), while opaque dark/metal cards take the
+ * screen-blend path where the thin-film foil turns dramatic and metallic.
+ */
+private enum class BaseSurface { White, Dark, Metal }
+
+/**
+ * Focused demo for the chromatic (iridescent) overlay — a holographic thin-film sheen: Newton's
+ * rings that shift hue with the light/angle. Tilt the device (or drag the card) to sweep the light.
+ * Material chips switch the overlay preset; surface chips switch the base under it, so you can see
+ * the same material read faint on white and dramatic on a dark/metal surface.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -90,6 +98,22 @@ fun ChromaticCardScreen(onBackClick: () -> Unit) {
   var customFoil by remember { mutableStateOf(true) }
   var gyroEnabled by remember { mutableStateOf(true) }
   var lensCenter by remember { mutableStateOf(Offset.Zero) }
+  // Default to a dark base so the new thin-film holographic preset reads strongly on first entry
+  // (the screen-blend path); the White chip restores the faint, minimal look.
+  var base by remember { mutableStateOf(BaseSurface.Dark) }
+
+  // The base only paints the card background — it is independent of the chromatic build above, so
+  // changing it never reallocates the lens modifier. Remember the gradient brush per base so the
+  // holder identity is stable and Brush.linearGradient is not rebuilt every recomposition.
+  val baseBrush = remember(base) {
+    when (base) {
+      BaseSurface.White -> Brush.linearGradient(listOf(Color.White, Color.White))
+      BaseSurface.Dark -> Brush.linearGradient(listOf(Color(0xFF1A1F2E), Color(0xFF2A3142)))
+      BaseSurface.Metal -> Brush.linearGradient(listOf(Color(0xFFB0B4BC), Color(0xFF40444C)))
+    }
+  }
+  // Keep the card title legible on every base: dark ink on white, light ink on the dark/metal.
+  val onBase = if (base == BaseSurface.White) Color.Black else Color.White
 
   // Drag fallback: accumulate a virtual tilt and feed it to the deterministic transform light, so
   // dragging sweeps the sheen the same way the gyro does. Deferred lambda reads keep the holder
@@ -130,20 +154,23 @@ fun ChromaticCardScreen(onBackClick: () -> Unit) {
         verticalArrangement = Arrangement.spacedBy(16.dp),
       ) {
         Text(
-          text = "A clean white card carries the iridescent material — tilt the device " +
-            "(or drag the card) and the rainbow sheen reacts to the light. Android 13+ / Skia.",
+          text = "A holographic thin-film sheen — Newton's-ring interference that shifts color " +
+            "with the light/angle. Tilt the device (or drag the card) to sweep it, and switch " +
+            "the base below to see it read faint on white or dramatic on dark/metal. " +
+            "Android 13+ / Skia.",
           fontSize = 14.sp,
           color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
           textAlign = TextAlign.Center,
         )
 
-        // A pure-white card so only the chromatic material shows (no photo underneath).
+        // A solid card so only the chromatic material shows (no photo underneath). The base brush
+        // switches white / dark / metal to demonstrate how the holographic sheen reads on each.
         Box(
           modifier = Modifier
             .fillMaxWidth()
             .height(360.dp)
             .clip(RoundedCornerShape(Dimens.itemSpacing))
-            .background(Color.White)
+            .background(baseBrush)
             .pointerInput(Unit) {
               detectDragGestures { _, dragAmount ->
                 // Drag accumulates a virtual tilt (clamped to a readable range) that drives the
@@ -169,15 +196,19 @@ fun ChromaticCardScreen(onBackClick: () -> Unit) {
         ) {
           Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Text(
-              text = "Pure White",
+              text = when (base) {
+                BaseSurface.White -> "Pure White"
+                BaseSurface.Dark -> "Dark"
+                BaseSurface.Metal -> "Metal"
+              },
               fontSize = 28.sp,
               fontWeight = FontWeight.Bold,
-              color = Color.Black.copy(alpha = 0.85f),
+              color = onBase.copy(alpha = 0.85f),
             )
             Text(
-              text = "Clean. Minimal.",
+              text = "Holographic.",
               fontSize = 16.sp,
-              color = Color.Black.copy(alpha = 0.55f),
+              color = onBase.copy(alpha = 0.55f),
             )
           }
         }
@@ -208,6 +239,28 @@ fun ChromaticCardScreen(onBackClick: () -> Unit) {
                 selected = preset == MaterialPreset.Custom,
                 onClick = { preset = MaterialPreset.Custom },
                 label = { Text("Custom") },
+              )
+            }
+
+            SectionLabel("Surface")
+            Row(
+              modifier = Modifier.fillMaxWidth(),
+              horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+              FilterChip(
+                selected = base == BaseSurface.White,
+                onClick = { base = BaseSurface.White },
+                label = { Text("White") },
+              )
+              FilterChip(
+                selected = base == BaseSurface.Dark,
+                onClick = { base = BaseSurface.Dark },
+                label = { Text("Dark") },
+              )
+              FilterChip(
+                selected = base == BaseSurface.Metal,
+                onClick = { base = BaseSurface.Metal },
+                label = { Text("Metal") },
               )
             }
 

--- a/app/src/commonMain/kotlin/demo/screen/ChromaticCardScreen.kt
+++ b/app/src/commonMain/kotlin/demo/screen/ChromaticCardScreen.kt
@@ -1,0 +1,296 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(
+  com.skydoves.cloudy.ExperimentalLiquidGlassMaterial::class,
+  com.skydoves.cloudy.ExperimentalLiquidGlassMotion::class,
+)
+
+package demo.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.skydoves.cloudy.ChromaticMode
+import com.skydoves.cloudy.ChromaticOverlay
+import com.skydoves.cloudy.LiquidGlassDefaults
+import com.skydoves.cloudy.liquidGlass
+import com.skydoves.cloudy.rememberGyroLightSource
+import com.skydoves.cloudy.rememberTransformLightSource
+import demo.component.CollapsingAppBarScaffold
+import demo.component.MaxWidthContainer
+import demo.theme.Dimens
+
+/**
+ * Which preset feeds the chromatic overlay. `Custom` is driven by the intensity slider and the
+ * Iridescent/Foil switch below; the other two are fixed library presets.
+ */
+private enum class MaterialPreset { PureWhite, Holographic, Custom }
+
+/**
+ * Focused demo for the chromatic (iridescent) overlay over a clean **white** card — the rainbow
+ * sheen reacts to the light, so on a flat white surface you see only the material, not the photo.
+ * Tilt the device (or drag the card) to sweep the light. Three material chips switch between the
+ * no-op preset, the holographic-foil preset, and a custom overlay tuned by the sliders below.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChromaticCardScreen(onBackClick: () -> Unit) {
+  var preset by remember { mutableStateOf(MaterialPreset.Holographic) }
+  var customIntensity by remember { mutableFloatStateOf(LiquidGlassDefaults.CHROMATIC_INTENSITY) }
+  var customFoil by remember { mutableStateOf(true) }
+  var gyroEnabled by remember { mutableStateOf(true) }
+  var lensCenter by remember { mutableStateOf(Offset.Zero) }
+
+  // Drag fallback: accumulate a virtual tilt and feed it to the deterministic transform light, so
+  // dragging sweeps the sheen the same way the gyro does. Deferred lambda reads keep the holder
+  // identity stable (a drag updates the draw, not this composition).
+  var rotationX by remember { mutableFloatStateOf(0f) }
+  var rotationY by remember { mutableFloatStateOf(0f) }
+  val gyroLight = rememberGyroLightSource(enabled = gyroEnabled)
+  val dragLight = rememberTransformLightSource(
+    rotationX = { rotationX },
+    rotationY = { rotationY },
+  )
+  val light = if (gyroEnabled) gyroLight else dragLight
+
+  // Rebuild the overlay only when an input actually changes — not every recomposition — so the
+  // ChromaticOverlay holder identity stays stable and the lens modifier is not reallocated.
+  val chromatic = remember(preset, customIntensity, customFoil) {
+    when (preset) {
+      MaterialPreset.PureWhite -> LiquidGlassDefaults.NoChromatic
+      MaterialPreset.Holographic -> LiquidGlassDefaults.Holographic
+      MaterialPreset.Custom -> ChromaticOverlay(
+        intensity = customIntensity,
+        mode = if (customFoil) ChromaticMode.Foil else ChromaticMode.Iridescent,
+      )
+    }
+  }
+
+  CollapsingAppBarScaffold(
+    title = "Chromatic Card",
+    onBackClick = onBackClick,
+  ) { paddingValues, _ ->
+    MaxWidthContainer(modifier = Modifier.padding(paddingValues)) {
+      Column(
+        modifier = Modifier
+          .fillMaxSize()
+          .verticalScroll(rememberScrollState())
+          .padding(Dimens.contentPadding),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+      ) {
+        Text(
+          text = "A clean white card carries the iridescent material — tilt the device " +
+            "(or drag the card) and the rainbow sheen reacts to the light. Android 13+ / Skia.",
+          fontSize = 14.sp,
+          color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+          textAlign = TextAlign.Center,
+        )
+
+        // A pure-white card so only the chromatic material shows (no photo underneath).
+        Box(
+          modifier = Modifier
+            .fillMaxWidth()
+            .height(360.dp)
+            .clip(RoundedCornerShape(Dimens.itemSpacing))
+            .background(Color.White)
+            .pointerInput(Unit) {
+              detectDragGestures { _, dragAmount ->
+                // Drag accumulates a virtual tilt (clamped to a readable range) that drives the
+                // fallback transform light; horizontal = yaw, vertical = pitch.
+                rotationY = (rotationY + dragAmount.x * 0.3f).coerceIn(-60f, 60f)
+                rotationX = (rotationX - dragAmount.y * 0.3f).coerceIn(-60f, 60f)
+              }
+            }
+            .onSizeChanged { size ->
+              lensCenter = Offset(size.width / 2f, size.height / 2f)
+            }
+            .liquidGlass(
+              lensCenter = lensCenter,
+              lensSize = Size(520f, 520f),
+              cornerRadius = 120f,
+              refraction = 0.25f,
+              curve = 0.25f,
+              edge = 0.6f,
+              light = light,
+              chromatic = chromatic,
+            ),
+          contentAlignment = Alignment.Center,
+        ) {
+          Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+              text = "Pure White",
+              fontSize = 28.sp,
+              fontWeight = FontWeight.Bold,
+              color = Color.Black.copy(alpha = 0.85f),
+            )
+            Text(
+              text = "Clean. Minimal.",
+              fontSize = 16.sp,
+              color = Color.Black.copy(alpha = 0.55f),
+            )
+          }
+        }
+
+        Card(
+          modifier = Modifier.fillMaxWidth(),
+          elevation = CardDefaults.cardElevation(defaultElevation = Dimens.cardElevation),
+          shape = RoundedCornerShape(Dimens.cardCornerRadius),
+          colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        ) {
+          Column(modifier = Modifier.padding(Dimens.contentPadding)) {
+            SectionLabel("Material")
+            Row(
+              modifier = Modifier.fillMaxWidth(),
+              horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+              FilterChip(
+                selected = preset == MaterialPreset.PureWhite,
+                onClick = { preset = MaterialPreset.PureWhite },
+                label = { Text("Pure White") },
+              )
+              FilterChip(
+                selected = preset == MaterialPreset.Holographic,
+                onClick = { preset = MaterialPreset.Holographic },
+                label = { Text("Holographic") },
+              )
+              FilterChip(
+                selected = preset == MaterialPreset.Custom,
+                onClick = { preset = MaterialPreset.Custom },
+                label = { Text("Custom") },
+              )
+            }
+
+            SectionLabel("Custom overlay")
+            LabeledSlider(
+              label = "Intensity (sheen strength)",
+              value = customIntensity,
+              onValueChange = {
+                customIntensity = it
+                preset = MaterialPreset.Custom
+              },
+              valueRange = 0f..1f,
+            )
+            Row(
+              modifier = Modifier.fillMaxWidth(),
+              verticalAlignment = Alignment.CenterVertically,
+            ) {
+              Text(
+                text = if (customFoil) "Mode: Foil (flowing bands)" else "Mode: Iridescent",
+                modifier = Modifier.weight(1f),
+                fontSize = 13.sp,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+              )
+              Switch(
+                checked = customFoil,
+                onCheckedChange = {
+                  customFoil = it
+                  preset = MaterialPreset.Custom
+                },
+              )
+            }
+
+            SectionLabel("Light")
+            Row(
+              modifier = Modifier.fillMaxWidth(),
+              verticalAlignment = Alignment.CenterVertically,
+            ) {
+              Text(
+                text = "Gyro lighting",
+                modifier = Modifier.weight(1f),
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+              )
+              Switch(checked = gyroEnabled, onCheckedChange = { gyroEnabled = it })
+            }
+            Text(
+              text = "Off: drag the card to sweep the light by hand.",
+              fontSize = 13.sp,
+              color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun SectionLabel(text: String) {
+  Spacer(modifier = Modifier.height(8.dp))
+  Text(
+    text = text,
+    fontSize = 14.sp,
+    fontWeight = FontWeight.Bold,
+    color = MaterialTheme.colorScheme.onSurface,
+  )
+}
+
+@Composable
+private fun LabeledSlider(
+  label: String,
+  value: Float,
+  onValueChange: (Float) -> Unit,
+  valueRange: ClosedFloatingPointRange<Float>,
+) {
+  Column(modifier = Modifier.fillMaxWidth()) {
+    Text(
+      text = label,
+      fontSize = 13.sp,
+      color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+    )
+    Slider(value = value, onValueChange = onValueChange, valueRange = valueRange)
+  }
+}

--- a/app/src/commonMain/kotlin/demo/screen/ChromaticCardScreen.kt
+++ b/app/src/commonMain/kotlin/demo/screen/ChromaticCardScreen.kt
@@ -25,6 +25,8 @@ import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -73,9 +75,23 @@ import demo.theme.Dimens
 
 /**
  * Which preset feeds the chromatic overlay. `Custom` is driven by the intensity slider and the
- * Iridescent/Foil switch below; the other two are fixed library presets.
+ * Iridescent/Foil switch below; the four named looks ([OilSlick]..[Pearl]) are fixed library
+ * presets on `LiquidGlassDefaults`, and [PureWhite] disables the sheen entirely.
  */
-private enum class MaterialPreset { PureWhite, Holographic, Custom }
+private enum class MaterialPreset { PureWhite, OilSlick, SoapBubble, MetallicFoil, Pearl, Custom }
+
+/**
+ * Chip label + preset, declared once as a top-level constant so the [FlowRow] iterates a stable list
+ * (no per-recomposition allocation of the chip set).
+ */
+private val MATERIAL_PRESETS: List<Pair<String, MaterialPreset>> = listOf(
+  "Pure White" to MaterialPreset.PureWhite,
+  "Oil Slick" to MaterialPreset.OilSlick,
+  "Soap Bubble" to MaterialPreset.SoapBubble,
+  "Metallic Foil" to MaterialPreset.MetallicFoil,
+  "Pearl" to MaterialPreset.Pearl,
+  "Custom" to MaterialPreset.Custom,
+)
 
 /**
  * Which surface sits under the chromatic material. The base changes how the holographic sheen
@@ -90,10 +106,10 @@ private enum class BaseSurface { White, Dark, Metal }
  * Material chips switch the overlay preset; surface chips switch the base under it, so you can see
  * the same material read faint on white and dramatic on a dark/metal surface.
  */
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun ChromaticCardScreen(onBackClick: () -> Unit) {
-  var preset by remember { mutableStateOf(MaterialPreset.Holographic) }
+  var preset by remember { mutableStateOf(MaterialPreset.OilSlick) }
   var customIntensity by remember { mutableFloatStateOf(LiquidGlassDefaults.CHROMATIC_INTENSITY) }
   var customFoil by remember { mutableStateOf(true) }
   var gyroEnabled by remember { mutableStateOf(true) }
@@ -132,7 +148,10 @@ fun ChromaticCardScreen(onBackClick: () -> Unit) {
   val chromatic = remember(preset, customIntensity, customFoil) {
     when (preset) {
       MaterialPreset.PureWhite -> LiquidGlassDefaults.NoChromatic
-      MaterialPreset.Holographic -> LiquidGlassDefaults.Holographic
+      MaterialPreset.OilSlick -> LiquidGlassDefaults.OilSlick
+      MaterialPreset.SoapBubble -> LiquidGlassDefaults.SoapBubble
+      MaterialPreset.MetallicFoil -> LiquidGlassDefaults.MetallicFoil
+      MaterialPreset.Pearl -> LiquidGlassDefaults.Pearl
       MaterialPreset.Custom -> ChromaticOverlay(
         intensity = customIntensity,
         mode = if (customFoil) ChromaticMode.Foil else ChromaticMode.Iridescent,
@@ -206,7 +225,14 @@ fun ChromaticCardScreen(onBackClick: () -> Unit) {
               color = onBase.copy(alpha = 0.85f),
             )
             Text(
-              text = "Holographic.",
+              text = when (preset) {
+                MaterialPreset.PureWhite -> "Pure white."
+                MaterialPreset.OilSlick -> "Oil slick."
+                MaterialPreset.SoapBubble -> "Soap bubble."
+                MaterialPreset.MetallicFoil -> "Metallic foil."
+                MaterialPreset.Pearl -> "Pearl."
+                MaterialPreset.Custom -> "Custom."
+              },
               fontSize = 16.sp,
               color = onBase.copy(alpha = 0.55f),
             )
@@ -221,25 +247,21 @@ fun ChromaticCardScreen(onBackClick: () -> Unit) {
         ) {
           Column(modifier = Modifier.padding(Dimens.contentPadding)) {
             SectionLabel("Material")
-            Row(
+            // Six presets overflow a single Row on phone widths, so wrap to the next line. The
+            // (label, preset) list is a stable constant, so this allocates no new lambdas per
+            // recomposition beyond the per-chip onClick (cheap, captures only the enum value).
+            FlowRow(
               modifier = Modifier.fillMaxWidth(),
               horizontalArrangement = Arrangement.spacedBy(8.dp),
+              verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-              FilterChip(
-                selected = preset == MaterialPreset.PureWhite,
-                onClick = { preset = MaterialPreset.PureWhite },
-                label = { Text("Pure White") },
-              )
-              FilterChip(
-                selected = preset == MaterialPreset.Holographic,
-                onClick = { preset = MaterialPreset.Holographic },
-                label = { Text("Holographic") },
-              )
-              FilterChip(
-                selected = preset == MaterialPreset.Custom,
-                onClick = { preset = MaterialPreset.Custom },
-                label = { Text("Custom") },
-              )
+              MATERIAL_PRESETS.forEach { (label, value) ->
+                FilterChip(
+                  selected = preset == value,
+                  onClick = { preset = value },
+                  label = { Text(label) },
+                )
+              }
             }
 
             SectionLabel("Surface")

--- a/app/src/commonMain/kotlin/demo/screen/GyroLightScreen.kt
+++ b/app/src/commonMain/kotlin/demo/screen/GyroLightScreen.kt
@@ -1,0 +1,260 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(com.skydoves.cloudy.ExperimentalLiquidGlassMotion::class)
+
+package demo.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.skydoves.cloudy.LiquidGlassDefaults
+import com.skydoves.cloudy.liquidGlassTuned
+import com.skydoves.cloudy.rememberGyroLightSource
+import com.skydoves.landscapist.ImageOptions
+import com.skydoves.landscapist.coil3.CoilImage
+import demo.component.CollapsingAppBarScaffold
+import demo.component.MaxWidthContainer
+import demo.model.MockUtil
+import demo.theme.Dimens
+
+/**
+ * Focused test screen for the gyro-driven specular highlight. A single large, centered glass lens
+ * over a poster, a "Gyro lighting" toggle, and a wide edge slider — tilt the device and the rim
+ * glint should sweep around the lens. Kept separate from the full Liquid Glass demo so the motion
+ * effect can be isolated.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GyroLightScreen(onBackClick: () -> Unit) {
+  val poster = remember { MockUtil.getMockPoster() }
+
+  var gyroEnabled by remember { mutableStateOf(true) }
+  var edge by remember { mutableFloatStateOf(0.6f) }
+  var cornerRadius by remember { mutableFloatStateOf(120f) }
+  var lensCenter by remember { mutableStateOf(Offset.Zero) }
+
+  // Glow tuning (the 4 specular knobs exposed via Modifier.liquidGlassTuned).
+  var glowIntensity by remember { mutableFloatStateOf(LiquidGlassDefaults.GLOW_INTENSITY) }
+  var glowSharpness by remember { mutableFloatStateOf(LiquidGlassDefaults.GLOW_SHARPNESS) }
+  var glowRimMix by remember { mutableFloatStateOf(0.4f) }
+  var glowWidthPx by remember { mutableFloatStateOf(12f) }
+
+  // Gyro-input tuning (fed into rememberGyroLightSource).
+  var hz by remember { mutableFloatStateOf(30f) }
+  var tiltGain by remember { mutableFloatStateOf(1.2f) }
+
+  // One sensor registration, shared with the lens below.
+  val gyroLight = rememberGyroLightSource(
+    enabled = gyroEnabled,
+    hz = hz.toInt(),
+    tiltGain = tiltGain,
+  )
+
+  CollapsingAppBarScaffold(
+    title = "Gyro Lighting",
+    onBackClick = onBackClick,
+  ) { paddingValues, _ ->
+    MaxWidthContainer(modifier = Modifier.padding(paddingValues)) {
+      Column(
+        modifier = Modifier
+          .fillMaxSize()
+          .verticalScroll(rememberScrollState())
+          .padding(Dimens.contentPadding),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+      ) {
+        Text(
+          text = "Tilt your device — the bright glint on the glass rim should sweep around. " +
+            "Turn the toggle off and the glint stays fixed (bottom-left). Android 13+ / Skia.",
+          fontSize = 14.sp,
+          color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+          textAlign = TextAlign.Center,
+        )
+
+        // A single big lens centered on the image so the rim is large and the glint is easy to see.
+        Box(
+          modifier = Modifier
+            .fillMaxWidth()
+            .height(360.dp)
+            .clip(RoundedCornerShape(Dimens.itemSpacing))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .onSizeChanged { size ->
+              lensCenter = Offset(size.width / 2f, size.height / 2f)
+            }
+            .liquidGlassTuned(
+              lensCenter = lensCenter,
+              lensSize = Size(520f, 520f),
+              cornerRadius = cornerRadius,
+              refraction = 0.25f,
+              curve = 0.25f,
+              edge = edge,
+              light = if (gyroEnabled) gyroLight else LiquidGlassDefaults.Light,
+              glowIntensity = glowIntensity,
+              glowSharpness = glowSharpness,
+              glowRimMix = glowRimMix,
+              glowWidthPx = glowWidthPx,
+            ),
+        ) {
+          CoilImage(
+            modifier = Modifier.fillMaxSize(),
+            imageModel = { poster.image },
+            imageOptions = ImageOptions(contentScale = ContentScale.Crop),
+          )
+        }
+
+        Card(
+          modifier = Modifier.fillMaxWidth(),
+          elevation = CardDefaults.cardElevation(defaultElevation = Dimens.cardElevation),
+          shape = RoundedCornerShape(Dimens.cardCornerRadius),
+          colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        ) {
+          Column(modifier = Modifier.padding(Dimens.contentPadding)) {
+            Row(
+              modifier = Modifier.fillMaxWidth(),
+              verticalAlignment = Alignment.CenterVertically,
+            ) {
+              Text(
+                text = "Gyro lighting",
+                modifier = Modifier.weight(1f),
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+              )
+              Switch(checked = gyroEnabled, onCheckedChange = { gyroEnabled = it })
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            LabeledSlider(
+              label = "Edge (highlight gate/width)",
+              value = edge,
+              onValueChange = { edge = it },
+              valueRange = 0f..1f,
+            )
+            LabeledSlider(
+              label = "Corner radius",
+              value = cornerRadius,
+              onValueChange = { cornerRadius = it },
+              valueRange = 0f..260f,
+            )
+
+            SectionLabel("Glow")
+            LabeledSlider(
+              label = "Intensity (how bright)",
+              value = glowIntensity,
+              onValueChange = { glowIntensity = it },
+              valueRange = 0f..1f,
+            )
+            LabeledSlider(
+              label = "Sharpness (how tight the glint)",
+              value = glowSharpness,
+              onValueChange = { glowSharpness = it },
+              valueRange = 1f..40f,
+            )
+            LabeledSlider(
+              label = "Body ↔ Rim (0 = moving focal pool, 1 = rim glint)",
+              value = glowRimMix,
+              onValueChange = { glowRimMix = it },
+              valueRange = 0f..1f,
+            )
+            LabeledSlider(
+              label = "Band width (px)",
+              value = glowWidthPx,
+              onValueChange = { glowWidthPx = it },
+              valueRange = 0f..40f,
+            )
+
+            SectionLabel("Gyro")
+            LabeledSlider(
+              label = "Emit rate (Hz)",
+              value = hz,
+              onValueChange = { hz = it },
+              valueRange = 15f..60f,
+            )
+            LabeledSlider(
+              label = "Tilt gain (sweep strength)",
+              value = tiltGain,
+              onValueChange = { tiltGain = it },
+              valueRange = 0.2f..3f,
+            )
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun SectionLabel(text: String) {
+  Spacer(modifier = Modifier.height(8.dp))
+  Text(
+    text = text,
+    fontSize = 14.sp,
+    fontWeight = FontWeight.Bold,
+    color = MaterialTheme.colorScheme.onSurface,
+  )
+}
+
+@Composable
+private fun LabeledSlider(
+  label: String,
+  value: Float,
+  onValueChange: (Float) -> Unit,
+  valueRange: ClosedFloatingPointRange<Float>,
+) {
+  Column(modifier = Modifier.fillMaxWidth()) {
+    Text(
+      text = label,
+      fontSize = 13.sp,
+      color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+    )
+    Slider(value = value, onValueChange = onValueChange, valueRange = valueRange)
+  }
+}

--- a/app/src/commonMain/kotlin/demo/screen/LiquidGlassDemoScreen.kt
+++ b/app/src/commonMain/kotlin/demo/screen/LiquidGlassDemoScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -57,7 +58,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.material3.Switch
 import com.skydoves.cloudy.LiquidGlassDefaults
 import com.skydoves.cloudy.cloudy
 import com.skydoves.cloudy.liquidGlass

--- a/app/src/commonMain/kotlin/demo/screen/LiquidGlassDemoScreen.kt
+++ b/app/src/commonMain/kotlin/demo/screen/LiquidGlassDemoScreen.kt
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:OptIn(com.skydoves.cloudy.ExperimentalLiquidGlassMotion::class)
+@file:OptIn(
+  com.skydoves.cloudy.ExperimentalLiquidGlassMotion::class,
+  com.skydoves.cloudy.ExperimentalLiquidGlassMaterial::class,
+)
 
 package demo.screen
 

--- a/app/src/commonMain/kotlin/demo/screen/LiquidGlassDemoScreen.kt
+++ b/app/src/commonMain/kotlin/demo/screen/LiquidGlassDemoScreen.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:OptIn(com.skydoves.cloudy.ExperimentalLiquidGlassMotion::class)
+
 package demo.screen
 
 import androidx.compose.foundation.background
@@ -55,8 +57,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.material3.Switch
+import com.skydoves.cloudy.LiquidGlassDefaults
 import com.skydoves.cloudy.cloudy
 import com.skydoves.cloudy.liquidGlass
+import com.skydoves.cloudy.rememberGyroLightSource
 import com.skydoves.landscapist.ImageOptions
 import com.skydoves.landscapist.coil3.CoilImage
 import demo.component.CollapsingAppBarScaffold
@@ -91,6 +96,10 @@ fun LiquidGlassDemoScreen(onBackClick: () -> Unit) {
 
   // Lens position
   var lensCenter by remember { mutableStateOf(Offset.Zero) }
+
+  // Gyro-driven specular: tilt the device to sweep the rim highlight (Android 13+ / Skia).
+  var gyroEnabled by remember { mutableStateOf(false) }
+  val gyroLight = rememberGyroLightSource(enabled = gyroEnabled)
 
   CollapsingAppBarScaffold(
     title = "Liquid Glass",
@@ -156,6 +165,7 @@ fun LiquidGlassDemoScreen(onBackClick: () -> Unit) {
                   edge = edge,
                   saturation = saturation,
                   dispersion = dispersion,
+                  light = if (gyroEnabled) gyroLight else LiquidGlassDefaults.Light,
                 ),
             ) {
               CoilImage(
@@ -235,6 +245,32 @@ fun LiquidGlassDemoScreen(onBackClick: () -> Unit) {
             )
 
             Spacer(modifier = Modifier.height(16.dp))
+
+            Row(
+              modifier = Modifier.fillMaxWidth(),
+              verticalAlignment = Alignment.CenterVertically,
+            ) {
+              Column(modifier = Modifier.weight(1f)) {
+                Text(
+                  text = "Gyro lighting",
+                  fontSize = 14.sp,
+                  fontWeight = FontWeight.Medium,
+                  color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                  text = "Tilt the device to sweep the highlight. Fixed when off, " +
+                    "unsupported, or Reduce Motion is on.",
+                  fontSize = 11.sp,
+                  color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                )
+              }
+              Switch(
+                checked = gyroEnabled,
+                onCheckedChange = { gyroEnabled = it },
+              )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
 
             ParameterSlider(
               label = "Shape",

--- a/app/src/commonMain/kotlin/demo/screen/MenuHomeScreen.kt
+++ b/app/src/commonMain/kotlin/demo/screen/MenuHomeScreen.kt
@@ -45,6 +45,7 @@ import demo.theme.Dimens
  * @param onGyroLightClick Callback when the Gyro Lighting test is selected.
  * @param onTransformLightClick Callback when the Transform Lighting test is selected.
  * @param onBlurLightClick Callback when the Blur Lighting test is selected.
+ * @param onChromaticCardClick Callback when the Chromatic Card demo is selected.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -59,6 +60,7 @@ fun MenuHomeScreen(
   onGyroLightClick: () -> Unit,
   onTransformLightClick: () -> Unit,
   onBlurLightClick: () -> Unit,
+  onChromaticCardClick: () -> Unit,
 ) {
   val posters = remember { MockUtil.getMockPosters() }
 
@@ -147,6 +149,14 @@ fun MenuHomeScreen(
             description = "A liquid-glass light pool rides the blurred backdrop — drag to sweep it",
             poster = posters[6],
             onClick = onBlurLightClick,
+          )
+        }
+        item {
+          MenuCard(
+            title = "Chromatic Card",
+            description = "A clean white card carries an iridescent sheen — tilt to react",
+            poster = posters[7],
+            onClick = onChromaticCardClick,
           )
         }
       }

--- a/app/src/commonMain/kotlin/demo/screen/MenuHomeScreen.kt
+++ b/app/src/commonMain/kotlin/demo/screen/MenuHomeScreen.kt
@@ -43,6 +43,7 @@ import demo.theme.Dimens
  * @param onLiquidGlassClick Callback when the Liquid Glass demo is selected.
  * @param onIssue112Click Callback when the Issue #112 BottomNav repro is selected.
  * @param onGyroLightClick Callback when the Gyro Lighting test is selected.
+ * @param onTransformLightClick Callback when the Transform Lighting test is selected.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -55,6 +56,7 @@ fun MenuHomeScreen(
   onLiquidGlassClick: () -> Unit,
   onIssue112Click: () -> Unit,
   onGyroLightClick: () -> Unit,
+  onTransformLightClick: () -> Unit,
 ) {
   val posters = remember { MockUtil.getMockPosters() }
 
@@ -127,6 +129,14 @@ fun MenuHomeScreen(
             description = "Tilt the device to sweep the specular highlight around the glass",
             poster = posters[5],
             onClick = onGyroLightClick,
+          )
+        }
+        item {
+          MenuCard(
+            title = "Transform Lighting",
+            description = "Rotate the glass card in 3D — its own tilt drives the glint (no sensor)",
+            poster = posters[5],
+            onClick = onTransformLightClick,
           )
         }
       }

--- a/app/src/commonMain/kotlin/demo/screen/MenuHomeScreen.kt
+++ b/app/src/commonMain/kotlin/demo/screen/MenuHomeScreen.kt
@@ -42,6 +42,7 @@ import demo.theme.Dimens
  * @param onProgressiveBlurClick Callback when the Progressive Blur demo is selected.
  * @param onLiquidGlassClick Callback when the Liquid Glass demo is selected.
  * @param onIssue112Click Callback when the Issue #112 BottomNav repro is selected.
+ * @param onGyroLightClick Callback when the Gyro Lighting test is selected.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -53,6 +54,7 @@ fun MenuHomeScreen(
   onProgressiveBlurClick: () -> Unit,
   onLiquidGlassClick: () -> Unit,
   onIssue112Click: () -> Unit,
+  onGyroLightClick: () -> Unit,
 ) {
   val posters = remember { MockUtil.getMockPosters() }
 
@@ -117,6 +119,14 @@ fun MenuHomeScreen(
             description = "Backdrop blur on a bottom bar over a scrolling list",
             poster = posters[6],
             onClick = onIssue112Click,
+          )
+        }
+        item {
+          MenuCard(
+            title = "Gyro Lighting",
+            description = "Tilt the device to sweep the specular highlight around the glass",
+            poster = posters[5],
+            onClick = onGyroLightClick,
           )
         }
       }

--- a/app/src/commonMain/kotlin/demo/screen/MenuHomeScreen.kt
+++ b/app/src/commonMain/kotlin/demo/screen/MenuHomeScreen.kt
@@ -44,6 +44,7 @@ import demo.theme.Dimens
  * @param onIssue112Click Callback when the Issue #112 BottomNav repro is selected.
  * @param onGyroLightClick Callback when the Gyro Lighting test is selected.
  * @param onTransformLightClick Callback when the Transform Lighting test is selected.
+ * @param onBlurLightClick Callback when the Blur Lighting test is selected.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -57,6 +58,7 @@ fun MenuHomeScreen(
   onIssue112Click: () -> Unit,
   onGyroLightClick: () -> Unit,
   onTransformLightClick: () -> Unit,
+  onBlurLightClick: () -> Unit,
 ) {
   val posters = remember { MockUtil.getMockPosters() }
 
@@ -137,6 +139,14 @@ fun MenuHomeScreen(
             description = "Rotate the glass card in 3D — its own tilt drives the glint (no sensor)",
             poster = posters[5],
             onClick = onTransformLightClick,
+          )
+        }
+        item {
+          MenuCard(
+            title = "Blur Lighting",
+            description = "A liquid-glass light pool rides the blurred backdrop — drag to sweep it",
+            poster = posters[6],
+            onClick = onBlurLightClick,
           )
         }
       }

--- a/app/src/commonMain/kotlin/demo/screen/TransformLightScreen.kt
+++ b/app/src/commonMain/kotlin/demo/screen/TransformLightScreen.kt
@@ -106,7 +106,8 @@ fun TransformLightScreen(onBackClick: () -> Unit) {
         verticalArrangement = Arrangement.spacedBy(16.dp),
       ) {
         Text(
-          text = "Tilt the glass card in 3D with the sliders — or drag it directly. The card's own " +
+          text =
+          "Tilt the glass card in 3D with the sliders — or drag it directly. The card's own " +
             "rotation drives the specular glint (no gyroscope), so it works the same on phone, " +
             "Desktop and Web.",
           fontSize = 14.sp,

--- a/app/src/commonMain/kotlin/demo/screen/TransformLightScreen.kt
+++ b/app/src/commonMain/kotlin/demo/screen/TransformLightScreen.kt
@@ -1,0 +1,230 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(com.skydoves.cloudy.ExperimentalLiquidGlassMotion::class)
+
+package demo.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.skydoves.cloudy.liquidGlassTuned
+import com.skydoves.cloudy.rememberTransformLightSource
+import com.skydoves.landscapist.ImageOptions
+import com.skydoves.landscapist.coil3.CoilImage
+import demo.component.CollapsingAppBarScaffold
+import demo.component.MaxWidthContainer
+import demo.model.MockUtil
+import demo.theme.Dimens
+import kotlin.math.abs
+
+/**
+ * Focused test screen for the transform-driven specular highlight. A single centered glass card is
+ * tilted in 3D via `Modifier.graphicsLayer { rotationX; rotationY }`, and the **same** rotations feed
+ * `rememberTransformLightSource`, so the rim glint tracks the card's own tilt — fully deterministic,
+ * no sensor, runs on Desktop and Web. Drive it with the rotationX / rotationY sliders or by dragging
+ * the card.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TransformLightScreen(onBackClick: () -> Unit) {
+  val poster = remember { MockUtil.getMockPoster() }
+
+  // The card's 3D rotation (degrees). These drive BOTH the graphicsLayer and the light source.
+  var rotationX by remember { mutableFloatStateOf(0f) }
+  var rotationY by remember { mutableFloatStateOf(0f) }
+  var gain by remember { mutableFloatStateOf(1.2f) }
+  var lensCenter by remember { mutableStateOf(Offset.Zero) }
+
+  // Same rx/ry that tilt the card also drive the light. Deferred lambda reads keep the holder
+  // identity stable: a rotation change invalidates the draw without recomposing this factory.
+  val light = rememberTransformLightSource(
+    rotationX = { rotationX },
+    rotationY = { rotationY },
+    gain = gain,
+  )
+
+  CollapsingAppBarScaffold(
+    title = "Transform Lighting",
+    onBackClick = onBackClick,
+  ) { paddingValues, _ ->
+    MaxWidthContainer(modifier = Modifier.padding(paddingValues)) {
+      Column(
+        modifier = Modifier
+          .fillMaxSize()
+          .verticalScroll(rememberScrollState())
+          .padding(Dimens.contentPadding),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+      ) {
+        Text(
+          text = "Tilt the glass card in 3D with the sliders — or drag it directly. The card's own " +
+            "rotation drives the specular glint (no gyroscope), so it works the same on phone, " +
+            "Desktop and Web.",
+          fontSize = 14.sp,
+          color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+          textAlign = TextAlign.Center,
+        )
+
+        // The card is rotated in 3D AND drag-rotatable; the same rx/ry feed the light above.
+        Box(
+          modifier = Modifier
+            .fillMaxWidth()
+            .height(360.dp)
+            .graphicsLayer {
+              this.rotationX = rotationX
+              this.rotationY = rotationY
+              cameraDistance = 12f * density
+            }
+            .pointerInput(Unit) {
+              detectDragGestures { _, dragAmount ->
+                // Horizontal drag yaws (rotationY), vertical drag pitches (rotationX). Clamp to a
+                // readable tilt range so the card never folds away from the viewer.
+                rotationY = (rotationY + dragAmount.x * 0.3f).coerceIn(-60f, 60f)
+                rotationX = (rotationX - dragAmount.y * 0.3f).coerceIn(-60f, 60f)
+              }
+            }
+            .clip(RoundedCornerShape(Dimens.itemSpacing))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .onSizeChanged { size ->
+              lensCenter = Offset(size.width / 2f, size.height / 2f)
+            }
+            .liquidGlassTuned(
+              lensCenter = lensCenter,
+              lensSize = Size(520f, 520f),
+              cornerRadius = 120f,
+              refraction = 0.25f,
+              curve = 0.25f,
+              edge = 0.6f,
+              light = light,
+            ),
+        ) {
+          CoilImage(
+            modifier = Modifier.fillMaxSize(),
+            imageModel = { poster.image },
+            imageOptions = ImageOptions(contentScale = ContentScale.Crop),
+          )
+        }
+
+        Card(
+          modifier = Modifier.fillMaxWidth(),
+          elevation = CardDefaults.cardElevation(defaultElevation = Dimens.cardElevation),
+          shape = RoundedCornerShape(Dimens.cardCornerRadius),
+          colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        ) {
+          Column(modifier = Modifier.padding(Dimens.contentPadding)) {
+            SectionLabel("Rotation (degrees)")
+            LabeledSlider(
+              label = "rotationX (pitch) — drives glint up/down",
+              value = rotationX,
+              onValueChange = { rotationX = it },
+              valueRange = -60f..60f,
+            )
+            LabeledSlider(
+              label = "rotationY (yaw) — drives glint left/right",
+              value = rotationY,
+              onValueChange = { rotationY = it },
+              valueRange = -60f..60f,
+            )
+
+            SectionLabel("Light")
+            LabeledSlider(
+              label = "Gain (sweep strength)",
+              value = gain,
+              onValueChange = { gain = it },
+              valueRange = 0.2f..3f,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+            Button(
+              modifier = Modifier.fillMaxWidth(),
+              enabled = abs(rotationX) > 0.001f || abs(rotationY) > 0.001f,
+              onClick = {
+                rotationX = 0f
+                rotationY = 0f
+              },
+            ) {
+              Text("Reset to flat")
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun SectionLabel(text: String) {
+  Spacer(modifier = Modifier.height(8.dp))
+  Text(
+    text = text,
+    fontSize = 14.sp,
+    fontWeight = FontWeight.Bold,
+    color = MaterialTheme.colorScheme.onSurface,
+  )
+}
+
+@Composable
+private fun LabeledSlider(
+  label: String,
+  value: Float,
+  onValueChange: (Float) -> Unit,
+  valueRange: ClosedFloatingPointRange<Float>,
+) {
+  Column(modifier = Modifier.fillMaxWidth()) {
+    Text(
+      text = label,
+      fontSize = 13.sp,
+      color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+    )
+    Slider(value = value, onValueChange = onValueChange, valueRange = valueRange)
+  }
+}

--- a/cloudy/api/android/cloudy.api
+++ b/cloudy/api/android/cloudy.api
@@ -1,5 +1,5 @@
 public final class com/skydoves/cloudy/CloudyBackground_androidKt {
-	public static final fun cloudy-NpZTi58 (Landroidx/compose/ui/Modifier;Lcom/skydoves/cloudy/Sky;ILcom/skydoves/cloudy/CloudyProgressive;JZZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Landroidx/compose/ui/Modifier;
+	public static final fun cloudy-mxsUjTo (Landroidx/compose/ui/Modifier;Lcom/skydoves/cloudy/Sky;ILcom/skydoves/cloudy/CloudyProgressive;JLcom/skydoves/cloudy/LiquidGlassLight;ZZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Landroidx/compose/ui/Modifier;
 	public static final fun sky (Landroidx/compose/ui/Modifier;Lcom/skydoves/cloudy/Sky;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/Modifier;
 }
 
@@ -142,6 +142,13 @@ public final class com/skydoves/cloudy/Cloudy_androidKt {
 	public static final fun cloudy (Landroidx/compose/ui/Modifier;IZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Landroidx/compose/ui/Modifier;
 }
 
+public abstract interface annotation class com/skydoves/cloudy/ExperimentalLiquidGlassMotion : java/lang/annotation/Annotation {
+}
+
+public final class com/skydoves/cloudy/GyroLightKt {
+	public static final fun rememberGyroLightSource-JHbHoSQ (ZIJFLandroidx/compose/runtime/Composer;II)Lcom/skydoves/cloudy/LiquidGlassLight;
+}
+
 public final class com/skydoves/cloudy/LiquidGlassDefaults {
 	public static final field $stable I
 	public static final field CONTRAST F
@@ -149,13 +156,42 @@ public final class com/skydoves/cloudy/LiquidGlassDefaults {
 	public static final field CURVE F
 	public static final field DISPERSION F
 	public static final field EDGE F
+	public static final field GLOW_INTENSITY F
+	public static final field GLOW_SHARPNESS F
 	public static final field INSTANCE Lcom/skydoves/cloudy/LiquidGlassDefaults;
 	public static final field MIN_ANDROID_API_FALLBACK I
 	public static final field MIN_ANDROID_API_FULL I
 	public static final field REFRACTION F
 	public static final field SATURATION F
+	public final fun getGlow ()Lcom/skydoves/cloudy/LiquidGlassGlow;
 	public final fun getLENS_SIZE-NH-jbRc ()J
+	public final fun getLIGHT_DIR-F1C5BW0 ()J
+	public final fun getLight ()Lcom/skydoves/cloudy/LiquidGlassLight;
+	public final fun getNoGlow ()Lcom/skydoves/cloudy/LiquidGlassGlow;
 	public final fun getTINT-0d7_KjU ()J
+}
+
+public final class com/skydoves/cloudy/LiquidGlassGlow {
+	public static final field $stable I
+	public static final field Companion Lcom/skydoves/cloudy/LiquidGlassGlow$Companion;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIntensity ()F
+	public final fun getSharpness ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/skydoves/cloudy/LiquidGlassGlow$Companion {
+	public final fun invoke (FF)Lcom/skydoves/cloudy/LiquidGlassGlow;
+	public static synthetic fun invoke$default (Lcom/skydoves/cloudy/LiquidGlassGlow$Companion;FFILjava/lang/Object;)Lcom/skydoves/cloudy/LiquidGlassGlow;
+}
+
+public final class com/skydoves/cloudy/LiquidGlassKt {
+	public static final fun LiquidGlassLight-k-4lQ0M (J)Lcom/skydoves/cloudy/LiquidGlassLight;
+}
+
+public final class com/skydoves/cloudy/LiquidGlassLight {
+	public static final field $stable I
 }
 
 public final class com/skydoves/cloudy/LiquidGlassShaderSource {
@@ -166,7 +202,8 @@ public final class com/skydoves/cloudy/LiquidGlassShaderSource {
 }
 
 public final class com/skydoves/cloudy/LiquidGlass_androidKt {
-	public static final fun liquidGlass-K15iNKo (Landroidx/compose/ui/Modifier;JJFFFFFFJFZLandroidx/compose/runtime/Composer;III)Landroidx/compose/ui/Modifier;
+	public static final fun liquidGlass--orAQqo (Landroidx/compose/ui/Modifier;JJFFFFFFJFLcom/skydoves/cloudy/LiquidGlassLight;Lcom/skydoves/cloudy/LiquidGlassGlow;ZLandroidx/compose/runtime/Composer;III)Landroidx/compose/ui/Modifier;
+	public static final fun liquidGlassTuned-iWwQIZ8 (Landroidx/compose/ui/Modifier;JJFFFFFFJFLcom/skydoves/cloudy/LiquidGlassLight;FFFFZLandroidx/compose/runtime/Composer;III)Landroidx/compose/ui/Modifier;
 }
 
 public final class com/skydoves/cloudy/PlatformBitmap {
@@ -196,5 +233,9 @@ public final class com/skydoves/cloudy/Sky {
 
 public final class com/skydoves/cloudy/SkyKt {
 	public static final fun rememberSky (Landroidx/compose/runtime/Composer;I)Lcom/skydoves/cloudy/Sky;
+}
+
+public final class com/skydoves/cloudy/TransformLightKt {
+	public static final fun rememberTransformLightSource-JHbHoSQ (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;JFLandroidx/compose/runtime/Composer;II)Lcom/skydoves/cloudy/LiquidGlassLight;
 }
 

--- a/cloudy/api/android/cloudy.api
+++ b/cloudy/api/android/cloudy.api
@@ -1,6 +1,10 @@
 public final class com/skydoves/cloudy/ChromaticMode : java/lang/Enum {
 	public static final field Foil Lcom/skydoves/cloudy/ChromaticMode;
 	public static final field Iridescent Lcom/skydoves/cloudy/ChromaticMode;
+	public static final field MetallicFoil Lcom/skydoves/cloudy/ChromaticMode;
+	public static final field OilSlick Lcom/skydoves/cloudy/ChromaticMode;
+	public static final field Pearl Lcom/skydoves/cloudy/ChromaticMode;
+	public static final field SoapBubble Lcom/skydoves/cloudy/ChromaticMode;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/skydoves/cloudy/ChromaticMode;
 	public static fun values ()[Lcom/skydoves/cloudy/ChromaticMode;
@@ -198,8 +202,12 @@ public final class com/skydoves/cloudy/LiquidGlassDefaults {
 	public final fun getLENS_SIZE-NH-jbRc ()J
 	public final fun getLIGHT_DIR-F1C5BW0 ()J
 	public final fun getLight ()Lcom/skydoves/cloudy/LiquidGlassLight;
+	public final fun getMetallicFoil ()Lcom/skydoves/cloudy/ChromaticOverlay;
 	public final fun getNoChromatic ()Lcom/skydoves/cloudy/ChromaticOverlay;
 	public final fun getNoGlow ()Lcom/skydoves/cloudy/LiquidGlassGlow;
+	public final fun getOilSlick ()Lcom/skydoves/cloudy/ChromaticOverlay;
+	public final fun getPearl ()Lcom/skydoves/cloudy/ChromaticOverlay;
+	public final fun getSoapBubble ()Lcom/skydoves/cloudy/ChromaticOverlay;
 	public final fun getTINT-0d7_KjU ()J
 }
 

--- a/cloudy/api/android/cloudy.api
+++ b/cloudy/api/android/cloudy.api
@@ -1,3 +1,28 @@
+public final class com/skydoves/cloudy/ChromaticMode : java/lang/Enum {
+	public static final field Foil Lcom/skydoves/cloudy/ChromaticMode;
+	public static final field Iridescent Lcom/skydoves/cloudy/ChromaticMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/skydoves/cloudy/ChromaticMode;
+	public static fun values ()[Lcom/skydoves/cloudy/ChromaticMode;
+}
+
+public final class com/skydoves/cloudy/ChromaticOverlay {
+	public static final field $stable I
+	public static final field Companion Lcom/skydoves/cloudy/ChromaticOverlay$Companion;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustomBrush ()Landroidx/compose/ui/graphics/Brush;
+	public final fun getIntensity ()F
+	public final fun getMode ()Lcom/skydoves/cloudy/ChromaticMode;
+	public final fun getSpectrum ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/skydoves/cloudy/ChromaticOverlay$Companion {
+	public final fun invoke (FLcom/skydoves/cloudy/ChromaticMode;Ljava/util/List;Landroidx/compose/ui/graphics/Brush;)Lcom/skydoves/cloudy/ChromaticOverlay;
+	public static synthetic fun invoke$default (Lcom/skydoves/cloudy/ChromaticOverlay$Companion;FLcom/skydoves/cloudy/ChromaticMode;Ljava/util/List;Landroidx/compose/ui/graphics/Brush;ILjava/lang/Object;)Lcom/skydoves/cloudy/ChromaticOverlay;
+}
+
 public final class com/skydoves/cloudy/CloudyBackground_androidKt {
 	public static final fun cloudy-mxsUjTo (Landroidx/compose/ui/Modifier;Lcom/skydoves/cloudy/Sky;ILcom/skydoves/cloudy/CloudyProgressive;JLcom/skydoves/cloudy/LiquidGlassLight;ZZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Landroidx/compose/ui/Modifier;
 	public static final fun sky (Landroidx/compose/ui/Modifier;Lcom/skydoves/cloudy/Sky;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/Modifier;
@@ -142,6 +167,9 @@ public final class com/skydoves/cloudy/Cloudy_androidKt {
 	public static final fun cloudy (Landroidx/compose/ui/Modifier;IZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Landroidx/compose/ui/Modifier;
 }
 
+public abstract interface annotation class com/skydoves/cloudy/ExperimentalLiquidGlassMaterial : java/lang/annotation/Annotation {
+}
+
 public abstract interface annotation class com/skydoves/cloudy/ExperimentalLiquidGlassMotion : java/lang/annotation/Annotation {
 }
 
@@ -151,6 +179,7 @@ public final class com/skydoves/cloudy/GyroLightKt {
 
 public final class com/skydoves/cloudy/LiquidGlassDefaults {
 	public static final field $stable I
+	public static final field CHROMATIC_INTENSITY F
 	public static final field CONTRAST F
 	public static final field CORNER_RADIUS F
 	public static final field CURVE F
@@ -164,9 +193,12 @@ public final class com/skydoves/cloudy/LiquidGlassDefaults {
 	public static final field REFRACTION F
 	public static final field SATURATION F
 	public final fun getGlow ()Lcom/skydoves/cloudy/LiquidGlassGlow;
+	public final fun getHOLOGRAPHIC_SPECTRUM ()Ljava/util/List;
+	public final fun getHolographic ()Lcom/skydoves/cloudy/ChromaticOverlay;
 	public final fun getLENS_SIZE-NH-jbRc ()J
 	public final fun getLIGHT_DIR-F1C5BW0 ()J
 	public final fun getLight ()Lcom/skydoves/cloudy/LiquidGlassLight;
+	public final fun getNoChromatic ()Lcom/skydoves/cloudy/ChromaticOverlay;
 	public final fun getNoGlow ()Lcom/skydoves/cloudy/LiquidGlassGlow;
 	public final fun getTINT-0d7_KjU ()J
 }
@@ -202,7 +234,7 @@ public final class com/skydoves/cloudy/LiquidGlassShaderSource {
 }
 
 public final class com/skydoves/cloudy/LiquidGlass_androidKt {
-	public static final fun liquidGlass--orAQqo (Landroidx/compose/ui/Modifier;JJFFFFFFJFLcom/skydoves/cloudy/LiquidGlassLight;Lcom/skydoves/cloudy/LiquidGlassGlow;ZLandroidx/compose/runtime/Composer;III)Landroidx/compose/ui/Modifier;
+	public static final fun liquidGlass-gA7x3C4 (Landroidx/compose/ui/Modifier;JJFFFFFFJFLcom/skydoves/cloudy/LiquidGlassLight;Lcom/skydoves/cloudy/LiquidGlassGlow;Lcom/skydoves/cloudy/ChromaticOverlay;ZLandroidx/compose/runtime/Composer;III)Landroidx/compose/ui/Modifier;
 	public static final fun liquidGlassTuned-iWwQIZ8 (Landroidx/compose/ui/Modifier;JJFFFFFFJFLcom/skydoves/cloudy/LiquidGlassLight;FFFFZLandroidx/compose/runtime/Composer;III)Landroidx/compose/ui/Modifier;
 }
 

--- a/cloudy/api/desktop/cloudy.api
+++ b/cloudy/api/desktop/cloudy.api
@@ -1,5 +1,5 @@
 public final class com/skydoves/cloudy/CloudyBackground_skikoKt {
-	public static final fun cloudy-NpZTi58 (Landroidx/compose/ui/Modifier;Lcom/skydoves/cloudy/Sky;ILcom/skydoves/cloudy/CloudyProgressive;JZZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Landroidx/compose/ui/Modifier;
+	public static final fun cloudy-mxsUjTo (Landroidx/compose/ui/Modifier;Lcom/skydoves/cloudy/Sky;ILcom/skydoves/cloudy/CloudyProgressive;JLcom/skydoves/cloudy/LiquidGlassLight;ZZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Landroidx/compose/ui/Modifier;
 	public static final fun sky (Landroidx/compose/ui/Modifier;Lcom/skydoves/cloudy/Sky;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/Modifier;
 }
 
@@ -142,6 +142,13 @@ public final class com/skydoves/cloudy/Cloudy_skikoKt {
 	public static final fun cloudy (Landroidx/compose/ui/Modifier;IZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Landroidx/compose/ui/Modifier;
 }
 
+public abstract interface annotation class com/skydoves/cloudy/ExperimentalLiquidGlassMotion : java/lang/annotation/Annotation {
+}
+
+public final class com/skydoves/cloudy/GyroLightKt {
+	public static final fun rememberGyroLightSource-JHbHoSQ (ZIJFLandroidx/compose/runtime/Composer;II)Lcom/skydoves/cloudy/LiquidGlassLight;
+}
+
 public final class com/skydoves/cloudy/LiquidGlassDefaults {
 	public static final field $stable I
 	public static final field CONTRAST F
@@ -149,13 +156,42 @@ public final class com/skydoves/cloudy/LiquidGlassDefaults {
 	public static final field CURVE F
 	public static final field DISPERSION F
 	public static final field EDGE F
+	public static final field GLOW_INTENSITY F
+	public static final field GLOW_SHARPNESS F
 	public static final field INSTANCE Lcom/skydoves/cloudy/LiquidGlassDefaults;
 	public static final field MIN_ANDROID_API_FALLBACK I
 	public static final field MIN_ANDROID_API_FULL I
 	public static final field REFRACTION F
 	public static final field SATURATION F
+	public final fun getGlow ()Lcom/skydoves/cloudy/LiquidGlassGlow;
 	public final fun getLENS_SIZE-NH-jbRc ()J
+	public final fun getLIGHT_DIR-F1C5BW0 ()J
+	public final fun getLight ()Lcom/skydoves/cloudy/LiquidGlassLight;
+	public final fun getNoGlow ()Lcom/skydoves/cloudy/LiquidGlassGlow;
 	public final fun getTINT-0d7_KjU ()J
+}
+
+public final class com/skydoves/cloudy/LiquidGlassGlow {
+	public static final field $stable I
+	public static final field Companion Lcom/skydoves/cloudy/LiquidGlassGlow$Companion;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIntensity ()F
+	public final fun getSharpness ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/skydoves/cloudy/LiquidGlassGlow$Companion {
+	public final fun invoke (FF)Lcom/skydoves/cloudy/LiquidGlassGlow;
+	public static synthetic fun invoke$default (Lcom/skydoves/cloudy/LiquidGlassGlow$Companion;FFILjava/lang/Object;)Lcom/skydoves/cloudy/LiquidGlassGlow;
+}
+
+public final class com/skydoves/cloudy/LiquidGlassKt {
+	public static final fun LiquidGlassLight-k-4lQ0M (J)Lcom/skydoves/cloudy/LiquidGlassLight;
+}
+
+public final class com/skydoves/cloudy/LiquidGlassLight {
+	public static final field $stable I
 }
 
 public final class com/skydoves/cloudy/LiquidGlassShaderSource {
@@ -166,7 +202,8 @@ public final class com/skydoves/cloudy/LiquidGlassShaderSource {
 }
 
 public final class com/skydoves/cloudy/LiquidGlass_skikoKt {
-	public static final fun liquidGlass-K15iNKo (Landroidx/compose/ui/Modifier;JJFFFFFFJFZLandroidx/compose/runtime/Composer;III)Landroidx/compose/ui/Modifier;
+	public static final fun liquidGlass--orAQqo (Landroidx/compose/ui/Modifier;JJFFFFFFJFLcom/skydoves/cloudy/LiquidGlassLight;Lcom/skydoves/cloudy/LiquidGlassGlow;ZLandroidx/compose/runtime/Composer;III)Landroidx/compose/ui/Modifier;
+	public static final fun liquidGlassTuned-iWwQIZ8 (Landroidx/compose/ui/Modifier;JJFFFFFFJFLcom/skydoves/cloudy/LiquidGlassLight;FFFFZLandroidx/compose/runtime/Composer;III)Landroidx/compose/ui/Modifier;
 }
 
 public final class com/skydoves/cloudy/PlatformBitmap {
@@ -198,5 +235,9 @@ public final class com/skydoves/cloudy/Sky {
 
 public final class com/skydoves/cloudy/SkyKt {
 	public static final fun rememberSky (Landroidx/compose/runtime/Composer;I)Lcom/skydoves/cloudy/Sky;
+}
+
+public final class com/skydoves/cloudy/TransformLightKt {
+	public static final fun rememberTransformLightSource-JHbHoSQ (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;JFLandroidx/compose/runtime/Composer;II)Lcom/skydoves/cloudy/LiquidGlassLight;
 }
 

--- a/cloudy/api/desktop/cloudy.api
+++ b/cloudy/api/desktop/cloudy.api
@@ -1,3 +1,28 @@
+public final class com/skydoves/cloudy/ChromaticMode : java/lang/Enum {
+	public static final field Foil Lcom/skydoves/cloudy/ChromaticMode;
+	public static final field Iridescent Lcom/skydoves/cloudy/ChromaticMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/skydoves/cloudy/ChromaticMode;
+	public static fun values ()[Lcom/skydoves/cloudy/ChromaticMode;
+}
+
+public final class com/skydoves/cloudy/ChromaticOverlay {
+	public static final field $stable I
+	public static final field Companion Lcom/skydoves/cloudy/ChromaticOverlay$Companion;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustomBrush ()Landroidx/compose/ui/graphics/Brush;
+	public final fun getIntensity ()F
+	public final fun getMode ()Lcom/skydoves/cloudy/ChromaticMode;
+	public final fun getSpectrum ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/skydoves/cloudy/ChromaticOverlay$Companion {
+	public final fun invoke (FLcom/skydoves/cloudy/ChromaticMode;Ljava/util/List;Landroidx/compose/ui/graphics/Brush;)Lcom/skydoves/cloudy/ChromaticOverlay;
+	public static synthetic fun invoke$default (Lcom/skydoves/cloudy/ChromaticOverlay$Companion;FLcom/skydoves/cloudy/ChromaticMode;Ljava/util/List;Landroidx/compose/ui/graphics/Brush;ILjava/lang/Object;)Lcom/skydoves/cloudy/ChromaticOverlay;
+}
+
 public final class com/skydoves/cloudy/CloudyBackground_skikoKt {
 	public static final fun cloudy-mxsUjTo (Landroidx/compose/ui/Modifier;Lcom/skydoves/cloudy/Sky;ILcom/skydoves/cloudy/CloudyProgressive;JLcom/skydoves/cloudy/LiquidGlassLight;ZZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Landroidx/compose/ui/Modifier;
 	public static final fun sky (Landroidx/compose/ui/Modifier;Lcom/skydoves/cloudy/Sky;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/Modifier;
@@ -142,6 +167,9 @@ public final class com/skydoves/cloudy/Cloudy_skikoKt {
 	public static final fun cloudy (Landroidx/compose/ui/Modifier;IZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Landroidx/compose/ui/Modifier;
 }
 
+public abstract interface annotation class com/skydoves/cloudy/ExperimentalLiquidGlassMaterial : java/lang/annotation/Annotation {
+}
+
 public abstract interface annotation class com/skydoves/cloudy/ExperimentalLiquidGlassMotion : java/lang/annotation/Annotation {
 }
 
@@ -151,6 +179,7 @@ public final class com/skydoves/cloudy/GyroLightKt {
 
 public final class com/skydoves/cloudy/LiquidGlassDefaults {
 	public static final field $stable I
+	public static final field CHROMATIC_INTENSITY F
 	public static final field CONTRAST F
 	public static final field CORNER_RADIUS F
 	public static final field CURVE F
@@ -164,9 +193,12 @@ public final class com/skydoves/cloudy/LiquidGlassDefaults {
 	public static final field REFRACTION F
 	public static final field SATURATION F
 	public final fun getGlow ()Lcom/skydoves/cloudy/LiquidGlassGlow;
+	public final fun getHOLOGRAPHIC_SPECTRUM ()Ljava/util/List;
+	public final fun getHolographic ()Lcom/skydoves/cloudy/ChromaticOverlay;
 	public final fun getLENS_SIZE-NH-jbRc ()J
 	public final fun getLIGHT_DIR-F1C5BW0 ()J
 	public final fun getLight ()Lcom/skydoves/cloudy/LiquidGlassLight;
+	public final fun getNoChromatic ()Lcom/skydoves/cloudy/ChromaticOverlay;
 	public final fun getNoGlow ()Lcom/skydoves/cloudy/LiquidGlassGlow;
 	public final fun getTINT-0d7_KjU ()J
 }
@@ -202,7 +234,7 @@ public final class com/skydoves/cloudy/LiquidGlassShaderSource {
 }
 
 public final class com/skydoves/cloudy/LiquidGlass_skikoKt {
-	public static final fun liquidGlass--orAQqo (Landroidx/compose/ui/Modifier;JJFFFFFFJFLcom/skydoves/cloudy/LiquidGlassLight;Lcom/skydoves/cloudy/LiquidGlassGlow;ZLandroidx/compose/runtime/Composer;III)Landroidx/compose/ui/Modifier;
+	public static final fun liquidGlass-gA7x3C4 (Landroidx/compose/ui/Modifier;JJFFFFFFJFLcom/skydoves/cloudy/LiquidGlassLight;Lcom/skydoves/cloudy/LiquidGlassGlow;Lcom/skydoves/cloudy/ChromaticOverlay;ZLandroidx/compose/runtime/Composer;III)Landroidx/compose/ui/Modifier;
 	public static final fun liquidGlassTuned-iWwQIZ8 (Landroidx/compose/ui/Modifier;JJFFFFFFJFLcom/skydoves/cloudy/LiquidGlassLight;FFFFZLandroidx/compose/runtime/Composer;III)Landroidx/compose/ui/Modifier;
 }
 

--- a/cloudy/api/desktop/cloudy.api
+++ b/cloudy/api/desktop/cloudy.api
@@ -1,6 +1,10 @@
 public final class com/skydoves/cloudy/ChromaticMode : java/lang/Enum {
 	public static final field Foil Lcom/skydoves/cloudy/ChromaticMode;
 	public static final field Iridescent Lcom/skydoves/cloudy/ChromaticMode;
+	public static final field MetallicFoil Lcom/skydoves/cloudy/ChromaticMode;
+	public static final field OilSlick Lcom/skydoves/cloudy/ChromaticMode;
+	public static final field Pearl Lcom/skydoves/cloudy/ChromaticMode;
+	public static final field SoapBubble Lcom/skydoves/cloudy/ChromaticMode;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/skydoves/cloudy/ChromaticMode;
 	public static fun values ()[Lcom/skydoves/cloudy/ChromaticMode;
@@ -198,8 +202,12 @@ public final class com/skydoves/cloudy/LiquidGlassDefaults {
 	public final fun getLENS_SIZE-NH-jbRc ()J
 	public final fun getLIGHT_DIR-F1C5BW0 ()J
 	public final fun getLight ()Lcom/skydoves/cloudy/LiquidGlassLight;
+	public final fun getMetallicFoil ()Lcom/skydoves/cloudy/ChromaticOverlay;
 	public final fun getNoChromatic ()Lcom/skydoves/cloudy/ChromaticOverlay;
 	public final fun getNoGlow ()Lcom/skydoves/cloudy/LiquidGlassGlow;
+	public final fun getOilSlick ()Lcom/skydoves/cloudy/ChromaticOverlay;
+	public final fun getPearl ()Lcom/skydoves/cloudy/ChromaticOverlay;
+	public final fun getSoapBubble ()Lcom/skydoves/cloudy/ChromaticOverlay;
 	public final fun getTINT-0d7_KjU ()J
 }
 

--- a/cloudy/build.gradle.kts
+++ b/cloudy/build.gradle.kts
@@ -165,6 +165,7 @@ kotlin {
       implementation(libs.androidx.core.ktx)
       implementation(libs.androidx.compose.ui)
       implementation(libs.androidx.compose.runtime)
+      implementation(libs.androidx.lifecycle.runtime.compose)
       implementation(libs.kotlinx.coroutines.android)
     }
 

--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
@@ -29,11 +29,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TileMode
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.asComposeRenderEffect
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
@@ -80,6 +83,7 @@ public actual fun Modifier.cloudy(
   @IntRange(from = 0) radius: Int,
   progressive: CloudyProgressive,
   tint: Color,
+  light: LiquidGlassLight?,
   enabled: Boolean,
   cpuBlurEnabled: Boolean,
   onStateChanged: (CloudyState) -> Unit,
@@ -107,6 +111,7 @@ public actual fun Modifier.cloudy(
       radius = radius,
       progressive = progressive,
       tint = tint,
+      light = light,
       cpuBlurEnabled = cpuBlurEnabled,
       onStateChanged = onStateChanged,
     ),
@@ -202,6 +207,7 @@ private data class CloudyBackgroundModifierElement(
   val radius: Int,
   val progressive: CloudyProgressive,
   val tint: Color,
+  val light: LiquidGlassLight?,
   val cpuBlurEnabled: Boolean,
   val onStateChanged: (CloudyState) -> Unit,
 ) : ModifierNodeElement<CloudyBackgroundModifierNode>() {
@@ -212,6 +218,7 @@ private data class CloudyBackgroundModifierElement(
     properties["radius"] = radius
     properties["progressive"] = progressive
     properties["tint"] = tint
+    properties["light"] = light
     properties["cpuBlurEnabled"] = cpuBlurEnabled
   }
 
@@ -220,12 +227,13 @@ private data class CloudyBackgroundModifierElement(
     radius = radius,
     progressive = progressive,
     tint = tint,
+    light = light,
     cpuBlurEnabled = cpuBlurEnabled,
     onStateChanged = onStateChanged,
   )
 
   override fun update(node: CloudyBackgroundModifierNode) {
-    node.update(sky, radius, progressive, tint, cpuBlurEnabled, onStateChanged)
+    node.update(sky, radius, progressive, tint, light, cpuBlurEnabled, onStateChanged)
   }
 }
 
@@ -234,6 +242,7 @@ private class CloudyBackgroundModifierNode(
   private var radius: Int,
   private var progressive: CloudyProgressive,
   private var tint: Color,
+  private var light: LiquidGlassLight?,
   private var cpuBlurEnabled: Boolean,
   private var onStateChanged: (CloudyState) -> Unit,
 ) : Modifier.Node(),
@@ -244,6 +253,13 @@ private class CloudyBackgroundModifierNode(
 
   private var positionInRoot: Offset = Offset.Zero
   private var size: IntSize = IntSize.Zero
+
+  // Specular highlight brush cache. The light direction is read at gyro rate (~30Hz), so the
+  // pool center moves most frames; rebuild the Brush only when center/radius actually change to
+  // avoid per-frame Brush allocation on the draw hot path. (The colorStops array is already a const.)
+  private var cachedBrush: Brush? = null
+  private var cachedCenter: Offset = Offset.Unspecified
+  private var cachedRadius: Float = -1f
 
   // Legacy blur state (API < 31)
   private var blurredBitmap: PlatformBitmap? = null
@@ -266,6 +282,7 @@ private class CloudyBackgroundModifierNode(
     radius: Int,
     progressive: CloudyProgressive,
     tint: Color,
+    light: LiquidGlassLight?,
     cpuBlurEnabled: Boolean,
     onStateChanged: (CloudyState) -> Unit,
   ) {
@@ -273,12 +290,14 @@ private class CloudyBackgroundModifierNode(
       this.radius != radius ||
       this.progressive != progressive ||
       this.tint != tint ||
+      this.light != light ||
       this.cpuBlurEnabled != cpuBlurEnabled
 
     this.sky = sky
     this.radius = radius
     this.progressive = progressive
     this.tint = tint
+    this.light = light
     this.cpuBlurEnabled = cpuBlurEnabled
     this.onStateChanged = onStateChanged
 
@@ -452,12 +471,51 @@ private class CloudyBackgroundModifierNode(
         if (snapshot.tintColor != Color.Transparent) {
           drawRect(color = snapshot.tintColor, blendMode = BlendMode.SrcOver)
         }
+
+        // Experimental specular highlight over the blurred backdrop (no-op when light == null)
+        if (light != null) drawHighlight()
       }
 
       onStateChanged(CloudyState.Success.Applied)
     } finally {
       context.releaseGraphicsLayer(blurLayer)
     }
+  }
+
+  /**
+   * Draws the moving specular highlight over the already-blurred backdrop. Called only from the
+   * blurred paths, inside their existing [clipRect]. Composited with the default `SrcOver` blend:
+   * warm-white over a bright backdrop self-attenuates just like the shader's Screen blend, and is
+   * identical to Screen at the dark end — `BlendMode.Screen` has no Compose equivalent and `Plus`
+   * is unreliable on vendor HWUI, so `SrcOver` (already used for tint) is the HWUI-safe choice.
+   *
+   * Reads the Node's [light] (must be non-null here) and [size] fields and reuses [cachedBrush]
+   * unless the pool center/radius moved this frame.
+   */
+  private fun DrawScope.drawHighlight() {
+    val light = light ?: return
+    // Node's measured IntSize field — qualified so it isn't shadowed by DrawScope.size (canvas Size).
+    val lensSize = this@CloudyBackgroundModifierNode.size
+    if (minOf(lensSize.width, lensSize.height) <= 0) return
+    // Pure geometry lives in commonMain so the shipped path is the unit-tested path.
+    val center = highlightPoolCenter(lensSize, light.direction.value, HIGHLIGHT_FOCAL_K)
+    val radius = highlightPoolRadius(lensSize, HIGHLIGHT_POOL_FRAC)
+    val brush = if (center != cachedCenter || radius != cachedRadius) {
+      Brush.radialGradient(
+        colorStops = HIGHLIGHT_STOPS,
+        center = center,
+        radius = radius,
+        tileMode = TileMode.Clamp,
+      ).also {
+        cachedBrush = it
+        cachedCenter = center
+        cachedRadius = radius
+      }
+    } else {
+      cachedBrush!!
+    }
+    // default SrcOver blend (faithful to the shader's Screen at this alpha range, HWUI-safe)
+    drawRect(brush = brush)
   }
 
   private var hasLoggedProgressiveWarning = false
@@ -490,6 +548,9 @@ private class CloudyBackgroundModifierNode(
         if (snapshot.tintColor != Color.Transparent) {
           drawRect(color = snapshot.tintColor, blendMode = BlendMode.SrcOver)
         }
+
+        // Experimental specular highlight over the blurred backdrop (no-op when light == null)
+        if (light != null) drawHighlight()
       }
       onStateChanged(CloudyState.Success.Captured(cached))
       return
@@ -505,6 +566,9 @@ private class CloudyBackgroundModifierNode(
         if (snapshot.tintColor != Color.Transparent) {
           drawRect(color = snapshot.tintColor, blendMode = BlendMode.SrcOver)
         }
+
+        // Experimental specular highlight over the blurred backdrop (no-op when light == null)
+        if (light != null) drawHighlight()
       }
     }
     // No cache: draw nothing (transparent) - blur will appear when ready

--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/GyroLight.android.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/GyroLight.android.kt
@@ -1,0 +1,263 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.cloudy
+
+import android.content.Context
+import android.database.ContentObserver
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.os.Build
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.Looper
+import android.provider.Settings
+import android.view.Surface
+import android.view.WindowManager
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+
+/**
+ * Android tilt source. Streams a smoothed, throttled screen-space light direction from the
+ * device's motion sensors. Hard no-op below API 33 (the Liquid Glass fallback has no shader),
+ * when disabled, in inspection/preview, when Reduce Motion is on, or when no sensor exists.
+ */
+@Composable
+internal actual fun rememberTiltSource(
+  enabled: Boolean,
+  hz: Int,
+  base: Offset,
+  tiltGain: Float,
+  out: MutableState<Offset>,
+) {
+  val context = LocalContext.current
+  val lifecycleOwner = LocalLifecycleOwner.current
+
+  // Hard no-op gate: below API 33 there is no RuntimeShader to consume lightDir, and preview must
+  // stay static. Never touch SensorManager in these cases.
+  if (!enabled ||
+    Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+    LocalInspectionMode.current
+  ) {
+    SideEffect { out.value = base }
+    return
+  }
+
+  // Live Reduce Motion state, backed by a ContentObserver on ANIMATOR_DURATION_SCALE.
+  val reduceMotion by rememberReduceMotionState(context)
+
+  // The provider owns the background HandlerThread. It is remembered (NOT created inside the
+  // lifecycle effect) and keyed only on values that change its math, so the thread is created
+  // once and torn down exactly once — register/unregister cycling does not leak it.
+  val provider = remember(base, tiltGain, hz) {
+    TiltLightProvider(
+      sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager,
+      windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager,
+      base = base,
+      tiltGain = tiltGain,
+      hz = hz,
+      mainHandler = Handler(Looper.getMainLooper()),
+      onLight = { out.value = it },
+    )
+  }
+
+  // Registration lifetime: start while STARTED (unless reduce-motion), stop on ON_STOP/dispose.
+  DisposableEffect(provider, lifecycleOwner, reduceMotion) {
+    val observer = LifecycleEventObserver { _, event ->
+      when (event) {
+        Lifecycle.Event.ON_START ->
+          if (!reduceMotion) provider.start() else { provider.stop(); out.value = base }
+        Lifecycle.Event.ON_STOP -> provider.stop()
+        else -> Unit
+      }
+    }
+    // If we are already STARTED when this effect (re)runs, reflect the current state immediately.
+    if (lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+      if (!reduceMotion) provider.start() else { provider.stop(); out.value = base }
+    }
+    lifecycleOwner.lifecycle.addObserver(observer)
+    onDispose {
+      lifecycleOwner.lifecycle.removeObserver(observer)
+      provider.stop()
+      out.value = base
+    }
+  }
+
+  // Provider lifetime: tear down the HandlerThread when the provider leaves composition or is
+  // re-keyed. This is the line the original sketch omitted; without quitSafely() the thread leaks.
+  DisposableEffect(provider) {
+    onDispose { provider.shutdown() }
+  }
+}
+
+/** Live [Reduce Motion][isReduceMotionEnabled] state, observed via a [ContentObserver]. */
+@Composable
+private fun rememberReduceMotionState(context: Context): MutableState<Boolean> {
+  val state = remember { mutableStateOf(isReduceMotionEnabled(context)) }
+  DisposableEffect(context) {
+    val resolver = context.contentResolver
+    val uri = Settings.Global.getUriFor(Settings.Global.ANIMATOR_DURATION_SCALE)
+    val observer = object : ContentObserver(Handler(Looper.getMainLooper())) {
+      override fun onChange(selfChange: Boolean) {
+        state.value = isReduceMotionEnabled(context)
+      }
+    }
+    resolver.registerContentObserver(uri, false, observer)
+    onDispose { resolver.unregisterContentObserver(observer) }
+  }
+  return state
+}
+
+/**
+ * Reduce Motion proxy: [Settings.Global.ANIMATOR_DURATION_SCALE] == 0 means the user disabled
+ * animations. There is no public reduce-motion boolean below API 33, so this is the correct
+ * cross-version signal (the setting exists since API 17, safe at minSdk 23).
+ */
+private fun isReduceMotionEnabled(context: Context): Boolean =
+  Settings.Global.getFloat(
+    context.contentResolver,
+    Settings.Global.ANIMATOR_DURATION_SCALE,
+    1f,
+  ) == 0f
+
+/**
+ * Reads one motion sensor and emits a smoothed, throttled, gated screen-space light direction.
+ *
+ * Threading contract:
+ * - [start]/[stop]/[shutdown] are called on the MAIN thread (lifecycle + content-observer).
+ * - [onSensorChanged] runs on a dedicated background [HandlerThread]; the math fields below are
+ *   confined to it. The only cross-thread hop is the [mainHandler] post of the emitted value.
+ */
+private class TiltLightProvider(
+  private val sensorManager: SensorManager,
+  private val windowManager: WindowManager,
+  private val base: Offset,
+  private val tiltGain: Float,
+  hz: Int,
+  private val mainHandler: Handler,
+  private val onLight: (Offset) -> Unit,
+) : SensorEventListener {
+
+  private val periodUs = 1_000_000 / hz // sensor rate hint (not honored exactly; we re-throttle)
+  private val minEmitNs = 1_000_000_000L / hz
+  private val alpha = 0.2f
+  private val epsilon = 0.003f // ~0.17° on a unit vector, below sensor noise floor
+
+  // Pick ONE sensor for the whole lifetime so there is no scale jump from runtime switching.
+  private val sensor: Sensor? =
+    sensorManager.getDefaultSensor(Sensor.TYPE_GRAVITY)
+      ?: sensorManager.getDefaultSensor(Sensor.TYPE_GAME_ROTATION_VECTOR)
+      ?: sensorManager.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR)
+      ?: sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
+
+  private val thread = HandlerThread("cloudy-tilt").apply { start() }
+  private val sensorHandler = Handler(thread.looper)
+
+  // --- confined to main thread ---
+  private var started = false
+
+  // --- confined to the sensor HandlerThread (touched only in onSensorChanged) ---
+  private var smooth = base
+  private var lastEmitNs = 0L
+  private var lastSent = base
+  private val rotM = FloatArray(9)
+  private val gFilt = FloatArray(3)
+  // -------------------------------------------------------------------------------
+
+  @Volatile
+  private var alive = true
+
+  fun start() {
+    val s = sensor ?: return // no sensor → stay frozen at base
+    if (started) return
+    started = true
+    sensorManager.registerListener(this, s, periodUs, sensorHandler)
+  }
+
+  fun stop() {
+    if (!started) return
+    started = false
+    sensorManager.unregisterListener(this)
+  }
+
+  fun shutdown() {
+    stop()
+    alive = false
+    thread.quitSafely()
+  }
+
+  override fun onSensorChanged(event: SensorEvent) {
+    if (!alive) return
+    val raw: Offset = when (event.sensor.type) {
+      Sensor.TYPE_GRAVITY -> {
+        val (gx, gy) = remapGravityToScreen(event.values[0], event.values[1])
+        gravityToLight(gx, gy, base, tiltGain)
+      }
+      Sensor.TYPE_GAME_ROTATION_VECTOR,
+      Sensor.TYPE_ROTATION_VECTOR,
+      -> {
+        // Gravity direction ≈ negated 3rd row of the world→device rotation matrix.
+        SensorManager.getRotationMatrixFromVector(rotM, event.values)
+        val (gx, gy) = remapGravityToScreen(-rotM[2] * 9.81f, -rotM[5] * 9.81f)
+        gravityToLight(gx, gy, base, tiltGain)
+      }
+      Sensor.TYPE_ACCELEROMETER -> {
+        // Low-pass to extract gravity from raw acceleration.
+        gFilt[0] += alpha * (event.values[0] - gFilt[0])
+        gFilt[1] += alpha * (event.values[1] - gFilt[1])
+        val (gx, gy) = remapGravityToScreen(gFilt[0], gFilt[1])
+        gravityToLight(gx, gy, base, tiltGain)
+      }
+      else -> return
+    }
+
+    smooth = emaStep(smooth, raw, alpha)
+    val now = System.nanoTime()
+    if (now - lastEmitNs < minEmitNs) return // 30 Hz emit throttle
+    val outVal = normalizeOr(smooth, base)
+    if ((outVal - lastSent).getDistance() < epsilon) return // ε-gate
+    smooth = outVal // snap EMA onto the emitted unit vector so a still phone truly stops emitting
+    lastEmitNs = now
+    lastSent = outVal
+    mainHandler.post { if (alive) onLight(outVal) } // Compose snapshot write on the main thread
+  }
+
+  override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
+
+  /** Rotates in-plane gravity (device axes) into screen-space, accounting for display rotation. */
+  private fun remapGravityToScreen(gx: Float, gy: Float): Pair<Float, Float> {
+    @Suppress("DEPRECATION") // context.display is API 30+; defaultDisplay works at minSdk 23
+    return when (windowManager.defaultDisplay.rotation) {
+      Surface.ROTATION_90 -> -gy to gx
+      Surface.ROTATION_180 -> -gx to -gy
+      Surface.ROTATION_270 -> gy to -gx
+      else -> gx to gy // ROTATION_0
+    }
+  }
+}

--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/GyroLight.android.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/GyroLight.android.kt
@@ -92,14 +92,24 @@ internal actual fun rememberTiltSource(
     val observer = LifecycleEventObserver { _, event ->
       when (event) {
         Lifecycle.Event.ON_START ->
-          if (!reduceMotion) provider.start() else { provider.stop(); out.value = base }
+          if (!reduceMotion) {
+            provider.start()
+          } else {
+            provider.stop()
+            out.value = base
+          }
         Lifecycle.Event.ON_STOP -> provider.stop()
         else -> Unit
       }
     }
     // If we are already STARTED when this effect (re)runs, reflect the current state immediately.
     if (lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
-      if (!reduceMotion) provider.start() else { provider.stop(); out.value = base }
+      if (!reduceMotion) {
+        provider.start()
+      } else {
+        provider.stop()
+        out.value = base
+      }
     }
     lifecycleOwner.lifecycle.addObserver(observer)
     onDispose {
@@ -139,12 +149,11 @@ private fun rememberReduceMotionState(context: Context): MutableState<Boolean> {
  * animations. There is no public reduce-motion boolean below API 33, so this is the correct
  * cross-version signal (the setting exists since API 17, safe at minSdk 23).
  */
-private fun isReduceMotionEnabled(context: Context): Boolean =
-  Settings.Global.getFloat(
-    context.contentResolver,
-    Settings.Global.ANIMATOR_DURATION_SCALE,
-    1f,
-  ) == 0f
+private fun isReduceMotionEnabled(context: Context): Boolean = Settings.Global.getFloat(
+  context.contentResolver,
+  Settings.Global.ANIMATOR_DURATION_SCALE,
+  1f,
+) == 0f
 
 /**
  * Reads one motion sensor and emits a smoothed, throttled, gated screen-space light direction.
@@ -193,6 +202,14 @@ private class TiltLightProvider(
   @Volatile
   private var alive = true
 
+  // Bumped on every stop(). onSensorChanged captures the current value when it posts to the main
+  // thread; the posted block drops itself if the token changed in the meantime. This kills the
+  // race where unregisterListener() stops NEW callbacks but a post already queued on mainHandler
+  // still runs after stop() and overwrites the freeze-to-base with a stale tilt value. @Volatile:
+  // written on the main thread (stop), read on the sensor HandlerThread (capture) and main (post).
+  @Volatile
+  private var generation = 0
+
   fun start() {
     val s = sensor ?: return // no sensor → stay frozen at base
     if (started) return
@@ -203,6 +220,7 @@ private class TiltLightProvider(
   fun stop() {
     if (!started) return
     started = false
+    generation++ // invalidate any in-flight mainHandler posts (stale emissions)
     sensorManager.unregisterListener(this)
   }
 
@@ -245,7 +263,8 @@ private class TiltLightProvider(
     smooth = outVal // snap EMA onto the emitted unit vector so a still phone truly stops emitting
     lastEmitNs = now
     lastSent = outVal
-    mainHandler.post { if (alive) onLight(outVal) } // Compose snapshot write on the main thread
+    val g = generation // capture now; the post drops itself if stop() bumped it before it ran
+    mainHandler.post { if (alive && g == generation) onLight(outVal) } // Compose write on main
   }
 
   override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit

--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/LiquidGlass.android.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/LiquidGlass.android.kt
@@ -274,7 +274,16 @@ private fun Modifier.liquidGlassApi33(
       // Only intensity + mode come from the public ChromaticOverlay; the remaining 4 are held at the
       // shader's tuned defaults (bands/cycles/phase/modulate) as constants here.
       shader.setFloatUniform("chromaticIntensity", chromatic.intensity)
-      shader.setFloatUniform("chromaticMode", if (chromatic.mode == ChromaticMode.Foil) 1f else 0f)
+      // Exhaustive when (no else) so adding a ChromaticMode without a float breaks the build here.
+      val chromaticModeF = when (chromatic.mode) {
+        ChromaticMode.Iridescent -> 0f
+        ChromaticMode.Foil -> 1f
+        ChromaticMode.OilSlick -> 2f
+        ChromaticMode.SoapBubble -> 3f
+        ChromaticMode.MetallicFoil -> 4f
+        ChromaticMode.Pearl -> 5f
+      }
+      shader.setFloatUniform("chromaticMode", chromaticModeF)
       shader.setFloatUniform("chromaticBands", 3f)
       shader.setFloatUniform("chromaticCycles", 1.5f)
       shader.setFloatUniform("chromaticPhase", 0f)

--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/LiquidGlass.android.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/LiquidGlass.android.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.platform.LocalInspectionMode
  *
  * **Note:** For blur effects, use [Modifier.cloudy] separately.
  */
+@ExperimentalLiquidGlassMaterial
 @Composable
 public actual fun Modifier.liquidGlass(
   lensCenter: Offset,
@@ -57,6 +58,7 @@ public actual fun Modifier.liquidGlass(
   edge: Float,
   light: LiquidGlassLight,
   glow: LiquidGlassGlow,
+  chromatic: ChromaticOverlay,
   enabled: Boolean,
 ): Modifier = liquidGlassImpl(
   lensCenter = lensCenter,
@@ -73,9 +75,11 @@ public actual fun Modifier.liquidGlass(
   // The stable public surface only exposes the two perceptual knobs; widen to the full 4-knob
   // tuning (extra knobs at their tuned defaults) for the single uniform-writing path below.
   tuning = glow.toTuning(),
+  chromatic = chromatic,
   enabled = enabled,
 )
 
+@OptIn(ExperimentalLiquidGlassMaterial::class)
 @ExperimentalLiquidGlassMotion
 @Composable
 public actual fun Modifier.liquidGlassTuned(
@@ -113,6 +117,9 @@ public actual fun Modifier.liquidGlassTuned(
     rimMix = glowRimMix,
     widthPx = glowWidthPx,
   ),
+  // liquidGlassTuned tunes the specular glint only; it does not expose the chromatic overlay, so
+  // forward the no-op preset (the binding still writes all 6 chromatic uniforms gate-free below).
+  chromatic = LiquidGlassDefaults.NoChromatic,
   enabled = enabled,
 )
 
@@ -120,6 +127,7 @@ public actual fun Modifier.liquidGlassTuned(
  * Single entry point shared by [liquidGlass] and [liquidGlassTuned]. Takes the full internal
  * [GlowTuning] so there is exactly one uniform-writing code path (in [liquidGlassApi33]).
  */
+@OptIn(ExperimentalLiquidGlassMaterial::class)
 @Composable
 private fun Modifier.liquidGlassImpl(
   lensCenter: Offset,
@@ -134,6 +142,7 @@ private fun Modifier.liquidGlassImpl(
   edge: Float,
   light: LiquidGlassLight,
   tuning: GlowTuning,
+  chromatic: ChromaticOverlay,
   enabled: Boolean,
 ): Modifier {
   // Validation
@@ -171,11 +180,12 @@ private fun Modifier.liquidGlassImpl(
       edge = edge,
       light = light,
       tuning = tuning,
+      chromatic = chromatic,
     )
   } else {
     // Fallback for older Android versions
-    // The fallback path has no shader, so the light/glow tuning is intentionally not
-    // forwarded (no specular uniforms to drive).
+    // The fallback path has no shader, so the light/glow/chromatic tuning is intentionally not
+    // forwarded (no specular/chromatic uniforms to drive).
     // Provides saturation, contrast, tint, and edge effects without lens refraction
     liquidGlassFallback(
       lensCenter = lensCenter,
@@ -189,6 +199,7 @@ private fun Modifier.liquidGlassImpl(
   }
 }
 
+@OptIn(ExperimentalLiquidGlassMaterial::class)
 @RequiresApi(Build.VERSION_CODES.TIRAMISU)
 @Composable
 private fun Modifier.liquidGlassApi33(
@@ -204,6 +215,7 @@ private fun Modifier.liquidGlassApi33(
   edge: Float,
   light: LiquidGlassLight,
   tuning: GlowTuning,
+  chromatic: ChromaticOverlay,
 ): Modifier {
   // Create and cache the RuntimeShader
   val shader = remember {
@@ -257,6 +269,16 @@ private fun Modifier.liquidGlassApi33(
       shader.setFloatUniform("specFocalK", tuning.focalK)
       shader.setFloatUniform("specPoolFrac", tuning.poolFrac)
       shader.setFloatUniform("specPoolGain", tuning.poolGain)
+      // Chromatic overlay — all 6 declared chromatic uniforms must be set every draw (gate-free);
+      // an unset AGSL uniform reads garbage. intensity == 0 keeps the term bit-exact off in-shader.
+      // Only intensity + mode come from the public ChromaticOverlay; the remaining 4 are held at the
+      // shader's tuned defaults (bands/cycles/phase/modulate) as constants here.
+      shader.setFloatUniform("chromaticIntensity", chromatic.intensity)
+      shader.setFloatUniform("chromaticMode", if (chromatic.mode == ChromaticMode.Foil) 1f else 0f)
+      shader.setFloatUniform("chromaticBands", 3f)
+      shader.setFloatUniform("chromaticCycles", 1.5f)
+      shader.setFloatUniform("chromaticPhase", 0f)
+      shader.setFloatUniform("chromaticModulate", 1f)
 
       // Apply shader as RenderEffect - "content" binds to underlying layer
       renderEffect = RenderEffect

--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/LiquidGlass.android.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/LiquidGlass.android.kt
@@ -258,9 +258,9 @@ private fun Modifier.liquidGlassApi33(
       // right alongside lightDir.
       shader.setFloatUniform("specStrength", tuning.intensity)
       shader.setFloatUniform("specPower", tuning.sharpness)
-      shader.setFloatUniform("specRimMix", tuning.rimMix) // 변경: was specSweep / tuning.travel
+      shader.setFloatUniform("specRimMix", tuning.rimMix)
       shader.setFloatUniform("specWidthPx", tuning.widthPx)
-      // Fake-3D 스페큘러 리스펙 — AGSL에 선언됨; 매 draw 무게이트 set 안 하면 garbage(0) 읽음.
+      // Every declared uniform must be set each draw, or AGSL reads garbage (0).
       shader.setFloatUniform("specLightZ", tuning.lightZ)
       shader.setFloatUniform("specDomeFrac", tuning.domeFrac)
       shader.setFloatUniform("specBodyPower", tuning.bodyPower)

--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/LiquidGlass.android.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/LiquidGlass.android.kt
@@ -278,7 +278,7 @@ private fun Modifier.liquidGlassApi33(
       shader.setFloatUniform("chromaticBands", 3f)
       shader.setFloatUniform("chromaticCycles", 1.5f)
       shader.setFloatUniform("chromaticPhase", 0f)
-      shader.setFloatUniform("chromaticModulate", 1f)
+      shader.setFloatUniform("chromaticModulate", 0.3f)
 
       // Apply shader as RenderEffect - "content" binds to underlying layer
       renderEffect = RenderEffect

--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/LiquidGlass.android.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/LiquidGlass.android.kt
@@ -246,7 +246,7 @@ private fun Modifier.liquidGlassApi33(
       // right alongside lightDir.
       shader.setFloatUniform("specStrength", tuning.intensity)
       shader.setFloatUniform("specPower", tuning.sharpness)
-      shader.setFloatUniform("specRimMix", tuning.rimMix)        // 변경: was specSweep / tuning.travel
+      shader.setFloatUniform("specRimMix", tuning.rimMix) // 변경: was specSweep / tuning.travel
       shader.setFloatUniform("specWidthPx", tuning.widthPx)
       // Fake-3D 스페큘러 리스펙 — AGSL에 선언됨; 매 draw 무게이트 set 안 하면 garbage(0) 읽음.
       shader.setFloatUniform("specLightZ", tuning.lightZ)

--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/LiquidGlass.android.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/LiquidGlass.android.kt
@@ -55,6 +55,85 @@ public actual fun Modifier.liquidGlass(
   contrast: Float,
   tint: Color,
   edge: Float,
+  light: LiquidGlassLight,
+  glow: LiquidGlassGlow,
+  enabled: Boolean,
+): Modifier = liquidGlassImpl(
+  lensCenter = lensCenter,
+  lensSize = lensSize,
+  cornerRadius = cornerRadius,
+  refraction = refraction,
+  curve = curve,
+  dispersion = dispersion,
+  saturation = saturation,
+  contrast = contrast,
+  tint = tint,
+  edge = edge,
+  light = light,
+  // The stable public surface only exposes the two perceptual knobs; widen to the full 4-knob
+  // tuning (extra knobs at their tuned defaults) for the single uniform-writing path below.
+  tuning = glow.toTuning(),
+  enabled = enabled,
+)
+
+@ExperimentalLiquidGlassMotion
+@Composable
+public actual fun Modifier.liquidGlassTuned(
+  lensCenter: Offset,
+  lensSize: Size,
+  cornerRadius: Float,
+  refraction: Float,
+  curve: Float,
+  dispersion: Float,
+  saturation: Float,
+  contrast: Float,
+  tint: Color,
+  edge: Float,
+  light: LiquidGlassLight,
+  glowIntensity: Float,
+  glowSharpness: Float,
+  glowRimMix: Float,
+  glowWidthPx: Float,
+  enabled: Boolean,
+): Modifier = liquidGlassImpl(
+  lensCenter = lensCenter,
+  lensSize = lensSize,
+  cornerRadius = cornerRadius,
+  refraction = refraction,
+  curve = curve,
+  dispersion = dispersion,
+  saturation = saturation,
+  contrast = contrast,
+  tint = tint,
+  edge = edge,
+  light = light,
+  tuning = GlowTuning(
+    intensity = glowIntensity,
+    sharpness = glowSharpness,
+    rimMix = glowRimMix,
+    widthPx = glowWidthPx,
+  ),
+  enabled = enabled,
+)
+
+/**
+ * Single entry point shared by [liquidGlass] and [liquidGlassTuned]. Takes the full internal
+ * [GlowTuning] so there is exactly one uniform-writing code path (in [liquidGlassApi33]).
+ */
+@Composable
+private fun Modifier.liquidGlassImpl(
+  lensCenter: Offset,
+  lensSize: Size,
+  cornerRadius: Float,
+  refraction: Float,
+  curve: Float,
+  dispersion: Float,
+  saturation: Float,
+  contrast: Float,
+  tint: Color,
+  edge: Float,
+  light: LiquidGlassLight,
+  tuning: GlowTuning,
   enabled: Boolean,
 ): Modifier {
   // Validation
@@ -90,9 +169,13 @@ public actual fun Modifier.liquidGlass(
       contrast = contrast,
       tint = tint,
       edge = edge,
+      light = light,
+      tuning = tuning,
     )
   } else {
     // Fallback for older Android versions
+    // The fallback path has no shader, so the light/glow tuning is intentionally not
+    // forwarded (no specular uniforms to drive).
     // Provides saturation, contrast, tint, and edge effects without lens refraction
     liquidGlassFallback(
       lensCenter = lensCenter,
@@ -119,6 +202,8 @@ private fun Modifier.liquidGlassApi33(
   contrast: Float,
   tint: Color,
   edge: Float,
+  light: LiquidGlassLight,
+  tuning: GlowTuning,
 ): Modifier {
   // Create and cache the RuntimeShader
   val shader = remember {
@@ -152,6 +237,26 @@ private fun Modifier.liquidGlassApi33(
       shader.setFloatUniform("contrast", contrast)
       shader.setFloatUniform("tint", tint.red, tint.green, tint.blue, tint.alpha)
       shader.setFloatUniform("edge", edge)
+      // Draw-phase read: only the value changes per tick (holder identity is stable), so a
+      // high-frequency light source invalidates the draw without recomposing. Always set
+      // (never gate) — the shader requires every declared uniform.
+      val lightDir = light.direction.value
+      shader.setFloatUniform("lightDir", lightDir.x, lightDir.y)
+      // Specular glint tuning — every declared uniform must be set on every draw (gate-free),
+      // right alongside lightDir.
+      shader.setFloatUniform("specStrength", tuning.intensity)
+      shader.setFloatUniform("specPower", tuning.sharpness)
+      shader.setFloatUniform("specRimMix", tuning.rimMix)        // 변경: was specSweep / tuning.travel
+      shader.setFloatUniform("specWidthPx", tuning.widthPx)
+      // Fake-3D 스페큘러 리스펙 — AGSL에 선언됨; 매 draw 무게이트 set 안 하면 garbage(0) 읽음.
+      shader.setFloatUniform("specLightZ", tuning.lightZ)
+      shader.setFloatUniform("specDomeFrac", tuning.domeFrac)
+      shader.setFloatUniform("specBodyPower", tuning.bodyPower)
+      shader.setFloatUniform("specBodyGain", tuning.bodyGain)
+      // Moving focal hotspot (dual-axis) — same gate-free contract.
+      shader.setFloatUniform("specFocalK", tuning.focalK)
+      shader.setFloatUniform("specPoolFrac", tuning.poolFrac)
+      shader.setFloatUniform("specPoolGain", tuning.poolGain)
 
       // Apply shader as RenderEffect - "content" binds to underlying layer
       renderEffect = RenderEffect

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/ChromaticOverlay.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/ChromaticOverlay.kt
@@ -1,0 +1,131 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.cloudy
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Which way the chromatic overlay paints its rainbow over the glass.
+ *
+ * - [Iridescent] — thin-film interference: the hue rotates with the light/normal angle, like oil on
+ *   water or a soap bubble. The sheen shifts as the surface (or the light) tilts.
+ * - [Foil] — flowing bands: a fixed number of rainbow bands projected along the light direction, so
+ *   moving the light makes the bands stream across the face like a holographic foil.
+ *
+ * Maps to the shader's `chromaticMode` uniform (`0f` = [Iridescent], `1f` = [Foil]).
+ */
+@ExperimentalLiquidGlassMaterial
+public enum class ChromaticMode { Iridescent, Foil }
+
+/**
+ * Perceptual description of the Liquid Glass **chromatic overlay** — the light-reactive iridescent
+ * sheen layered on top of the white specular glint.
+ *
+ * Exposes the knobs a caller usually wants: how strong the sheen is ([intensity]), how it paints
+ * ([mode]), and the rainbow [spectrum] / [customBrush] used by the consumer (non-shader) path. The
+ * remaining shader tunables (band count, hue cycles, phase, focal-pool modulation) are held at their
+ * tuned defaults and written as constants by each platform binding, so they are not part of this
+ * stable surface.
+ *
+ * This is intentionally **not** a `data class`: the constructor is internal and `equals`/`hashCode`
+ * are hand-written, so future knobs can be added via a secondary constructor (or by widening the
+ * factory) without breaking the generated-component / copy ABI of a data class.
+ *
+ * Construct with the [ChromaticOverlay] companion `invoke`; presets live on [LiquidGlassDefaults]
+ * ([LiquidGlassDefaults.NoChromatic], [LiquidGlassDefaults.Holographic]).
+ *
+ * > **Shader path note:** when fed to [Modifier.liquidGlass], only [intensity] and [mode] reach the
+ * > shader (the rainbow hue is synthesized on the GPU). [spectrum] and [customBrush] are carried for
+ * > the consumer / `customBrush` path and future expansion; they are **not** sampled by the current
+ * > liquid-glass shader binding.
+ *
+ * @property intensity Overlay strength, roughly `0..1`. `0` disables the sheen (bit-exact: the shader
+ *   gate skips the term entirely). Maps to the shader's `chromaticIntensity`.
+ * @property mode How the rainbow is painted — [ChromaticMode.Iridescent] or [ChromaticMode.Foil].
+ *   Maps to the shader's `chromaticMode`.
+ * @property spectrum Rainbow color stops for the consumer / [customBrush] path. The shader path
+ *   synthesizes hue on the GPU and does **not** sample this list. Defensively copied by the factory,
+ *   so the holder stays truly immutable even if the caller mutates the original list.
+ * @property customBrush Optional caller-supplied [Brush] for the consumer path (currently unused by
+ *   the liquid-glass shader binding; reserved for the future cloudy consumer path). If you build a
+ *   brush inline, wrap it in `remember` so the holder identity is stable across recompositions —
+ *   constructing a new brush every recomposition reallocates the modifier and defeats the stability
+ *   guarantee (see [LiquidGlassLight]'s remember note).
+ *
+ * @see LiquidGlassDefaults.NoChromatic
+ * @see LiquidGlassDefaults.Holographic
+ */
+@ExperimentalLiquidGlassMaterial
+@Immutable
+public class ChromaticOverlay internal constructor(
+  public val intensity: Float,
+  public val mode: ChromaticMode,
+  public val spectrum: List<Color>,
+  public val customBrush: Brush? = null,
+) {
+  override fun equals(other: Any?): Boolean = this === other ||
+    (
+      other is ChromaticOverlay &&
+        intensity == other.intensity &&
+        mode == other.mode &&
+        spectrum == other.spectrum &&
+        customBrush == other.customBrush
+      )
+
+  override fun hashCode(): Int {
+    // equals() uses `==` so -0.0f and 0.0f compare equal, but Float.hashCode() hashes their bits and
+    // would differ. Normalize -0.0f -> 0.0f (the `== 0f` check catches both) to keep the
+    // equals/hashCode contract: equal instances must yield equal hash codes.
+    val i = if (intensity == 0f) 0f else intensity
+    var result = i.hashCode()
+    result = result * 31 + mode.hashCode()
+    result = result * 31 + spectrum.hashCode()
+    result = result * 31 + (customBrush?.hashCode() ?: 0)
+    return result
+  }
+
+  override fun toString(): String =
+    "ChromaticOverlay(intensity=$intensity, mode=$mode, spectrum=$spectrum, " +
+      "customBrush=$customBrush)"
+
+  public companion object {
+    /**
+     * Creates a [ChromaticOverlay] from its perceptual knobs.
+     *
+     * Exposed as a companion `invoke` rather than a same-named top-level factory function: the
+     * primary constructor is `internal` and takes the same signature, so a top-level
+     * `fun ChromaticOverlay(...)` would be a conflicting overload. `invoke` keeps the intended
+     * `ChromaticOverlay(...)` call syntax while leaving the internal constructor free for future
+     * secondary-constructor additions (ABI stability).
+     *
+     * @param intensity Overlay strength (`0..1`). `0` disables the sheen.
+     *   Default: [LiquidGlassDefaults.CHROMATIC_INTENSITY].
+     * @param mode How the rainbow is painted. Default: [ChromaticMode.Iridescent].
+     * @param spectrum Rainbow color stops (consumer / [customBrush] path only).
+     *   Default: [LiquidGlassDefaults.HOLOGRAPHIC_SPECTRUM]. Defensively copied with `.toList()` so
+     *   the resulting holder is truly immutable.
+     * @param customBrush Optional caller-supplied brush (consumer path; unused by the shader path).
+     */
+    public operator fun invoke(
+      intensity: Float = LiquidGlassDefaults.CHROMATIC_INTENSITY,
+      mode: ChromaticMode = ChromaticMode.Iridescent,
+      spectrum: List<Color> = LiquidGlassDefaults.HOLOGRAPHIC_SPECTRUM,
+      customBrush: Brush? = null,
+    ): ChromaticOverlay = ChromaticOverlay(intensity, mode, spectrum.toList(), customBrush)
+  }
+}

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/ChromaticOverlay.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/ChromaticOverlay.kt
@@ -22,8 +22,8 @@ import androidx.compose.ui.graphics.Color
 /**
  * Which way the chromatic overlay paints its rainbow over the glass.
  *
- * - [Iridescent] — thin-film interference: the hue rotates with the light/normal angle, like oil on
- *   water or a soap bubble. The sheen shifts as the surface (or the light) tilts.
+ * - [Iridescent] — thin-film interference (Newton's rings): the hue rotates with the light/normal
+ *   angle, like oil on water or a soap bubble. The sheen shifts as the surface/light tilts.
  * - [Foil] — flowing bands: a fixed number of rainbow bands projected along the light direction, so
  *   moving the light makes the bands stream across the face like a holographic foil.
  *

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/ChromaticOverlay.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/ChromaticOverlay.kt
@@ -22,15 +22,36 @@ import androidx.compose.ui.graphics.Color
 /**
  * Which way the chromatic overlay paints its rainbow over the glass.
  *
- * - [Iridescent] — thin-film interference (Newton's rings): the hue rotates with the light/normal
- *   angle, like oil on water or a soap bubble. The sheen shifts as the surface/light tilts.
- * - [Foil] — flowing bands: a fixed number of rainbow bands projected along the light direction, so
- *   moving the light makes the bands stream across the face like a holographic foil.
- *
- * Maps to the shader's `chromaticMode` uniform (`0f` = [Iridescent], `1f` = [Foil]).
+ * Maps to the shader's `chromaticMode` uniform, one float per entry in declared order
+ * (`0f` = [Iridescent] … `5f` = [Pearl]); the binding's `when` is exhaustive over this enum, so the
+ * float mapping stays in lockstep with the order below — **do not reorder**.
  */
 @ExperimentalLiquidGlassMaterial
-public enum class ChromaticMode { Iridescent, Foil }
+public enum class ChromaticMode {
+  /**
+   * Thin-film interference (Newton's rings): the hue rotates with the light/normal angle, like oil
+   * on water or a soap bubble. The sheen shifts as the surface/light tilts.
+   */
+  Iridescent,
+
+  /**
+   * Flowing bands: a fixed number of rainbow bands projected along the light direction, so moving
+   * the light makes the bands stream across the face like a holographic foil.
+   */
+  Foil,
+
+  /** Oil slick — tight, busy thin-film film: dense, fast-cycling hue swirls like petrol on a road. */
+  OilSlick,
+
+  /** Soap bubble — wide, airy interference bands: broad, slow color sweeps like a large bubble. */
+  SoapBubble,
+
+  /** Metallic foil — strong, hard-edged metallic sheen: punchy, high-contrast holographic metal. */
+  MetallicFoil,
+
+  /** Pearl — soft, subtle nacre: gentle pastel iridescence like the inside of a shell. */
+  Pearl,
+}
 
 /**
  * Perceptual description of the Liquid Glass **chromatic overlay** — the light-reactive iridescent

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/CloudyBackground.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/CloudyBackground.kt
@@ -114,6 +114,7 @@ public expect fun Modifier.sky(sky: Sky): Modifier
  * @param tint Optional tint color to blend over the blurred background.
  *             Use semi-transparent colors for best results.
  *             Defaults to [Color.Transparent] (no tint).
+ * @param light Optional experimental [LiquidGlassLight]; when non-null, a moving specular highlight is drawn over the blurred backdrop. Defaults to null (no highlight).
  * @param enabled If false, disables the blur effect and renders nothing (transparent).
  * @param cpuBlurEnabled Whether to enable CPU-based blur on Android 30 and below.
  *                       When `false` (default), a scrim overlay is shown instead of blur.
@@ -134,6 +135,7 @@ public expect fun Modifier.cloudy(
   radius: Int = CloudyDefaults.BACKGROUND_RADIUS,
   progressive: CloudyProgressive = CloudyProgressive.None,
   tint: Color = Color.Transparent,
+  light: LiquidGlassLight? = null,
   enabled: Boolean = true,
   cpuBlurEnabled: Boolean = CloudyDefaults.CPP_BLUR_ENABLED,
   onStateChanged: (CloudyState) -> Unit = {},

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/GyroLight.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/GyroLight.kt
@@ -1,0 +1,145 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.cloudy
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.geometry.Offset
+import kotlin.math.sqrt
+
+/**
+ * Creates a motion-driven [LiquidGlassLight] whose direction tracks the device tilt, so the
+ * Liquid Glass rim specular sweeps as the phone is tilted (à la iOS 26 "lights move in space").
+ *
+ * Pass the result to [Modifier.liquidGlass]'s `light` parameter. The returned holder has a
+ * stable identity; only its value changes (throttled, smoothed), so it invalidates the draw
+ * without recomposing the modifier.
+ *
+ * ## Behavior & fallbacks
+ * - **Android API < 33**: no-op (the Liquid Glass fallback has no shader). The light stays at
+ *   [base] and no sensors are registered.
+ * - **No motion sensor / Desktop / Web**: no-op; light stays at [base].
+ * - **Reduce Motion** (Android `ANIMATOR_DURATION_SCALE == 0`, iOS `isReduceMotionEnabled`):
+ *   the light is frozen at [base] and sensors are not started; observed live so toggling the
+ *   setting while on screen takes effect.
+ *
+ * ## Usage in lists
+ * Hoist this **once** above a list and share the returned [LiquidGlassLight] across items — one
+ * call registers one sensor listener. Calling it per item registers one listener per item.
+ *
+ * ## iOS
+ * The consuming app's `Info.plist` **must** declare `NSMotionUsageDescription`, or recent iOS
+ * terminates the app on the first device-motion read. v1 uses a portrait-oriented projection;
+ * landscape on iOS is not yet remapped.
+ *
+ * @param enabled When false, the light is frozen at [base] and no sensors are registered.
+ * @param hz Target emit rate (Hz). The value is throttled to this rate regardless of the raw
+ *   sensor rate.
+ * @param base The resting light direction used when flat / disabled / unsupported. Defaults to
+ *   [LiquidGlassDefaults.LIGHT_DIR].
+ * @param tiltGain How strongly tilt displaces the light from [base]. Higher = more sweep.
+ */
+@ExperimentalLiquidGlassMotion
+@Composable
+public fun rememberGyroLightSource(
+  enabled: Boolean = true,
+  hz: Int = 30,
+  base: Offset = LiquidGlassDefaults.LIGHT_DIR,
+  tiltGain: Float = 1.2f,
+): LiquidGlassLight {
+  val dirState = remember { mutableStateOf(base) }
+  // Platform actual owns sensor registration/teardown, throttling, smoothing and gating.
+  rememberTiltSource(enabled = enabled, hz = hz, base = base, tiltGain = tiltGain, out = dirState)
+  // Stable holder identity; only dirState.value changes per tick.
+  return remember(dirState) { LiquidGlassLight(dirState) }
+}
+
+/**
+ * Platform sensor binding. Writes a smoothed, throttled screen-space light direction into [out].
+ * Implemented with a real provider on Android/iOS and as a no-op elsewhere.
+ */
+@Composable
+internal expect fun rememberTiltSource(
+  enabled: Boolean,
+  hz: Int,
+  base: Offset,
+  tiltGain: Float,
+  out: MutableState<Offset>,
+)
+
+// ---------------------------------------------------------------------------------------------
+// Pure math — platform-independent so it is unit-testable (commonTest) and reused by actuals.
+// ---------------------------------------------------------------------------------------------
+
+/** One step of a 1-pole exponential moving average toward [raw]. [alpha] in (0,1]. */
+internal fun emaStep(prev: Offset, raw: Offset, alpha: Float): Offset =
+  prev + (raw - prev) * alpha
+
+/**
+ * Projects a device gravity vector onto a screen-space light direction.
+ *
+ * A flat device (gx≈0, gy≈0) yields [base]; tilting displaces the light by `tiltGain` scaled
+ * by the in-plane gravity components (normalized by ~g). [base] is normalized first so the
+ * sweep magnitude is consistent regardless of base length.
+ *
+ * @param gx in-plane gravity x (screen axes, after any display remap), m/s²
+ * @param gy in-plane gravity y, m/s²
+ */
+internal fun gravityToLight(gx: Float, gy: Float, base: Offset, tiltGain: Float): Offset {
+  val b = normalizeOr(base, Offset(-1f, -1f))
+  // ~9.81 m/s²; divide so a full 90° tilt maps to ~tiltGain of displacement.
+  val nx = (-gx) / 9.81f
+  val ny = (-gy) / 9.81f
+  return Offset(b.x + tiltGain * nx, b.y + tiltGain * ny)
+}
+
+/** Returns the unit vector of [o], or [fallback] if [o] is ~zero. */
+internal fun normalizeOr(o: Offset, fallback: Offset): Offset {
+  val len = sqrt(o.x * o.x + o.y * o.y)
+  return if (len < 1e-4f) fallback else Offset(o.x / len, o.y / len)
+}
+
+/**
+ * Projects a gravity vector in **G units** (~[-1, 1], as CoreMotion reports) onto a portrait
+ * screen-space light direction (y-down).
+ *
+ * Unlike [gravityToLight] (which expects m/s² and divides by ~9.81), the input here is already in
+ * G, so it is used directly — reusing [gravityToLight] for CoreMotion gravity would make the sweep
+ * ~10x too weak. Used by the iOS provider; kept here so it is platform-independent and testable.
+ *
+ * Device axes: +x = right edge, +y = top edge (y-up). Upright portrait gravity ≈ (0, -1, 0).
+ * - `dx = gx`  → lowering the right edge slides the light toward screen-right.
+ * - `dy = -gy` → flip device y-up to screen y-down.
+ * A flat device (gx≈gy≈0) returns the normalized [base] exactly.
+ */
+internal fun projectGravityPortrait(gx: Float, gy: Float, base: Offset, tiltGain: Float): Offset {
+  val b = normalizeOr(base, Offset(-1f, -1f))
+  return Offset(b.x + tiltGain * gx, b.y + tiltGain * -gy)
+}
+
+/**
+ * Whether the sensor should actually run. Encodes every gate with zero platform dependencies so
+ * the decision is unit-testable.
+ */
+internal fun shouldRunSensor(
+  enabled: Boolean,
+  reduceMotion: Boolean,
+  hasSensor: Boolean,
+  shaderPathActive: Boolean,
+): Boolean = enabled && !reduceMotion && hasSensor && shaderPathActive

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/GyroLight.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/GyroLight.kt
@@ -88,8 +88,7 @@ internal expect fun rememberTiltSource(
 // ---------------------------------------------------------------------------------------------
 
 /** One step of a 1-pole exponential moving average toward [raw]. [alpha] in (0,1]. */
-internal fun emaStep(prev: Offset, raw: Offset, alpha: Float): Offset =
-  prev + (raw - prev) * alpha
+internal fun emaStep(prev: Offset, raw: Offset, alpha: Float): Offset = prev + (raw - prev) * alpha
 
 /**
  * Projects a device gravity vector onto a screen-space light direction.

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlass.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlass.kt
@@ -262,12 +262,13 @@ public object LiquidGlassDefaults {
   public val NoChromatic: ChromaticOverlay = ChromaticOverlay(0f, ChromaticMode.Iridescent)
 
   /**
-   * A ready-made holographic-foil chromatic overlay — flowing rainbow bands at the default
+   * A ready-made holographic chromatic overlay — a thin-film interference sheen (Newton's-ring
+   * bands that shift hue with the light/normal angle, like oil on water) at the default
    * [CHROMATIC_INTENSITY]. Singleton; do not reassign.
    */
   @ExperimentalLiquidGlassMaterial
   public val Holographic: ChromaticOverlay =
-    ChromaticOverlay(CHROMATIC_INTENSITY, ChromaticMode.Foil, HOLOGRAPHIC_SPECTRUM)
+    ChromaticOverlay(CHROMATIC_INTENSITY, ChromaticMode.Iridescent, HOLOGRAPHIC_SPECTRUM)
 
   /** Minimum Android API level required for the full liquid glass effect. */
   public const val MIN_ANDROID_API_FULL: Int = 33

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlass.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlass.kt
@@ -270,6 +270,41 @@ public object LiquidGlassDefaults {
   public val Holographic: ChromaticOverlay =
     ChromaticOverlay(CHROMATIC_INTENSITY, ChromaticMode.Iridescent, HOLOGRAPHIC_SPECTRUM)
 
+  /**
+   * Oil-slick preset — a tight, busy thin-film film ([ChromaticMode.OilSlick]) at the default
+   * [CHROMATIC_INTENSITY]: dense, fast-cycling hue swirls like petrol on a wet road. Singleton; do
+   * not reassign.
+   */
+  @ExperimentalLiquidGlassMaterial
+  public val OilSlick: ChromaticOverlay =
+    ChromaticOverlay(CHROMATIC_INTENSITY, ChromaticMode.OilSlick)
+
+  /**
+   * Soap-bubble preset — wide, airy interference bands ([ChromaticMode.SoapBubble]) at the default
+   * [CHROMATIC_INTENSITY]: broad, slow color sweeps like a large bubble. Singleton; do not reassign.
+   */
+  @ExperimentalLiquidGlassMaterial
+  public val SoapBubble: ChromaticOverlay =
+    ChromaticOverlay(CHROMATIC_INTENSITY, ChromaticMode.SoapBubble)
+
+  /**
+   * Metallic-foil preset — a strong, hard-edged metallic sheen ([ChromaticMode.MetallicFoil]) at a
+   * raised `0.75f` intensity so the punchy, high-contrast holographic metal reads boldly. Singleton;
+   * do not reassign.
+   */
+  @ExperimentalLiquidGlassMaterial
+  public val MetallicFoil: ChromaticOverlay =
+    ChromaticOverlay(0.75f, ChromaticMode.MetallicFoil)
+
+  /**
+   * Pearl preset — a soft, subtle nacre ([ChromaticMode.Pearl]) at a lowered `0.45f` intensity so the
+   * gentle pastel iridescence stays understated, like the inside of a shell. Singleton; do not
+   * reassign.
+   */
+  @ExperimentalLiquidGlassMaterial
+  public val Pearl: ChromaticOverlay =
+    ChromaticOverlay(0.45f, ChromaticMode.Pearl)
+
   /** Minimum Android API level required for the full liquid glass effect. */
   public const val MIN_ANDROID_API_FULL: Int = 33
 

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlass.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlass.kt
@@ -16,10 +16,151 @@
 package com.skydoves.cloudy
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+
+/**
+ * Holder for the Liquid Glass specular light direction.
+ *
+ * The [direction] is a screen-space 2D vector (y-down) that drives the rim specular
+ * highlight in the glass shader. Wrapping it in a stable holder (rather than passing a
+ * raw [Offset]) keeps the [Modifier.liquidGlass] call from recomposing on every update:
+ * the holder identity stays constant while only [direction]'s value changes, so a
+ * high-frequency source (e.g. a gyroscope at 30 Hz) invalidates only the draw, not the
+ * composition.
+ *
+ * Create a static light with the [LiquidGlassLight] factory (remember it if the offset is
+ * computed inline), or a motion-driven one with `rememberGyroLightSource`.
+ *
+ * @see rememberGyroLightSource
+ * @see LiquidGlassDefaults.Light
+ */
+@Immutable
+public class LiquidGlassLight internal constructor(
+  internal val direction: State<Offset>,
+)
+
+/**
+ * Creates a static (fixed) [LiquidGlassLight] pointing in [direction].
+ *
+ * Wrap inline calls in `remember` (or use [LiquidGlassDefaults.Light]) so the holder
+ * identity is stable across recompositions; constructing a new holder every recomposition
+ * reallocates the modifier and defeats the stability guarantee.
+ *
+ * @param direction Screen-space light direction (y-down). Magnitude is irrelevant — the
+ *   shader normalizes it.
+ */
+public fun LiquidGlassLight(direction: Offset): LiquidGlassLight =
+  LiquidGlassLight(mutableStateOf(direction))
+
+/**
+ * Perceptual tuning for the Liquid Glass specular glint — the bright single-lobe rim highlight
+ * that the [light] source sweeps around the lens.
+ *
+ * Exposes the two knobs a caller usually wants: how bright the glint is ([intensity]) and how
+ * tight/focused it is ([sharpness]). The remaining shader tunables (radial sweep blend, band
+ * width) are held at their tuned defaults and are only reachable through the experimental
+ * [Modifier.liquidGlassTuned] modifier.
+ *
+ * This is intentionally **not** a `data class`: the constructor is internal and `equals`/
+ * `hashCode` are hand-written, so future knobs can be added via a secondary constructor (or by
+ * widening the factory) without breaking the generated-component / copy ABI of a data class.
+ *
+ * Construct with the [LiquidGlassGlow] factory; defaults reproduce the historical hardcoded glint
+ * ([LiquidGlassDefaults.Glow]).
+ *
+ * @property intensity Peak highlight brightness, roughly `0..1` (screen-blended, so it stays
+ *   `<= 1.0`). `0` disables the glint. Maps to the shader's `specStrength`.
+ * @property sharpness Glint lobe sharpness — higher = one tighter, more focused highlight; lower =
+ *   a broader, softer wash. Maps to the shader's `specPower`.
+ *
+ * @see LiquidGlassDefaults.Glow
+ * @see LiquidGlassDefaults.NoGlow
+ */
+@Immutable
+public class LiquidGlassGlow internal constructor(
+  public val intensity: Float,
+  public val sharpness: Float,
+) {
+  override fun equals(other: Any?): Boolean =
+    this === other ||
+      (other is LiquidGlassGlow && intensity == other.intensity && sharpness == other.sharpness)
+
+  override fun hashCode(): Int = intensity.hashCode() * 31 + sharpness.hashCode()
+
+  override fun toString(): String =
+    "LiquidGlassGlow(intensity=$intensity, sharpness=$sharpness)"
+
+  public companion object {
+    /**
+     * Creates a [LiquidGlassGlow] from the two perceptual knobs.
+     *
+     * Exposed as a companion `invoke` rather than a same-named top-level factory function: the
+     * primary constructor is `internal` and takes the same `(Float, Float)` signature, so a
+     * top-level `fun LiquidGlassGlow(Float, Float)` would be a conflicting overload. `invoke`
+     * keeps the intended `LiquidGlassGlow(...)` call syntax while leaving the internal
+     * constructor free for future secondary-constructor additions (ABI stability).
+     *
+     * @param intensity Peak highlight brightness (`0..1`). `0` disables the glint.
+     *   Default: [LiquidGlassDefaults.GLOW_INTENSITY].
+     * @param sharpness Glint lobe sharpness; higher = tighter glint.
+     *   Default: [LiquidGlassDefaults.GLOW_SHARPNESS].
+     */
+    public operator fun invoke(
+      intensity: Float = LiquidGlassDefaults.GLOW_INTENSITY,
+      sharpness: Float = LiquidGlassDefaults.GLOW_SHARPNESS,
+    ): LiquidGlassGlow = LiquidGlassGlow(intensity, sharpness)
+  }
+}
+
+/**
+ * Full specular tuning. Internal: the stable public surface only exposes the two perceptual knobs
+ * via [LiquidGlassGlow]; the extra knobs ([rimMix], [widthPx], [lightZ], [domeFrac], [bodyPower],
+ * [bodyGain]) are reachable only through the experimental [Modifier.liquidGlassTuned]. Every platform
+ * binding writes all eight as uniforms each draw, so the shader never sees a missing uniform.
+ *
+ * @property intensity ex-`SPEC_STRENGTH` — peak highlight (screen-blended; stays `<= 1.0`).
+ * @property sharpness ex-`SPEC_POWER` — rim/back lobe sharpness (Blinn).
+ * @property rimMix body↔rim crossfade: `0` = pure body sheen, `1` = pure rim glint.
+ * @property widthPx ex-`SPEC_WIDTH_PX` — rim band thickness, decoupled from `edge`.
+ * @property lightZ fake-3D light z-height; tilts the synthesized bevel normal toward the viewer.
+ * @property domeFrac bevel depth as a fraction of the lens half-extent; `> 1` removes the static
+ *   dead-core (no interior pixel reaches `n_cos == 0`).
+ * @property bodyPower body-sheen lobe sharpness (broad, gentle ramp).
+ * @property bodyGain body-sheen intensity scale.
+ * @property focalK moving-hotspot offset toward the light, as a fraction of the lens half-extent.
+ *   This is what makes the highlight pour across the face on BOTH axes (pitch=vertical, roll=
+ *   horizontal): the focal pool center is `lensCenter + lightVec * (minHalf * focalK)`.
+ * @property poolFrac focal-pool radius as a fraction of the lens half-extent; smaller = a tighter,
+ *   more localized pool of light.
+ * @property poolGain focal-pool peak scale (multiplies `intensity`); the dominant visible term at
+ *   the default [rimMix].
+ */
+@Immutable
+internal class GlowTuning(
+  val intensity: Float = LiquidGlassDefaults.GLOW_INTENSITY,
+  val sharpness: Float = LiquidGlassDefaults.GLOW_SHARPNESS,
+  // rimMix biased toward the body (focal pool) so the moving hotspot — not the thin rim band —
+  // carries the visible, dual-axis motion. rimMix=1 still reverts to the legacy pure-rim glint.
+  val rimMix: Float = 0.4f,
+  val widthPx: Float = 12.0f,
+  val lightZ: Float = 0.55f,
+  val domeFrac: Float = 1.15f,
+  val bodyPower: Float = 2.5f,
+  val bodyGain: Float = 0.6f,
+  val focalK: Float = 0.55f,
+  val poolFrac: Float = 0.7f,
+  val poolGain: Float = 1.3f,
+)
+
+/** Widens a public [LiquidGlassGlow] into the internal 4-knob [GlowTuning] (extra knobs default). */
+internal fun LiquidGlassGlow.toTuning(): GlowTuning =
+  GlowTuning(intensity = intensity, sharpness = sharpness)
 
 /**
  * Default values for the Liquid Glass effect.
@@ -51,6 +192,41 @@ public object LiquidGlassDefaults {
 
   /** Default edge lighting width. 0.0 = no edge, higher = wider edge lighting. */
   public const val EDGE: Float = 0.2f
+
+  /**
+   * Default specular light direction (screen-space, y-down). Unnormalized raw value; the
+   * shader applies `normalize(lightDir)`, so this evaluates to exactly the historical
+   * hardcoded `normalize(float2(-1, -1))` — output is unchanged unless a caller opts in.
+   */
+  public val LIGHT_DIR: Offset = Offset(-1f, -1f)
+
+  /**
+   * Default fixed light — matches the pre-motion behavior. Singleton; do not reassign.
+   */
+  public val Light: LiquidGlassLight = LiquidGlassLight(LIGHT_DIR)
+
+  /**
+   * Default specular glint intensity (peak brightness). Reproduces the historical hardcoded
+   * `SPEC_STRENGTH`, so output is unchanged unless a caller opts into a custom [LiquidGlassGlow].
+   */
+  public const val GLOW_INTENSITY: Float = 0.7f
+
+  /**
+   * Default specular glint sharpness (lobe power). Reproduces the historical hardcoded
+   * `SPEC_POWER` — one tight glint.
+   */
+  public const val GLOW_SHARPNESS: Float = 10.0f
+
+  /**
+   * Default glow — matches the historical hardcoded glint. Singleton; do not reassign.
+   */
+  public val Glow: LiquidGlassGlow = LiquidGlassGlow(GLOW_INTENSITY, GLOW_SHARPNESS)
+
+  /**
+   * A glow that disables the specular glint (zero intensity). Singleton; do not reassign.
+   * Sharpness is a harmless `1.0` since the highlight is scaled to zero regardless.
+   */
+  public val NoGlow: LiquidGlassGlow = LiquidGlassGlow(0f, 1f)
 
   /** Minimum Android API level required for the full liquid glass effect. */
   public const val MIN_ANDROID_API_FULL: Int = 33
@@ -144,6 +320,17 @@ public object LiquidGlassDefaults {
  *   a boolean where value > 0 draws a fixed width edge effect.
  *   Default: [LiquidGlassDefaults.EDGE] (0.2).
  *
+ * @param light The specular light source driving the rim highlight. Defaults to a fixed
+ *   light ([LiquidGlassDefaults.Light]) that reproduces the previous behavior. Pass a
+ *   motion-driven source from `rememberGyroLightSource` to make the highlight sweep as the
+ *   device tilts. No-op on Android API < 33 (the fallback path has no shader).
+ *
+ * @param glow Perceptual tuning for the specular glint — how bright ([LiquidGlassGlow.intensity])
+ *   and how tight ([LiquidGlassGlow.sharpness]) the rim highlight is. Defaults to
+ *   [LiquidGlassDefaults.Glow] (the historical look); use [LiquidGlassDefaults.NoGlow] to remove
+ *   the glint. For the full set of shader tunables, see the experimental [Modifier.liquidGlassTuned].
+ *   No-op on Android API < 33 (the fallback path has no shader).
+ *
  * @param enabled If false, disables the effect and returns the original modifier.
  *
  * @return A [Modifier] with the Liquid Glass effect applied.
@@ -164,5 +351,7 @@ public expect fun Modifier.liquidGlass(
   contrast: Float = LiquidGlassDefaults.CONTRAST,
   tint: Color = LiquidGlassDefaults.TINT,
   edge: Float = LiquidGlassDefaults.EDGE,
+  light: LiquidGlassLight = LiquidGlassDefaults.Light,
+  glow: LiquidGlassGlow = LiquidGlassDefaults.Glow,
   enabled: Boolean = true,
 ): Modifier

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlass.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlass.kt
@@ -231,6 +231,44 @@ public object LiquidGlassDefaults {
    */
   public val NoGlow: LiquidGlassGlow = LiquidGlassGlow(0f, 1f)
 
+  /**
+   * Default chromatic overlay intensity (sheen strength). A mid value so the preset
+   * [Holographic] reads clearly without washing out the underlying content.
+   */
+  public const val CHROMATIC_INTENSITY: Float = 0.6f
+
+  /**
+   * Default rainbow stops for the chromatic overlay's consumer / `customBrush` path. The shader
+   * path synthesizes hue on the GPU and does not sample this list; it is provided so the consumer
+   * path (and future expansion) has a sensible full-spectrum default. Seven evenly-spaced hues
+   * (red → violet).
+   */
+  public val HOLOGRAPHIC_SPECTRUM: List<Color> = listOf(
+    Color(0xFFFF0000), // red
+    Color(0xFFFF7F00), // orange
+    Color(0xFFFFFF00), // yellow
+    Color(0xFF00FF00), // green
+    Color(0xFF0000FF), // blue
+    Color(0xFF4B0082), // indigo
+    Color(0xFF9400D3), // violet
+  )
+
+  /**
+   * A chromatic overlay that disables the iridescent sheen (zero intensity). Singleton; do not
+   * reassign. This is the default for the `chromatic` parameter of [Modifier.liquidGlass], so the
+   * glass is bit-exact unchanged unless a caller opts into an overlay.
+   */
+  @ExperimentalLiquidGlassMaterial
+  public val NoChromatic: ChromaticOverlay = ChromaticOverlay(0f, ChromaticMode.Iridescent)
+
+  /**
+   * A ready-made holographic-foil chromatic overlay — flowing rainbow bands at the default
+   * [CHROMATIC_INTENSITY]. Singleton; do not reassign.
+   */
+  @ExperimentalLiquidGlassMaterial
+  public val Holographic: ChromaticOverlay =
+    ChromaticOverlay(CHROMATIC_INTENSITY, ChromaticMode.Foil, HOLOGRAPHIC_SPECTRUM)
+
   /** Minimum Android API level required for the full liquid glass effect. */
   public const val MIN_ANDROID_API_FULL: Int = 33
 
@@ -334,6 +372,17 @@ public object LiquidGlassDefaults {
  *   the glint. For the full set of shader tunables, see the experimental [Modifier.liquidGlassTuned].
  *   No-op on Android API < 33 (the fallback path has no shader).
  *
+ * @param chromatic The chromatic / iridescent overlay — a light-reactive rainbow sheen layered over
+ *   the glass, independent of the white specular glint. Defaults to
+ *   [LiquidGlassDefaults.NoChromatic] (no sheen, bit-exact unchanged); use
+ *   [LiquidGlassDefaults.Holographic] or a custom [ChromaticOverlay] to enable it. Only
+ *   [ChromaticOverlay.intensity] and [ChromaticOverlay.mode] reach the shader (hue is synthesized on
+ *   the GPU). No-op on Android API < 33 (the fallback path has no shader). **Experimental:** because
+ *   this parameter's type is experimental, the whole function requires
+ *   `@OptIn(ExperimentalLiquidGlassMaterial::class)` — but the default leaves the historical look
+ *   untouched, so opting in is only a one-line annotation (no behavior change) until you pass a real
+ *   overlay.
+ *
  * @param enabled If false, disables the effect and returns the original modifier.
  *
  * @return A [Modifier] with the Liquid Glass effect applied.
@@ -342,6 +391,7 @@ public object LiquidGlassDefaults {
  * @see LiquidGlassShaderSource
  * @see cloudy
  */
+@ExperimentalLiquidGlassMaterial
 @Composable
 public expect fun Modifier.liquidGlass(
   lensCenter: Offset,
@@ -356,5 +406,6 @@ public expect fun Modifier.liquidGlass(
   edge: Float = LiquidGlassDefaults.EDGE,
   light: LiquidGlassLight = LiquidGlassDefaults.Light,
   glow: LiquidGlassGlow = LiquidGlassDefaults.Glow,
+  chromatic: ChromaticOverlay = LiquidGlassDefaults.NoChromatic,
   enabled: Boolean = true,
 ): Modifier

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlass.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlass.kt
@@ -41,9 +41,7 @@ import androidx.compose.ui.graphics.Color
  * @see LiquidGlassDefaults.Light
  */
 @Immutable
-public class LiquidGlassLight internal constructor(
-  internal val direction: State<Offset>,
-)
+public class LiquidGlassLight internal constructor(internal val direction: State<Offset>)
 
 /**
  * Creates a static (fixed) [LiquidGlassLight] pointing in [direction].
@@ -87,14 +85,19 @@ public class LiquidGlassGlow internal constructor(
   public val intensity: Float,
   public val sharpness: Float,
 ) {
-  override fun equals(other: Any?): Boolean =
-    this === other ||
-      (other is LiquidGlassGlow && intensity == other.intensity && sharpness == other.sharpness)
+  override fun equals(other: Any?): Boolean = this === other ||
+    (other is LiquidGlassGlow && intensity == other.intensity && sharpness == other.sharpness)
 
-  override fun hashCode(): Int = intensity.hashCode() * 31 + sharpness.hashCode()
+  override fun hashCode(): Int {
+    // equals() uses `==` so -0.0f and 0.0f compare equal, but Float.hashCode() hashes their bits
+    // and would differ. Normalize -0.0f -> 0.0f (the `== 0f` check catches both) to keep the
+    // equals/hashCode contract: equal instances must yield equal hash codes.
+    val i = if (intensity == 0f) 0f else intensity
+    val s = if (sharpness == 0f) 0f else sharpness
+    return i.hashCode() * 31 + s.hashCode()
+  }
 
-  override fun toString(): String =
-    "LiquidGlassGlow(intensity=$intensity, sharpness=$sharpness)"
+  override fun toString(): String = "LiquidGlassGlow(intensity=$intensity, sharpness=$sharpness)"
 
   public companion object {
     /**

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassExperimental.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassExperimental.kt
@@ -1,0 +1,82 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.cloudy
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Marks motion-driven Liquid Glass APIs (e.g. `rememberGyroLightSource`) as experimental.
+ *
+ * These APIs read device-motion sensors and may change. Opt in with
+ * `@OptIn(ExperimentalLiquidGlassMotion::class)` or by propagating the annotation.
+ */
+@RequiresOptIn(
+  level = RequiresOptIn.Level.WARNING,
+  message = "Motion-driven Liquid Glass APIs are experimental and may change.",
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
+public annotation class ExperimentalLiquidGlassMotion
+
+/**
+ * Experimental variant of [Modifier.liquidGlass] that exposes the **full** specular-glint tuning,
+ * not just the two perceptual knobs of [LiquidGlassGlow].
+ *
+ * The stable public surface intentionally keeps glow tuning to [LiquidGlassGlow] (intensity +
+ * sharpness). This modifier opens the remaining shader tunables — [glowRimMix] and [glowWidthPx] —
+ * for live experimentation (e.g. the demo's slider screen), behind the [ExperimentalLiquidGlassMotion]
+ * opt-in so they are not part of the committed API contract.
+ *
+ * ## Why four loose floats instead of a tuning object
+ * The full tuning is modelled internally by `GlowTuning`, but that type is deliberately `internal`
+ * so it never leaks into the stable ABI. Rather than promote a second public type that is only
+ * reachable here, this modifier takes the four knobs as plain floats. A separate demo module can
+ * construct floats with no extra public type, and the internal binding folds them straight into
+ * `GlowTuning` — keeping a single uniform-writing path per platform shared with [Modifier.liquidGlass].
+ *
+ * All other parameters mirror [Modifier.liquidGlass]; see that modifier for their semantics.
+ *
+ * @param glowIntensity ex-`SPEC_STRENGTH` — peak highlight brightness (`0..1`, screen-blended).
+ * @param glowSharpness ex-`SPEC_POWER` — lobe sharpness; higher = one tighter glint.
+ * @param glowRimMix body↔rim crossfade (0 = body sheen, 1 = rim glint).
+ * @param glowWidthPx ex-`SPEC_WIDTH_PX` — specular band thickness in pixels, decoupled from `edge`.
+ *
+ * @see Modifier.liquidGlass
+ */
+@ExperimentalLiquidGlassMotion
+@Composable
+public expect fun Modifier.liquidGlassTuned(
+  lensCenter: Offset,
+  lensSize: Size = LiquidGlassDefaults.LENS_SIZE,
+  cornerRadius: Float = LiquidGlassDefaults.CORNER_RADIUS,
+  refraction: Float = LiquidGlassDefaults.REFRACTION,
+  curve: Float = LiquidGlassDefaults.CURVE,
+  dispersion: Float = LiquidGlassDefaults.DISPERSION,
+  saturation: Float = LiquidGlassDefaults.SATURATION,
+  contrast: Float = LiquidGlassDefaults.CONTRAST,
+  tint: Color = LiquidGlassDefaults.TINT,
+  edge: Float = LiquidGlassDefaults.EDGE,
+  light: LiquidGlassLight = LiquidGlassDefaults.Light,
+  glowIntensity: Float = LiquidGlassDefaults.GLOW_INTENSITY,
+  glowSharpness: Float = LiquidGlassDefaults.GLOW_SHARPNESS,
+  glowRimMix: Float = 0.6f,
+  glowWidthPx: Float = 12.0f,
+  enabled: Boolean = true,
+): Modifier

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassExperimental.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassExperimental.kt
@@ -36,6 +36,23 @@ import androidx.compose.ui.graphics.Color
 public annotation class ExperimentalLiquidGlassMotion
 
 /**
+ * Marks the chromatic / iridescent material APIs (e.g. [ChromaticOverlay], [ChromaticMode], and the
+ * `chromatic` parameter of [Modifier.liquidGlass]) as experimental.
+ *
+ * These APIs add a light-reactive rainbow sheen on top of the glass and may change. Opt in with
+ * `@OptIn(ExperimentalLiquidGlassMaterial::class)` or by propagating the annotation. The annotation
+ * is applied at the type / parameter level only — the stable [Modifier.liquidGlass] surface is
+ * unaffected unless a caller actually opts into a chromatic overlay.
+ */
+@RequiresOptIn(
+  level = RequiresOptIn.Level.WARNING,
+  message = "Chromatic / material Liquid Glass APIs are experimental and may change.",
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
+public annotation class ExperimentalLiquidGlassMaterial
+
+/**
  * Experimental variant of [Modifier.liquidGlass] that exposes the **full** specular-glint tuning,
  * not just the two perceptual knobs of [LiquidGlassGlow].
  *

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassHighlight.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassHighlight.kt
@@ -1,0 +1,87 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.cloudy
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.IntSize
+
+/**
+ * Shared tuning for the background-blur specular highlight drawn by [Modifier.cloudy] when a
+ * [LiquidGlassLight] is supplied. These mirror the focal-pool terms of the AGSL/SKSL Liquid Glass
+ * shader (`LiquidGlassShaderSource`) so the Compose-side approximation lines up with the shader look,
+ * but are kept here (not in the shader's `GlowTuning`) because the cloudy highlight is a flat radial
+ * gradient composited over an already-blurred backdrop, not a per-pixel lens evaluation.
+ *
+ * Internal: both platform bindings ([CloudyBackground.android] / [CloudyBackground.skiko]) read these.
+ */
+
+/** Moving-hotspot offset toward the light, as a fraction of the min lens dimension. Mirrors `GlowTuning.focalK`. */
+internal const val HIGHLIGHT_FOCAL_K: Float = 0.55f
+
+/** Focal-pool radius as a fraction of the min lens dimension. Mirrors `GlowTuning.poolFrac`. */
+internal const val HIGHLIGHT_POOL_FRAC: Float = 0.70f
+
+/**
+ * Warm white used for the highlight. The shader's specular is a near-white screen-blended term;
+ * a slight warm bias reads as a physically-lit glint rather than a flat white wash.
+ */
+internal val HIGHLIGHT_WARM: Color = Color(0xFFFFF7E6)
+
+/**
+ * Radial alpha falloff approximating the shader's `smoothstep(poolR, 0, d)^2 * 0.35` focal pool
+ * (peak ~0.35 at the center, fading to 0 at the rim). Six stops keep the ramp smooth enough to avoid
+ * banding while staying a constant (zero per-frame allocation — only the [androidx.compose.ui.graphics.Brush]
+ * built from it is rebuilt when the center/radius move).
+ */
+internal val HIGHLIGHT_STOPS: Array<Pair<Float, Color>> = arrayOf(
+  0.00f to HIGHLIGHT_WARM.copy(alpha = 0.35f),
+  0.15f to HIGHLIGHT_WARM.copy(alpha = 0.31f),
+  0.35f to HIGHLIGHT_WARM.copy(alpha = 0.17f),
+  0.55f to HIGHLIGHT_WARM.copy(alpha = 0.066f),
+  0.75f to HIGHLIGHT_WARM.copy(alpha = 0.0085f),
+  1.00f to HIGHLIGHT_WARM.copy(alpha = 0.00f),
+)
+
+// ---------------------------------------------------------------------------------------------
+// Pure geometry — platform-independent so it is unit-testable (commonTest) and is the exact code
+// the platform draw helpers call (no duplicated math). Mirrors the shader's focal-pool placement.
+// ---------------------------------------------------------------------------------------------
+
+/**
+ * Screen-space center of the focal-pool highlight: the lens center pushed toward the (normalized)
+ * light [dir] by `minDim * focalK`. This is what makes the highlight pour across the face on both
+ * axes as the surface tilts. [dir] is normalized first (via [normalizeOr], falling back to
+ * [LiquidGlassDefaults.LIGHT_DIR]) so magnitude is irrelevant. Screen space is y-down.
+ *
+ * @param size the lens (child) size in pixels.
+ * @param dir the screen-space light direction (y-down); any magnitude.
+ * @param focalK offset toward the light as a fraction of the min lens dimension.
+ */
+internal fun highlightPoolCenter(size: IntSize, dir: Offset, focalK: Float): Offset =
+  Offset(size.width / 2f, size.height / 2f) +
+    normalizeOr(dir, LiquidGlassDefaults.LIGHT_DIR) * (minOf(size.width, size.height).toFloat() * focalK)
+
+/**
+ * Radius of the focal-pool highlight: `minDim * poolFrac`, clamped to at least `1f` to mirror the
+ * shader's `max(minHalf * specPoolFrac, 1.0)` zero-width guard (a zero radius gives an undefined
+ * radial gradient).
+ *
+ * @param size the lens (child) size in pixels.
+ * @param poolFrac pool radius as a fraction of the min lens dimension.
+ */
+internal fun highlightPoolRadius(size: IntSize, poolFrac: Float): Float =
+  maxOf(minOf(size.width, size.height).toFloat() * poolFrac, 1f)

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassHighlight.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassHighlight.kt
@@ -42,17 +42,19 @@ internal const val HIGHLIGHT_POOL_FRAC: Float = 0.70f
 internal val HIGHLIGHT_WARM: Color = Color(0xFFFFF7E6)
 
 /**
- * Radial alpha falloff approximating the shader's `smoothstep(poolR, 0, d)^2 * 0.35` focal pool
- * (peak ~0.35 at the center, fading to 0 at the rim). Six stops keep the ramp smooth enough to avoid
+ * Radial alpha falloff approximating the shader's `smoothstep(poolR, 0, d)^2 * 0.5` focal pool
+ * (peak ~0.5 at the center, fading to 0 at the rim). Six stops keep the ramp smooth enough to avoid
  * banding while staying a constant (zero per-frame allocation — only the [androidx.compose.ui.graphics.Brush]
- * built from it is rebuilt when the center/radius move).
+ * built from it is rebuilt when the center/radius move). The peak matches the shader's perceived
+ * specular punch (`specStrength * specPoolGain`) over a mid-tone backdrop; over bright/warm content the
+ * SrcOver pool self-attenuates, so it never blows out.
  */
 internal val HIGHLIGHT_STOPS: Array<Pair<Float, Color>> = arrayOf(
-  0.00f to HIGHLIGHT_WARM.copy(alpha = 0.35f),
-  0.15f to HIGHLIGHT_WARM.copy(alpha = 0.31f),
-  0.35f to HIGHLIGHT_WARM.copy(alpha = 0.17f),
-  0.55f to HIGHLIGHT_WARM.copy(alpha = 0.066f),
-  0.75f to HIGHLIGHT_WARM.copy(alpha = 0.0085f),
+  0.00f to HIGHLIGHT_WARM.copy(alpha = 0.50f),
+  0.15f to HIGHLIGHT_WARM.copy(alpha = 0.44f),
+  0.35f to HIGHLIGHT_WARM.copy(alpha = 0.258f),
+  0.55f to HIGHLIGHT_WARM.copy(alpha = 0.09f),
+  0.75f to HIGHLIGHT_WARM.copy(alpha = 0.012f),
   1.00f to HIGHLIGHT_WARM.copy(alpha = 0.00f),
 )
 

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassHighlight.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassHighlight.kt
@@ -75,7 +75,8 @@ internal val HIGHLIGHT_STOPS: Array<Pair<Float, Color>> = arrayOf(
  */
 internal fun highlightPoolCenter(size: IntSize, dir: Offset, focalK: Float): Offset =
   Offset(size.width / 2f, size.height / 2f) +
-    normalizeOr(dir, LiquidGlassDefaults.LIGHT_DIR) * (minOf(size.width, size.height).toFloat() * focalK)
+    normalizeOr(dir, LiquidGlassDefaults.LIGHT_DIR) *
+    (minOf(size.width, size.height).toFloat() * focalK)
 
 /**
  * Radius of the focal-pool highlight: `minDim * poolFrac`, clamped to at least `1f` to mirror the

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassShaderSource.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassShaderSource.kt
@@ -47,9 +47,22 @@ uniform float saturation;
 uniform float contrast;
 uniform float4 tint;
 uniform float edge;
+uniform float2 lightDir;
+uniform float specStrength;
+uniform float specPower;
+uniform float specRimMix;     // 변경: was specSweep — body<->rim crossfade (D)
+uniform float specWidthPx;
+uniform float specLightZ;      // NEW
+uniform float specDomeFrac;    // NEW
+uniform float specBodyPower;   // NEW
+uniform float specBodyGain;    // NEW
+uniform float specFocalK;      // NEW: focal-pool offset toward light (fraction of minHalf)
+uniform float specPoolFrac;    // NEW: focal-pool radius (fraction of minHalf)
+uniform float specPoolGain;    // NEW: focal-pool peak scale
 uniform shader content;
 
 const float SMOOTH_EDGE_PX = 1.5;
+const float SEAM_BLEND_PX = 8.0;   // 대각 블렌드 반폭(px); 클수록 내부 크리스 부드러움
 
 // Signed distance to a box with rounded corners
 // Negative = inside, Positive = outside, Zero = on boundary
@@ -137,12 +150,88 @@ half4 main(float2 xy) {
 
     pixel.rgb = processColor(pixel.rgb, saturation, contrast, tint);
 
-    // Specular rim highlight
-    if (edge > 0.0) {
-        float rimBlend = smoothstep(-edge * 10.0, 0.0, sdf);
-        float2 lightVec = normalize(float2(-1.0, -1.0));
-        float specular = abs(dot(normal, lightVec));
-        pixel.rgb += half3(rimBlend * specular * edge);
+    // Specular highlight — a moving focal hotspot + a tight Blinn rim glint.
+    // 4 terms: focal pool (light pours across the face, dual-axis) + body sheen modeling fill
+    //          + tight Blinn rim glint + back-rim fill.
+    // 게이트가 specStrength도 검사 → NoGlow(specStrength==0)는 ALU 0 + bit-exact off (F).
+    // specStrength는 두 binding 모두 항상 set 되므로 게이트가 필요 uniform write를 막지 않음.
+    // specRimMix:   0 = 순수 body(focal pool), 1 = 순수 rim glint (crossfade)
+    // specPower:    rim/back lobe 샤프니스 (Blinn)
+    // specWidthPx:  rim band 두께, `edge`와 분리
+    // specStrength: peak highlight (screen-blended; <= 1.0)
+    // specLightZ/specDomeFrac/specBodyPower/specBodyGain: fake-3D bevel 라이팅
+    // specFocalK/specPoolFrac/specPoolGain: 빛이 면을 가로질러 흐르는 이동 핫스팟(양축)
+    if (edge > 0.0 && specStrength > 0.0) {
+        float2 lightVec = normalize(lightDir);
+
+        // --- seam-free in-plane direction (스페큘러 전용; 굴절이 읽는 'normal'은 불변) ---
+        // 굴절 경로(상단)는 hard-pick 'normal'을 그대로 사용한다(회귀 없음, G1).
+        // 여기서만 d.x==d.y 대각 크리스를 없앤 연속 방향을 따로 만든다.
+        // 둥근 사각형 내부는 L-inf 필드라 진짜 gradient는 대각에서 불연속 → 8px softmax로 블렌딩.
+        float2 d2 = abs(p) - halfDim + float2(r);                 // boxRoundedSDF와 동일 기저
+        float2 s2 = float2(p.x >= 0.0 ? 1.0 : -1.0, p.y >= 0.0 ? 1.0 : -1.0);
+        float2 specDir2;
+        if (max(d2.x, d2.y) > 0.0) {
+            specDir2 = s2 * normalize(max(d2, 0.0));              // 외부/코너: 해석적
+        } else {
+            // 내부: w->1 x-우세, ->0 y-우세, =0.5 대각 seam. +1e-4 = dead-center normalize 특이점 가드.
+            float w  = clamp(0.5 + 0.5 * (d2.x - d2.y) / SEAM_BLEND_PX, 0.0, 1.0);
+            float2 v = float2(s2.x * w, s2.y * (1.0 - w)) + float2(0.0, 1.0e-4);
+            specDir2 = normalize(v);
+        }
+
+        // --- fake-3D surface normal from the rounded-rect bevel ---
+        float minHalf = min(halfDim.x, halfDim.y);
+        float bevelPx = max(minHalf * specDomeFrac, 1.0);
+        float depthIn = max(-sdf, 0.0);
+        float t       = clamp(depthIn / bevelPx, 0.0, 1.0);
+        float n_cos   = 1.0 - t;                                  // 면내 크기
+        float n_sin   = sqrt(max(1.0 - n_cos * n_cos, 0.0));      // float: n_cos~1 근처 치명적 상쇄
+        float3 N      = normalize(float3(specDir2 * n_cos, n_sin + 1.0e-3));
+
+        float3 L = normalize(float3(lightVec, specLightZ));
+        float3 V = float3(0.0, 0.0, 1.0);
+
+        // --- MOVING FOCAL HOTSPOT — "light pours across the face on both axes" ---
+        // 핫스팟을 lightVec 방향으로 minHalf*specFocalK 만큼 옮긴다: pitch(lightVec.y)=수직,
+        // roll(lightVec.x)=수평 이동 → 이동하는 밝은 풀(둘 다 축). N≈+Z로 붕괴하던 옛 body sheen과
+        // 달리 면 전체에서 빛 방향을 강하게 따른다. inside 마스크로 렌즈 밖/림은 페이드.
+        float2 focal     = lightVec * (minHalf * specFocalK);     // lensCenter(=원점) 기준 오프셋
+        float  poolR     = max(minHalf * specPoolFrac, 1.0);      // 0 가드(zero-width smoothstep 회피)
+        float  poolD     = length(p - focal);
+        float  pool      = smoothstep(poolR, 0.0, poolD);         // 1 at focal, 0 at rim
+        float  inside    = smoothstep(0.0, -6.0, sdf);            // 렌즈 안쪽만(밖/경계 페이드)
+        float  focalPool = pool * pool * specStrength * specPoolGain * inside; // pool^2 = 더 단단한 코어
+
+        // --- broad body sheen (완만한 modeling fill, 핫스팟 위에 더함) ---
+        float ndl       = max(dot(N, L), 0.0);
+        float bodySheen = pow(ndl, specBodyPower) * specStrength * specBodyGain; // float: pow는 fp16서 밴딩
+
+        // --- tight Blinn rim glint, rim band에 한정 ---
+        // specWidthPx==0이면 zero-width smoothstep = 구현정의 하드스텝 → max(...,1.0) 가드 (G6).
+        float3 H       = normalize(L + V);
+        float  rimBand = smoothstep(-max(specWidthPx, 1.0), 0.0, sdf);
+        float  glint   = pow(max(dot(N, H), 0.0), specPower) * specStrength;     // float: pow bands in fp16
+        float  rim     = glint * rimBand;
+
+        // --- back-rim fill (반대편 광원, rim-locked, 1/4 가중) ---
+        float3 Lb   = normalize(float3(-lightVec, specLightZ));
+        float  back  = pow(max(dot(N, Lb), 0.0), specPower) * specStrength * rimBand * 0.25; // float: pow
+
+        // --- ordered dither: 넓은 body 램프의 8-bit Mach 밴드 깨기 ---
+        // lens-local 좌표를 fract로 bound 후 sin → 대형 렌즈서 sin 인자 폭주/줄무늬 붕괴 방지 (G5).
+        // specStrength를 곱해 off일 때 정확히 0 (F).
+        float2 hp = fract((p / minHalf) * 0.5 + 0.5);             // bounded ~[0,1)
+        float  dn = fract(sin(dot(hp, float2(12.9898, 78.233))) * 43758.5453) - 0.5;
+
+        // --- body(이동 핫스팟 + sheen + dither) <-> rim 선형 crossfade (monotonic, pure endpoint) ---
+        // rimMix=0 -> 순수 body(focal pool); rimMix=1 -> 순수 rim glint(과거 룩).
+        float body      = focalPool + bodySheen + dn * (1.0 / 255.0) * specStrength;
+        float rimMix    = clamp(specRimMix, 0.0, 1.0);
+        float highlight = body * (1.0 - rimMix) + (rim + back) * rimMix;
+
+        // Screen blend: 밝은 배경에서도 생존, [0,1]로 clamp → 1.0 초과 불가(스크린 블렌드 불변식 보장).
+        pixel.rgb += half3((1.0 - pixel.rgb) * clamp(highlight, 0.0, 1.0));
     }
 
     // Anti-aliased edge transition
@@ -167,9 +256,22 @@ uniform float saturation;
 uniform float contrast;
 uniform float4 tint;
 uniform float edge;
+uniform float2 lightDir;
+uniform float specStrength;
+uniform float specPower;
+uniform float specRimMix;     // 변경: was specSweep — body<->rim crossfade (D)
+uniform float specWidthPx;
+uniform float specLightZ;      // NEW
+uniform float specDomeFrac;    // NEW
+uniform float specBodyPower;   // NEW
+uniform float specBodyGain;    // NEW
+uniform float specFocalK;      // NEW: focal-pool offset toward light (fraction of minHalf)
+uniform float specPoolFrac;    // NEW: focal-pool radius (fraction of minHalf)
+uniform float specPoolGain;    // NEW: focal-pool peak scale
 uniform shader content;
 
 const float SMOOTH_EDGE_PX = 1.5;
+const float SEAM_BLEND_PX = 8.0;   // 대각 블렌드 반폭(px); 클수록 내부 크리스 부드러움
 
 // Signed distance to a box with rounded corners
 // Negative = inside, Positive = outside, Zero = on boundary
@@ -257,12 +359,88 @@ half4 main(float2 xy) {
 
     pixel.rgb = processColor(pixel.rgb, saturation, contrast, tint);
 
-    // Specular rim highlight
-    if (edge > 0.0) {
-        float rimBlend = smoothstep(-edge * 10.0, 0.0, sdf);
-        float2 lightVec = normalize(float2(-1.0, -1.0));
-        float specular = abs(dot(normal, lightVec));
-        pixel.rgb += half3(rimBlend * specular * edge);
+    // Specular highlight — a moving focal hotspot + a tight Blinn rim glint.
+    // 4 terms: focal pool (light pours across the face, dual-axis) + body sheen modeling fill
+    //          + tight Blinn rim glint + back-rim fill.
+    // 게이트가 specStrength도 검사 → NoGlow(specStrength==0)는 ALU 0 + bit-exact off (F).
+    // specStrength는 두 binding 모두 항상 set 되므로 게이트가 필요 uniform write를 막지 않음.
+    // specRimMix:   0 = 순수 body(focal pool), 1 = 순수 rim glint (crossfade)
+    // specPower:    rim/back lobe 샤프니스 (Blinn)
+    // specWidthPx:  rim band 두께, `edge`와 분리
+    // specStrength: peak highlight (screen-blended; <= 1.0)
+    // specLightZ/specDomeFrac/specBodyPower/specBodyGain: fake-3D bevel 라이팅
+    // specFocalK/specPoolFrac/specPoolGain: 빛이 면을 가로질러 흐르는 이동 핫스팟(양축)
+    if (edge > 0.0 && specStrength > 0.0) {
+        float2 lightVec = normalize(lightDir);
+
+        // --- seam-free in-plane direction (스페큘러 전용; 굴절이 읽는 'normal'은 불변) ---
+        // 굴절 경로(상단)는 hard-pick 'normal'을 그대로 사용한다(회귀 없음, G1).
+        // 여기서만 d.x==d.y 대각 크리스를 없앤 연속 방향을 따로 만든다.
+        // 둥근 사각형 내부는 L-inf 필드라 진짜 gradient는 대각에서 불연속 → 8px softmax로 블렌딩.
+        float2 d2 = abs(p) - halfDim + float2(r);                 // boxRoundedSDF와 동일 기저
+        float2 s2 = float2(p.x >= 0.0 ? 1.0 : -1.0, p.y >= 0.0 ? 1.0 : -1.0);
+        float2 specDir2;
+        if (max(d2.x, d2.y) > 0.0) {
+            specDir2 = s2 * normalize(max(d2, 0.0));              // 외부/코너: 해석적
+        } else {
+            // 내부: w->1 x-우세, ->0 y-우세, =0.5 대각 seam. +1e-4 = dead-center normalize 특이점 가드.
+            float w  = clamp(0.5 + 0.5 * (d2.x - d2.y) / SEAM_BLEND_PX, 0.0, 1.0);
+            float2 v = float2(s2.x * w, s2.y * (1.0 - w)) + float2(0.0, 1.0e-4);
+            specDir2 = normalize(v);
+        }
+
+        // --- fake-3D surface normal from the rounded-rect bevel ---
+        float minHalf = min(halfDim.x, halfDim.y);
+        float bevelPx = max(minHalf * specDomeFrac, 1.0);
+        float depthIn = max(-sdf, 0.0);
+        float t       = clamp(depthIn / bevelPx, 0.0, 1.0);
+        float n_cos   = 1.0 - t;                                  // 면내 크기
+        float n_sin   = sqrt(max(1.0 - n_cos * n_cos, 0.0));      // float: n_cos~1 근처 치명적 상쇄
+        float3 N      = normalize(float3(specDir2 * n_cos, n_sin + 1.0e-3));
+
+        float3 L = normalize(float3(lightVec, specLightZ));
+        float3 V = float3(0.0, 0.0, 1.0);
+
+        // --- MOVING FOCAL HOTSPOT — "light pours across the face on both axes" ---
+        // 핫스팟을 lightVec 방향으로 minHalf*specFocalK 만큼 옮긴다: pitch(lightVec.y)=수직,
+        // roll(lightVec.x)=수평 이동 → 이동하는 밝은 풀(둘 다 축). N≈+Z로 붕괴하던 옛 body sheen과
+        // 달리 면 전체에서 빛 방향을 강하게 따른다. inside 마스크로 렌즈 밖/림은 페이드.
+        float2 focal     = lightVec * (minHalf * specFocalK);     // lensCenter(=원점) 기준 오프셋
+        float  poolR     = max(minHalf * specPoolFrac, 1.0);      // 0 가드(zero-width smoothstep 회피)
+        float  poolD     = length(p - focal);
+        float  pool      = smoothstep(poolR, 0.0, poolD);         // 1 at focal, 0 at rim
+        float  inside    = smoothstep(0.0, -6.0, sdf);            // 렌즈 안쪽만(밖/경계 페이드)
+        float  focalPool = pool * pool * specStrength * specPoolGain * inside; // pool^2 = 더 단단한 코어
+
+        // --- broad body sheen (완만한 modeling fill, 핫스팟 위에 더함) ---
+        float ndl       = max(dot(N, L), 0.0);
+        float bodySheen = pow(ndl, specBodyPower) * specStrength * specBodyGain; // float: pow는 fp16서 밴딩
+
+        // --- tight Blinn rim glint, rim band에 한정 ---
+        // specWidthPx==0이면 zero-width smoothstep = 구현정의 하드스텝 → max(...,1.0) 가드 (G6).
+        float3 H       = normalize(L + V);
+        float  rimBand = smoothstep(-max(specWidthPx, 1.0), 0.0, sdf);
+        float  glint   = pow(max(dot(N, H), 0.0), specPower) * specStrength;     // float: pow bands in fp16
+        float  rim     = glint * rimBand;
+
+        // --- back-rim fill (반대편 광원, rim-locked, 1/4 가중) ---
+        float3 Lb   = normalize(float3(-lightVec, specLightZ));
+        float  back  = pow(max(dot(N, Lb), 0.0), specPower) * specStrength * rimBand * 0.25; // float: pow
+
+        // --- ordered dither: 넓은 body 램프의 8-bit Mach 밴드 깨기 ---
+        // lens-local 좌표를 fract로 bound 후 sin → 대형 렌즈서 sin 인자 폭주/줄무늬 붕괴 방지 (G5).
+        // specStrength를 곱해 off일 때 정확히 0 (F).
+        float2 hp = fract((p / minHalf) * 0.5 + 0.5);             // bounded ~[0,1)
+        float  dn = fract(sin(dot(hp, float2(12.9898, 78.233))) * 43758.5453) - 0.5;
+
+        // --- body(이동 핫스팟 + sheen + dither) <-> rim 선형 crossfade (monotonic, pure endpoint) ---
+        // rimMix=0 -> 순수 body(focal pool); rimMix=1 -> 순수 rim glint(과거 룩).
+        float body      = focalPool + bodySheen + dn * (1.0 / 255.0) * specStrength;
+        float rimMix    = clamp(specRimMix, 0.0, 1.0);
+        float highlight = body * (1.0 - rimMix) + (rim + back) * rimMix;
+
+        // Screen blend: 밝은 배경에서도 생존, [0,1]로 clamp → 1.0 초과 불가(스크린 블렌드 불변식 보장).
+        pixel.rgb += half3((1.0 - pixel.rgb) * clamp(highlight, 0.0, 1.0));
     }
 
     // Anti-aliased edge transition

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassShaderSource.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassShaderSource.kt
@@ -289,17 +289,21 @@ half4 main(float2 xy) {
         float  poolNorm = clamp(cPool * cPool, 0.0, 1.0);           // raw pool²(정규화) = modulator
         float  chroma  = chromaticIntensity * mix(1.0, poolNorm, chromaticModulate);
 
-        // tint-multiply 블렌드: chroma=0→불변, chroma=1→pixel*chromaRGB.
-        // 흰 카드는 background()가 liquidGlass 레이어 '뒤'에 그려져 content.eval()이 그 영역을 투명(a≈0)으로
-        // 돌려준다 → multiply는 보여줄 픽셀이 없다. 오버레이를 '얹는 재질'로 보이게: 빛나는 베이스(흰색이 깔린
-        // 것으로 가정)에 chromaRGB를 곱한 값과, 실제 content(불투명 사진 등) 위 tint-multiply를 content alpha로
-        // 보간하고, alpha를 chroma 만큼 끌어올린다. 불투명 content(a=1)면 정확히 기존 tint-multiply와 동일(무회귀).
-        // chromaticIntensity==0이면 이 블록 자체가 실행되지 않아 bit-exact off 보존.
+        // 두 경로가 정반대 블렌드를 원한다 → content alpha로 보간:
+        //   투명 베이스(a→0, 흰 카드): cOnWhite = chromaRGB. 흰(1,1,1)*무지개 = 순수 무지개. screen이면
+        //     흰 배경에서 1-(1-1)*(…)=1 로 무지개가 사라지므로 multiply(=흰*chromaRGB)가 맞다. 절대 불변.
+        //   불투명 베이스(a→1, 사진): cOnSrc = SCREEN(=어두워지지 않는 glow). multiply는 항상 값을 낮춰
+        //     (chromaRGB는 채널 하나가 항상 0) 어두운/컬러 픽셀을 탁하게 만든다(인물부 색조오염, 측정 -26%).
+        //     screen = pixel + (1-pixel)*chromaRGB*chroma 와 등가 → 항상 pixel 이상(밝아지는 방향),
+        //     1 self-limit(과포화/클립 없음), 흰 픽셀(=1)은 거의 불변. 어두운 인물부에도 무지개가 더해 보인다.
+        // 불투명 white(=1)는 screen이 1을 유지(흰 위에 glow를 더 못 얹음) — 물리적으로 옳고, 흰 '카드'는
+        // 투명 경로(a≈0)를 타므로 회귀 없음. chromaticIntensity==0이면 블록 미실행 → bit-exact off 보존.
         half  cChroma  = half(clamp(chroma, 0.0, 1.0));
-        half3 cOnWhite = half3(chromaRGB);                         // 흰 베이스(1,1,1) * chromaRGB = chromaRGB
-        half3 cOnSrc   = mix(pixel.rgb, pixel.rgb * half3(chromaRGB), cChroma); // 불투명 content 위 동작(불변)
-        pixel.rgb = mix(cOnWhite, cOnSrc, pixel.a);               // a=0→흰 위 무지개, a=1→기존 multiply
-        pixel.a   = max(pixel.a, cChroma);                        // 투명 배경에서도 오버레이가 보이도록
+        half3 cChromaRGB = half3(chromaRGB) * cChroma;            // chroma 가중 무지개(공유 항)
+        half3 cOnWhite = half3(chromaRGB);                        // 흰 베이스(1,1,1) * chromaRGB = chromaRGB(불변)
+        half3 cOnSrc   = half3(1.0) - (half3(1.0) - pixel.rgb) * (half3(1.0) - cChromaRGB); // SCREEN glow
+        pixel.rgb = mix(cOnWhite, cOnSrc, pixel.a);              // a=0→흰 위 무지개, a=1→screen glow
+        pixel.a   = max(pixel.a, cChroma);                       // 투명 배경에서도 오버레이가 보이도록
     }
 
     // Anti-aliased edge transition
@@ -566,17 +570,21 @@ half4 main(float2 xy) {
         float  poolNorm = clamp(cPool * cPool, 0.0, 1.0);           // raw pool²(정규화) = modulator
         float  chroma  = chromaticIntensity * mix(1.0, poolNorm, chromaticModulate);
 
-        // tint-multiply 블렌드: chroma=0→불변, chroma=1→pixel*chromaRGB.
-        // 흰 카드는 background()가 liquidGlass 레이어 '뒤'에 그려져 content.eval()이 그 영역을 투명(a≈0)으로
-        // 돌려준다 → multiply는 보여줄 픽셀이 없다. 오버레이를 '얹는 재질'로 보이게: 빛나는 베이스(흰색이 깔린
-        // 것으로 가정)에 chromaRGB를 곱한 값과, 실제 content(불투명 사진 등) 위 tint-multiply를 content alpha로
-        // 보간하고, alpha를 chroma 만큼 끌어올린다. 불투명 content(a=1)면 정확히 기존 tint-multiply와 동일(무회귀).
-        // chromaticIntensity==0이면 이 블록 자체가 실행되지 않아 bit-exact off 보존.
+        // 두 경로가 정반대 블렌드를 원한다 → content alpha로 보간:
+        //   투명 베이스(a→0, 흰 카드): cOnWhite = chromaRGB. 흰(1,1,1)*무지개 = 순수 무지개. screen이면
+        //     흰 배경에서 1-(1-1)*(…)=1 로 무지개가 사라지므로 multiply(=흰*chromaRGB)가 맞다. 절대 불변.
+        //   불투명 베이스(a→1, 사진): cOnSrc = SCREEN(=어두워지지 않는 glow). multiply는 항상 값을 낮춰
+        //     (chromaRGB는 채널 하나가 항상 0) 어두운/컬러 픽셀을 탁하게 만든다(인물부 색조오염, 측정 -26%).
+        //     screen = pixel + (1-pixel)*chromaRGB*chroma 와 등가 → 항상 pixel 이상(밝아지는 방향),
+        //     1 self-limit(과포화/클립 없음), 흰 픽셀(=1)은 거의 불변. 어두운 인물부에도 무지개가 더해 보인다.
+        // 불투명 white(=1)는 screen이 1을 유지(흰 위에 glow를 더 못 얹음) — 물리적으로 옳고, 흰 '카드'는
+        // 투명 경로(a≈0)를 타므로 회귀 없음. chromaticIntensity==0이면 블록 미실행 → bit-exact off 보존.
         half  cChroma  = half(clamp(chroma, 0.0, 1.0));
-        half3 cOnWhite = half3(chromaRGB);                         // 흰 베이스(1,1,1) * chromaRGB = chromaRGB
-        half3 cOnSrc   = mix(pixel.rgb, pixel.rgb * half3(chromaRGB), cChroma); // 불투명 content 위 동작(불변)
-        pixel.rgb = mix(cOnWhite, cOnSrc, pixel.a);               // a=0→흰 위 무지개, a=1→기존 multiply
-        pixel.a   = max(pixel.a, cChroma);                        // 투명 배경에서도 오버레이가 보이도록
+        half3 cChromaRGB = half3(chromaRGB) * cChroma;            // chroma 가중 무지개(공유 항)
+        half3 cOnWhite = half3(chromaRGB);                        // 흰 베이스(1,1,1) * chromaRGB = chromaRGB(불변)
+        half3 cOnSrc   = half3(1.0) - (half3(1.0) - pixel.rgb) * (half3(1.0) - cChromaRGB); // SCREEN glow
+        pixel.rgb = mix(cOnWhite, cOnSrc, pixel.a);              // a=0→흰 위 무지개, a=1→screen glow
+        pixel.a   = max(pixel.a, cChroma);                       // 투명 배경에서도 오버레이가 보이도록
     }
 
     // Anti-aliased edge transition

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassShaderSource.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassShaderSource.kt
@@ -59,6 +59,12 @@ uniform float specBodyGain;    // NEW
 uniform float specFocalK;      // NEW: focal-pool offset toward light (fraction of minHalf)
 uniform float specPoolFrac;    // NEW: focal-pool radius (fraction of minHalf)
 uniform float specPoolGain;    // NEW: focal-pool peak scale
+uniform float chromaticIntensity;  // NEW: 0 = off (bit-exact, ALU 0). 0..1 iridescent overlay strength
+uniform float chromaticMode;       // NEW: 0 = Iridescent (thin-film), 1 = Foil (flowing bands); float enum
+uniform float chromaticBands;      // NEW: Foil rainbow band count along the light direction (e.g. 3)
+uniform float chromaticCycles;     // NEW: Iridescent hue cycles across the light/normal angle (e.g. 1.5)
+uniform float chromaticPhase;      // NEW: static hue phase offset (radians-free, fract domain; e.g. 0)
+uniform float chromaticModulate;   // NEW: 0..1, modulate rainbow strength by the focal pool (e.g. 1)
 uniform shader content;
 
 const float SMOOTH_EDGE_PX = 1.5;
@@ -232,6 +238,59 @@ half4 main(float2 xy) {
 
         // Screen blend: 밝은 배경에서도 생존, [0,1]로 clamp → 1.0 초과 불가(스크린 블렌드 불변식 보장).
         pixel.rgb += half3((1.0 - pixel.rgb) * clamp(highlight, 0.0, 1.0));
+    }
+
+    // Chromatic overlay — light-reactive iridescent sheen, independent of the white specular pool.
+    // 흰색 specular(screen-blend) 위에 별도로 얹는 무지갯빛 항. specular와 분리된 자체 게이트라
+    // chromaticIntensity==0이면 pixel.rgb 수정 0 → 기존 룩과 bit-exact, ALU 0 (uniform 분기).
+    // specular 게이트(edge/specStrength)와 독립 → specular off에서도 무지개만 켤 수 있다.
+    // 두 모드: 0 = Iridescent(박막 간섭, 빛/노멀 각도로 hue), 1 = Foil(빛 방향 투영, lightVec 움직이면 띠가 흐른다).
+    // hue·HSV→RGB 산술 체인은 전부 float/float3 — AGSL half(fp16)는 채도 만점 무지개에 밴딩이 심함.
+    // 블렌드는 tint-multiply(흰 카드도 chromaRGB로 채색); screen은 흰 배경(pixel≈1)에서 무지개가 사라짐.
+    if (chromaticIntensity > 0.0) {
+        // 공유 스칼라 재계산(specular 게이트 밖 → 독립). lightDir/halfDim/sdf/p는 main 스코프에서 그대로.
+        float2 cLightVec = normalize(lightDir);                       // 빛 방향(2D), specular의 lightVec와 동일식
+        float  cMinHalf  = min(halfDim.x, halfDim.y);                 // p 정규화 기준(specular minHalf와 동일)
+        float2 pNorm     = p / cMinHalf;                              // lens-local 정규화 좌표(~[-1,1]); px면 fract 앨리어싱
+
+        // bevel 노멀/광원 3D 재구성(Iridescent용 dot(N,L)). specular :183-192와 동일 수식, chroma-local 이름.
+        float2 cD2 = abs(p) - halfDim + float2(r);                    // boxRoundedSDF와 동일 기저
+        float2 cS2 = float2(p.x >= 0.0 ? 1.0 : -1.0, p.y >= 0.0 ? 1.0 : -1.0);
+        float2 cSpecDir;
+        if (max(cD2.x, cD2.y) > 0.0) {
+            cSpecDir = cS2 * normalize(max(cD2, 0.0));                // 외부/코너: 해석적
+        } else {
+            float cw  = clamp(0.5 + 0.5 * (cD2.x - cD2.y) / SEAM_BLEND_PX, 0.0, 1.0);
+            float2 cv = float2(cS2.x * cw, cS2.y * (1.0 - cw)) + float2(0.0, 1.0e-4);
+            cSpecDir  = normalize(cv);                                // 내부: seam-free softmax
+        }
+        float  cBevelPx = max(cMinHalf * specDomeFrac, 1.0);
+        float  cT       = clamp(max(-sdf, 0.0) / cBevelPx, 0.0, 1.0);
+        float  cNcos    = 1.0 - cT;
+        float  cNsin    = sqrt(max(1.0 - cNcos * cNcos, 0.0));        // n_cos~1 상쇄 가드(float)
+        float3 cN       = normalize(float3(cSpecDir * cNcos, cNsin + 1.0e-3));
+        float3 cL       = normalize(float3(cLightVec, specLightZ));
+
+        // hue 합성 — 두 모드(전 체인 float). Foil: 표면을 빛에 투영 → 빛 움직이면 띠가 흐름.
+        //                                Iridescent: 빛/노멀 각도 → 박막 간섭처럼 hue가 돈다.
+        float hueF = fract(dot(pNorm, cLightVec) * chromaticBands + chromaticPhase);
+        float hueI = fract(dot(cN, cL) * chromaticCycles + chromaticPhase);
+        float hue  = mix(hueI, hueF, chromaticMode);                 // mode 0→Iridescent, 1→Foil
+        // 6-세그먼트 HSV(채도/명도=1)→RGB 램프(float3). half3로 받으면 fp16 양자화로 밴딩.
+        float3 chromaRGB = clamp(
+            abs(fract(float3(hue) + float3(0.0, 2.0 / 3.0, 1.0 / 3.0)) * 6.0 - 3.0) - 1.0,
+            0.0, 1.0);
+
+        // focal-pool 모듈레이션 — specular의 raw pool²(정규화본; specStrength/Gain 곱 전)으로 무지개 세기 변조.
+        // specular 게이트 밖이라 pool을 저렴하게 재계산(length+smoothstep 몇 줄): focal/poolR 식은 specular와 동일.
+        float2 cFocal  = cLightVec * (cMinHalf * specFocalK);        // 빛 방향 오프셋(lensCenter=원점 기준)
+        float  cPoolR  = max(cMinHalf * specPoolFrac, 1.0);          // zero-width smoothstep 가드
+        float  cPool   = smoothstep(cPoolR, 0.0, length(p - cFocal));// 1 at focal, 0 at rim
+        float  poolNorm = clamp(cPool * cPool, 0.0, 1.0);           // raw pool²(정규화) = modulator
+        float  chroma  = chromaticIntensity * mix(1.0, poolNorm, chromaticModulate);
+
+        // tint-multiply 블렌드: chroma=0→불변, chroma=1→pixel*chromaRGB. 흰 배경이 chromaRGB로 물든다.
+        pixel.rgb = mix(pixel.rgb, pixel.rgb * half3(chromaRGB), clamp(chroma, 0.0, 1.0));
     }
 
     // Anti-aliased edge transition
@@ -268,6 +327,12 @@ uniform float specBodyGain;    // NEW
 uniform float specFocalK;      // NEW: focal-pool offset toward light (fraction of minHalf)
 uniform float specPoolFrac;    // NEW: focal-pool radius (fraction of minHalf)
 uniform float specPoolGain;    // NEW: focal-pool peak scale
+uniform float chromaticIntensity;  // NEW: 0 = off (bit-exact, ALU 0). 0..1 iridescent overlay strength
+uniform float chromaticMode;       // NEW: 0 = Iridescent (thin-film), 1 = Foil (flowing bands); float enum
+uniform float chromaticBands;      // NEW: Foil rainbow band count along the light direction (e.g. 3)
+uniform float chromaticCycles;     // NEW: Iridescent hue cycles across the light/normal angle (e.g. 1.5)
+uniform float chromaticPhase;      // NEW: static hue phase offset (radians-free, fract domain; e.g. 0)
+uniform float chromaticModulate;   // NEW: 0..1, modulate rainbow strength by the focal pool (e.g. 1)
 uniform shader content;
 
 const float SMOOTH_EDGE_PX = 1.5;
@@ -441,6 +506,59 @@ half4 main(float2 xy) {
 
         // Screen blend: 밝은 배경에서도 생존, [0,1]로 clamp → 1.0 초과 불가(스크린 블렌드 불변식 보장).
         pixel.rgb += half3((1.0 - pixel.rgb) * clamp(highlight, 0.0, 1.0));
+    }
+
+    // Chromatic overlay — light-reactive iridescent sheen, independent of the white specular pool.
+    // 흰색 specular(screen-blend) 위에 별도로 얹는 무지갯빛 항. specular와 분리된 자체 게이트라
+    // chromaticIntensity==0이면 pixel.rgb 수정 0 → 기존 룩과 bit-exact, ALU 0 (uniform 분기).
+    // specular 게이트(edge/specStrength)와 독립 → specular off에서도 무지개만 켤 수 있다.
+    // 두 모드: 0 = Iridescent(박막 간섭, 빛/노멀 각도로 hue), 1 = Foil(빛 방향 투영, lightVec 움직이면 띠가 흐른다).
+    // hue·HSV→RGB 산술 체인은 전부 float/float3 — AGSL half(fp16)는 채도 만점 무지개에 밴딩이 심함.
+    // 블렌드는 tint-multiply(흰 카드도 chromaRGB로 채색); screen은 흰 배경(pixel≈1)에서 무지개가 사라짐.
+    if (chromaticIntensity > 0.0) {
+        // 공유 스칼라 재계산(specular 게이트 밖 → 독립). lightDir/halfDim/sdf/p는 main 스코프에서 그대로.
+        float2 cLightVec = normalize(lightDir);                       // 빛 방향(2D), specular의 lightVec와 동일식
+        float  cMinHalf  = min(halfDim.x, halfDim.y);                 // p 정규화 기준(specular minHalf와 동일)
+        float2 pNorm     = p / cMinHalf;                              // lens-local 정규화 좌표(~[-1,1]); px면 fract 앨리어싱
+
+        // bevel 노멀/광원 3D 재구성(Iridescent용 dot(N,L)). specular :183-192와 동일 수식, chroma-local 이름.
+        float2 cD2 = abs(p) - halfDim + float2(r);                    // boxRoundedSDF와 동일 기저
+        float2 cS2 = float2(p.x >= 0.0 ? 1.0 : -1.0, p.y >= 0.0 ? 1.0 : -1.0);
+        float2 cSpecDir;
+        if (max(cD2.x, cD2.y) > 0.0) {
+            cSpecDir = cS2 * normalize(max(cD2, 0.0));                // 외부/코너: 해석적
+        } else {
+            float cw  = clamp(0.5 + 0.5 * (cD2.x - cD2.y) / SEAM_BLEND_PX, 0.0, 1.0);
+            float2 cv = float2(cS2.x * cw, cS2.y * (1.0 - cw)) + float2(0.0, 1.0e-4);
+            cSpecDir  = normalize(cv);                                // 내부: seam-free softmax
+        }
+        float  cBevelPx = max(cMinHalf * specDomeFrac, 1.0);
+        float  cT       = clamp(max(-sdf, 0.0) / cBevelPx, 0.0, 1.0);
+        float  cNcos    = 1.0 - cT;
+        float  cNsin    = sqrt(max(1.0 - cNcos * cNcos, 0.0));        // n_cos~1 상쇄 가드(float)
+        float3 cN       = normalize(float3(cSpecDir * cNcos, cNsin + 1.0e-3));
+        float3 cL       = normalize(float3(cLightVec, specLightZ));
+
+        // hue 합성 — 두 모드(전 체인 float). Foil: 표면을 빛에 투영 → 빛 움직이면 띠가 흐름.
+        //                                Iridescent: 빛/노멀 각도 → 박막 간섭처럼 hue가 돈다.
+        float hueF = fract(dot(pNorm, cLightVec) * chromaticBands + chromaticPhase);
+        float hueI = fract(dot(cN, cL) * chromaticCycles + chromaticPhase);
+        float hue  = mix(hueI, hueF, chromaticMode);                 // mode 0→Iridescent, 1→Foil
+        // 6-세그먼트 HSV(채도/명도=1)→RGB 램프(float3). half3로 받으면 fp16 양자화로 밴딩.
+        float3 chromaRGB = clamp(
+            abs(fract(float3(hue) + float3(0.0, 2.0 / 3.0, 1.0 / 3.0)) * 6.0 - 3.0) - 1.0,
+            0.0, 1.0);
+
+        // focal-pool 모듈레이션 — specular의 raw pool²(정규화본; specStrength/Gain 곱 전)으로 무지개 세기 변조.
+        // specular 게이트 밖이라 pool을 저렴하게 재계산(length+smoothstep 몇 줄): focal/poolR 식은 specular와 동일.
+        float2 cFocal  = cLightVec * (cMinHalf * specFocalK);        // 빛 방향 오프셋(lensCenter=원점 기준)
+        float  cPoolR  = max(cMinHalf * specPoolFrac, 1.0);          // zero-width smoothstep 가드
+        float  cPool   = smoothstep(cPoolR, 0.0, length(p - cFocal));// 1 at focal, 0 at rim
+        float  poolNorm = clamp(cPool * cPool, 0.0, 1.0);           // raw pool²(정규화) = modulator
+        float  chroma  = chromaticIntensity * mix(1.0, poolNorm, chromaticModulate);
+
+        // tint-multiply 블렌드: chroma=0→불변, chroma=1→pixel*chromaRGB. 흰 배경이 chromaRGB로 물든다.
+        pixel.rgb = mix(pixel.rgb, pixel.rgb * half3(chromaRGB), clamp(chroma, 0.0, 1.0));
     }
 
     // Anti-aliased edge transition

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassShaderSource.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassShaderSource.kt
@@ -199,8 +199,8 @@ half4 main(float2 xy) {
         float2 focal     = lightVec * (minHalf * specFocalK);     // lensCenter(=원점) 기준 오프셋
         float  poolR     = max(minHalf * specPoolFrac, 1.0);      // 0 가드(zero-width smoothstep 회피)
         float  poolD     = length(p - focal);
-        float  pool      = smoothstep(poolR, 0.0, poolD);         // 1 at focal, 0 at rim
-        float  inside    = smoothstep(0.0, -6.0, sdf);            // 렌즈 안쪽만(밖/경계 페이드)
+        float  pool      = 1.0 - smoothstep(0.0, poolR, poolD);   // 1 at focal, 0 at rim (edge0<edge1)
+        float  inside    = 1.0 - smoothstep(-6.0, 0.0, sdf);      // 렌즈 안쪽만(밖/경계 페이드; edge0<edge1)
         float  focalPool = pool * pool * specStrength * specPoolGain * inside; // pool^2 = 더 단단한 코어
 
         // --- broad body sheen (완만한 modeling fill, 핫스팟 위에 더함) ---
@@ -408,8 +408,8 @@ half4 main(float2 xy) {
         float2 focal     = lightVec * (minHalf * specFocalK);     // lensCenter(=원점) 기준 오프셋
         float  poolR     = max(minHalf * specPoolFrac, 1.0);      // 0 가드(zero-width smoothstep 회피)
         float  poolD     = length(p - focal);
-        float  pool      = smoothstep(poolR, 0.0, poolD);         // 1 at focal, 0 at rim
-        float  inside    = smoothstep(0.0, -6.0, sdf);            // 렌즈 안쪽만(밖/경계 페이드)
+        float  pool      = 1.0 - smoothstep(0.0, poolR, poolD);   // 1 at focal, 0 at rim (edge0<edge1)
+        float  inside    = 1.0 - smoothstep(-6.0, 0.0, sdf);      // 렌즈 안쪽만(밖/경계 페이드; edge0<edge1)
         float  focalPool = pool * pool * specStrength * specPoolGain * inside; // pool^2 = 더 단단한 코어
 
         // --- broad body sheen (완만한 modeling fill, 핫스팟 위에 더함) ---

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassShaderSource.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassShaderSource.kt
@@ -16,25 +16,18 @@
 package com.skydoves.cloudy
 
 /**
- * Cloudy's Liquid Glass shader implementation for creating realistic glass lens distortion effects.
+ * Liquid Glass shader for realistic glass lens distortion effects.
  *
- * This GPU shader provides an interactive liquid glass visualization featuring:
- * - Smooth-cornered rectangular lens geometry with configurable radius
- * - Physically-inspired light bending through curved glass surfaces
- * - RGB wavelength separation for prismatic color fringing
- * - Real-time color manipulation (vibrancy, intensity, overlay)
- * - Specular rim highlights with directional illumination
- * - Sub-pixel edge smoothing for crisp boundaries
+ * Features: rounded-rect lens geometry, light bending through a curved surface,
+ * RGB wavelength separation, color processing (vibrancy/intensity/overlay),
+ * specular rim highlights, and a light-reactive chromatic overlay.
  *
- * Pair with [Modifier.cloudy] for combined blur + glass aesthetics.
- *
- * Supports AGSL (Android 13+) and SKSL (Skia-based platforms).
+ * Pair with [Modifier.cloudy] for combined blur + glass. Supports AGSL (Android 13+)
+ * and SKSL (Skia-based platforms).
  */
 public object LiquidGlassShaderSource {
 
-  /**
-   * AGSL shader for Android RuntimeShader (API 33+).
-   */
+  /** AGSL shader for Android RuntimeShader (API 33+). */
   public const val AGSL: String = """
 uniform float2 resolution;
 uniform float2 lensCenter;
@@ -50,78 +43,65 @@ uniform float edge;
 uniform float2 lightDir;
 uniform float specStrength;
 uniform float specPower;
-uniform float specRimMix;     // 변경: was specSweep — body<->rim crossfade (D)
+uniform float specRimMix;     // body<->rim crossfade
 uniform float specWidthPx;
-uniform float specLightZ;      // NEW
-uniform float specDomeFrac;    // NEW
-uniform float specBodyPower;   // NEW
-uniform float specBodyGain;    // NEW
-uniform float specFocalK;      // NEW: focal-pool offset toward light (fraction of minHalf)
-uniform float specPoolFrac;    // NEW: focal-pool radius (fraction of minHalf)
-uniform float specPoolGain;    // NEW: focal-pool peak scale
-uniform float chromaticIntensity;  // NEW: 0 = off (bit-exact, ALU 0). 0..1 iridescent overlay strength
-uniform float chromaticMode;       // NEW: 0 = Iridescent (thin-film), 1 = Foil (flowing bands); float enum
-uniform float chromaticBands;      // NEW: Foil rainbow band count along the light direction (e.g. 3)
-uniform float chromaticCycles;     // NEW: Iridescent hue cycles across the light/normal angle (e.g. 1.5)
-uniform float chromaticPhase;      // NEW: static hue phase offset (radians-free, fract domain; e.g. 0)
-uniform float chromaticModulate;   // NEW: 0..1, modulate rainbow strength by the focal pool (e.g. 1)
+uniform float specLightZ;
+uniform float specDomeFrac;
+uniform float specBodyPower;
+uniform float specBodyGain;
+uniform float specFocalK;          // focal-pool offset toward light (fraction of minHalf)
+uniform float specPoolFrac;        // focal-pool radius (fraction of minHalf)
+uniform float specPoolGain;        // focal-pool peak scale
+uniform float chromaticIntensity;  // 0 = off (bit-exact, ALU 0). 0..1 overlay strength
+uniform float chromaticMode;       // float enum: 0 Iridescent, 1 Foil, 2..5 named looks
+uniform float chromaticBands;      // Foil rainbow band count along the light direction
+uniform float chromaticCycles;     // Iridescent hue cycles across the light/normal angle
+uniform float chromaticPhase;      // static hue phase offset (fract domain)
+uniform float chromaticModulate;   // 0..1, modulate rainbow strength by the focal pool
 uniform shader content;
 
 const float SMOOTH_EDGE_PX = 1.5;
-const float SEAM_BLEND_PX = 8.0;   // 대각 블렌드 반폭(px); 클수록 내부 크리스 부드러움
+const float SEAM_BLEND_PX = 8.0;   // diagonal-seam blend half-width (px)
 
-// --- Thin-film interference (Iridescent / Holographic) constants ---
-// OPD 모델: opd ≈ (thickness / cos(refr)) → Newton's rings. thickness=bevel 깊이 cT(중심0→림1),
-// cosT=cos(입사각, 빛 반응). 림으로 갈수록 막이 두꺼워 밴드가 촘촘(고전 박막), 빛이 돌면 위상 쓸림.
-const float CHROMA_OPD_GAIN  = 3.0;   // 면 위 Newton 밴드 수(높을수록 다밴드; 너무 크면 aliasing/busy)
-const float CHROMA_OPD_BASE  = 0.10;  // 기저 막 차수(중심 저OPD를 밝은 은백 0차에 두고 밖으로 색이 쌓임)
-// thickness↔light 가중: 1=순수 두께링, 0=순수 빛각도. 두 효과 블렌드(둘 다 holographic에 기여).
-const float CHROMA_THICK_MIX = 0.55;
-// per-channel 파수비(파장 역수 ~650/560/470nm). 벌릴수록 금→자홍→청록 Newton 분리가 또렷.
-const float3 CHROMA_KRGB     = float3(1.0, 1.18, 1.42);
-// 금속 floor: 채널이 0까지 안 떨어지게(형광 무지개 아님). 낮게 둬 채도 살리되 0은 아님.
-const float CHROMA_METAL_FLOOR = 0.12;
-// 고차 coherence wash-out 율. 클수록 빨리 은백(파스텔↑·busy↓). 외곽 고차 링을 silver로 진정.
-const float CHROMA_WASHOUT     = 0.16;
+// Thin-film interference (Iridescent / Holographic) base set.
+// opd ~ thickness/cos(refr) (Newton's rings): thickness = bevel depth (center 0 -> rim 1),
+// cosT = cos(incidence) (light-reactive). Thicker film at the rim -> denser bands.
+const float CHROMA_OPD_GAIN  = 3.0;   // Newton band count (too high -> aliasing/busy)
+const float CHROMA_OPD_BASE  = 0.10;  // base film order (low-OPD center sits at silver 0th)
+const float CHROMA_THICK_MIX = 0.55;  // 1 = pure thickness rings, 0 = pure light angle
+const float3 CHROMA_KRGB     = float3(1.0, 1.18, 1.42); // wavenumber ratio (~650/560/470nm)
+const float CHROMA_METAL_FLOOR = 0.12; // keep channels off 0 (metal, not neon)
+const float CHROMA_WASHOUT     = 0.16; // higher-order wash-out to silver
 
-// --- Named holographic looks (chromaticMode 2..5) ---
-// mode 0 (Iridescent) = 위 CHROMA_* 베이스 그대로(bit-exact 무회귀), mode 1 (Foil) = 선형 띠(불변).
-// 신규 4종은 같은 thin-film 경로를 타되 아래 per-look 세트(밴드밀도·채널분리·콘트라스트·파스텔율·
-// 빛추종)를 branchless step-mask로 고른다. 셰이더 안 mode 분기 → 새 uniform 0개(설계 B).
-// 각 세트는 실기기(S25) 실측으로 4종이 확연히 구분되게 벌렸다.
-// 필드: OPD_GAIN(밴드 수), KRGB(금↔청록 분리), METAL_FLOOR(콘트라스트; 낮을수록↑), WASHOUT(파스텔율;
-//       높을수록 은백), MOD(focal-pool 추종 = "빛 반사처럼 깔리는" 세기; 셰이더 내부 효과 modulate).
-// OilSlick: 촘촘 다밴드 + 넓은 분리 + 저washout(고채도) + 강한 빛추종 → 기름막.
+// Named holographic looks (chromaticMode 2..5). Same thin-film path, per-look set picked
+// by a branchless step-mask (no in-shader mode branch, no extra uniform). mode 0/1 keep the
+// base constants bit-exact. Fields: GAIN (band count), KRGB (gold<->cyan split), FLOOR
+// (contrast, lower = more), WASHOUT (pastel rate), MOD (focal-pool follow strength).
 const float CHROMA_OIL_GAIN       = 5.5;
 const float3 CHROMA_OIL_KRGB      = float3(1.0, 1.30, 1.72);
 const float CHROMA_OIL_FLOOR      = 0.05;
 const float CHROMA_OIL_WASHOUT    = 0.07;
 const float CHROMA_OIL_MOD        = 0.75;
-// SoapBubble: 넓은 띠(저밀도) + 높은 washout(파스텔·은백) + 약한 빛추종(면 균일) → 비눗방울.
 const float CHROMA_SOAP_GAIN      = 1.7;
 const float3 CHROMA_SOAP_KRGB     = float3(1.0, 1.11, 1.26);
 const float CHROMA_SOAP_FLOOR     = 0.22;
 const float CHROMA_SOAP_WASHOUT   = 0.50;
 const float CHROMA_SOAP_MOD       = 0.22;
-// MetallicFoil: 저washout(채도유지) + 저floor(콘트라스트↑) + 강한 빛추종 → 강한 고채도 금속박.
 const float CHROMA_FOILM_GAIN     = 3.6;
 const float3 CHROMA_FOILM_KRGB    = float3(1.0, 1.26, 1.62);
 const float CHROMA_FOILM_FLOOR    = 0.03;
 const float CHROMA_FOILM_WASHOUT  = 0.05;
 const float CHROMA_FOILM_MOD      = 0.82;
-// Pearl: 높은 washout(파스텔) + 높은 floor(저콘트라스트 은백) + 좁은 분리 → 은은한 진주.
 const float CHROMA_PEARL_GAIN     = 2.4;
 const float3 CHROMA_PEARL_KRGB    = float3(1.0, 1.07, 1.18);
 const float CHROMA_PEARL_FLOOR    = 0.46;
 const float CHROMA_PEARL_WASHOUT  = 0.58;
 const float CHROMA_PEARL_MOD      = 0.20;
-// Fresnel rim 부스트 — 가장자리(cT→1)서 무지개를 더 밝게(유리 림에 빛 걸림).
-// MetallicFoil/Pearl에만 가산(아래 mFoilM/mPearl 마스크). 저비용 1항.
+// Fresnel rim boost (cT->1), added for MetallicFoil/Pearl only.
 const float CHROMA_RIM_POW        = 3.0;
 const float CHROMA_RIM_GAIN       = 0.45;
 
-// Signed distance to a box with rounded corners
-// Negative = inside, Positive = outside, Zero = on boundary
+// Signed distance to a rounded-corner box. Negative inside, positive outside.
 float boxRoundedSDF(float2 p, float2 halfDim, float r) {
     float2 d = abs(p) - halfDim + float2(r);
     float exterior = length(max(d, 0.0));
@@ -129,7 +109,7 @@ float boxRoundedSDF(float2 p, float2 halfDim, float r) {
     return exterior + interior - r;
 }
 
-// Outward-facing direction vector from the lens surface
+// Outward-facing direction from the lens surface.
 float2 lensNormalDirection(float2 p, float2 halfDim, float r) {
     float2 d = abs(p) - halfDim + float2(r);
     float2 s = float2(p.x >= 0.0 ? 1.0 : -1.0, p.y >= 0.0 ? 1.0 : -1.0);
@@ -140,12 +120,12 @@ float2 lensNormalDirection(float2 p, float2 halfDim, float r) {
     return d.x > d.y ? float2(s.x, 0.0) : float2(0.0, s.y);
 }
 
-// Perceptual brightness (ITU-R BT.709 standard)
+// Perceptual brightness (ITU-R BT.709).
 float toBrightness(half3 c) {
     return dot(c, half3(0.2126, 0.7152, 0.0722));
 }
 
-// Color processing: vibrancy, intensity adjustment, and color overlay
+// Vibrancy, intensity adjustment, and color overlay.
 half3 processColor(half3 src, float vibrancy, float intensity, float4 overlay) {
     float mono = toBrightness(src);
     half3 vibrant = half3(clamp(mix(half3(mono), src, vibrancy), 0.0, 1.0));
@@ -206,143 +186,125 @@ half4 main(float2 xy) {
 
     pixel.rgb = processColor(pixel.rgb, saturation, contrast, tint);
 
-    // Specular highlight — a moving focal hotspot + a tight Blinn rim glint.
-    // 4 terms: focal pool (light pours across the face, dual-axis) + body sheen modeling fill
-    //          + tight Blinn rim glint + back-rim fill.
-    // 게이트가 specStrength도 검사 → NoGlow(specStrength==0)는 ALU 0 + bit-exact off (F).
-    // specStrength는 두 binding 모두 항상 set 되므로 게이트가 필요 uniform write를 막지 않음.
-    // specRimMix:   0 = 순수 body(focal pool), 1 = 순수 rim glint (crossfade)
-    // specPower:    rim/back lobe 샤프니스 (Blinn)
-    // specWidthPx:  rim band 두께, `edge`와 분리
-    // specStrength: peak highlight (screen-blended; <= 1.0)
-    // specLightZ/specDomeFrac/specBodyPower/specBodyGain: fake-3D bevel 라이팅
-    // specFocalK/specPoolFrac/specPoolGain: 빛이 면을 가로질러 흐르는 이동 핫스팟(양축)
+    // Specular highlight: moving focal pool + body sheen + tight Blinn rim glint + back-rim fill.
+    // Gate also checks specStrength so specStrength==0 is ALU 0 + bit-exact off.
+    //   specRimMix 0 = pure body (focal pool), 1 = pure rim glint
+    //   specPower  rim/back lobe sharpness (Blinn); specWidthPx rim band thickness
+    //   specStrength peak highlight (screen-blended, <= 1.0)
+    //   specLightZ/specDomeFrac/specBodyPower/specBodyGain  fake-3D bevel lighting
+    //   specFocalK/specPoolFrac/specPoolGain  dual-axis moving hotspot
     if (edge > 0.0 && specStrength > 0.0) {
         float2 lightVec = normalize(lightDir);
 
-        // --- seam-free in-plane direction (스페큘러 전용; 굴절이 읽는 'normal'은 불변) ---
-        // 굴절 경로(상단)는 hard-pick 'normal'을 그대로 사용한다(회귀 없음, G1).
-        // 여기서만 d.x==d.y 대각 크리스를 없앤 연속 방향을 따로 만든다.
-        // 둥근 사각형 내부는 L-inf 필드라 진짜 gradient는 대각에서 불연속 → 8px softmax로 블렌딩.
-        float2 d2 = abs(p) - halfDim + float2(r);                 // boxRoundedSDF와 동일 기저
+        // Seam-free in-plane direction (specular only; refraction's 'normal' is unchanged).
+        // Rounded-rect interior is an L-inf field, so the gradient is discontinuous on the
+        // diagonal -> blend with an 8px softmax.
+        float2 d2 = abs(p) - halfDim + float2(r);
         float2 s2 = float2(p.x >= 0.0 ? 1.0 : -1.0, p.y >= 0.0 ? 1.0 : -1.0);
         float2 specDir2;
         if (max(d2.x, d2.y) > 0.0) {
-            specDir2 = s2 * normalize(max(d2, 0.0));              // 외부/코너: 해석적
+            specDir2 = s2 * normalize(max(d2, 0.0));
         } else {
-            // 내부: w->1 x-우세, ->0 y-우세, =0.5 대각 seam. +1e-4 = dead-center normalize 특이점 가드.
+            // w->1 x-dominant, ->0 y-dominant, =0.5 diagonal seam. +1e-4 guards normalize at dead center.
             float w  = clamp(0.5 + 0.5 * (d2.x - d2.y) / SEAM_BLEND_PX, 0.0, 1.0);
             float2 v = float2(s2.x * w, s2.y * (1.0 - w)) + float2(0.0, 1.0e-4);
             specDir2 = normalize(v);
         }
 
-        // --- fake-3D surface normal from the rounded-rect bevel ---
+        // Fake-3D surface normal from the rounded-rect bevel.
         float minHalf = min(halfDim.x, halfDim.y);
         float bevelPx = max(minHalf * specDomeFrac, 1.0);
         float depthIn = max(-sdf, 0.0);
         float t       = clamp(depthIn / bevelPx, 0.0, 1.0);
-        float n_cos   = 1.0 - t;                                  // 면내 크기
-        float n_sin   = sqrt(max(1.0 - n_cos * n_cos, 0.0));      // float: n_cos~1 근처 치명적 상쇄
+        float n_cos   = 1.0 - t;
+        float n_sin   = sqrt(max(1.0 - n_cos * n_cos, 0.0));      // float: catastrophic cancellation near n_cos~1
         float3 N      = normalize(float3(specDir2 * n_cos, n_sin + 1.0e-3));
 
         float3 L = normalize(float3(lightVec, specLightZ));
         float3 V = float3(0.0, 0.0, 1.0);
 
-        // --- MOVING FOCAL HOTSPOT — "light pours across the face on both axes" ---
-        // 핫스팟을 lightVec 방향으로 minHalf*specFocalK 만큼 옮긴다: pitch(lightVec.y)=수직,
-        // roll(lightVec.x)=수평 이동 → 이동하는 밝은 풀(둘 다 축). N≈+Z로 붕괴하던 옛 body sheen과
-        // 달리 면 전체에서 빛 방향을 강하게 따른다. inside 마스크로 렌즈 밖/림은 페이드.
-        float2 focal     = lightVec * (minHalf * specFocalK);     // lensCenter(=원점) 기준 오프셋
-        float  poolR     = max(minHalf * specPoolFrac, 1.0);      // 0 가드(zero-width smoothstep 회피)
+        // Moving focal hotspot: shift the pool by minHalf*specFocalK along lightVec so it
+        // tracks the light on both axes (pitch=lightVec.y, roll=lightVec.x). inside fades the rim.
+        float2 focal     = lightVec * (minHalf * specFocalK);
+        float  poolR     = max(minHalf * specPoolFrac, 1.0);      // guard zero-width smoothstep
         float  poolD     = length(p - focal);
-        float  pool      = 1.0 - smoothstep(0.0, poolR, poolD);   // 1 at focal, 0 at rim (edge0<edge1)
-        float  inside    = 1.0 - smoothstep(-6.0, 0.0, sdf);      // 렌즈 안쪽만(밖/경계 페이드; edge0<edge1)
-        float  focalPool = pool * pool * specStrength * specPoolGain * inside; // pool^2 = 더 단단한 코어
+        float  pool      = 1.0 - smoothstep(0.0, poolR, poolD);   // edge0<edge1; 1 at focal, 0 at rim
+        float  inside    = 1.0 - smoothstep(-6.0, 0.0, sdf);      // lens interior only
+        float  focalPool = pool * pool * specStrength * specPoolGain * inside; // pool^2 = harder core
 
-        // --- broad body sheen (완만한 modeling fill, 핫스팟 위에 더함) ---
+        // Broad body sheen (modeling fill).
         float ndl       = max(dot(N, L), 0.0);
-        float bodySheen = pow(ndl, specBodyPower) * specStrength * specBodyGain; // float: pow는 fp16서 밴딩
+        float bodySheen = pow(ndl, specBodyPower) * specStrength * specBodyGain; // float: pow bands in fp16
 
-        // --- tight Blinn rim glint, rim band에 한정 ---
-        // specWidthPx==0이면 zero-width smoothstep = 구현정의 하드스텝 → max(...,1.0) 가드 (G6).
+        // Tight Blinn rim glint, limited to the rim band.
         float3 H       = normalize(L + V);
-        float  rimBand = smoothstep(-max(specWidthPx, 1.0), 0.0, sdf);
-        float  glint   = pow(max(dot(N, H), 0.0), specPower) * specStrength;     // float: pow bands in fp16
+        float  rimBand = smoothstep(-max(specWidthPx, 1.0), 0.0, sdf); // max(..,1) guards zero-width smoothstep
+        float  glint   = pow(max(dot(N, H), 0.0), specPower) * specStrength; // float: pow bands in fp16
         float  rim     = glint * rimBand;
 
-        // --- back-rim fill (반대편 광원, rim-locked, 1/4 가중) ---
+        // Back-rim fill (opposite light, rim-locked, 1/4 weight).
         float3 Lb   = normalize(float3(-lightVec, specLightZ));
         float  back  = pow(max(dot(N, Lb), 0.0), specPower) * specStrength * rimBand * 0.25; // float: pow
 
-        // --- ordered dither: 넓은 body 램프의 8-bit Mach 밴드 깨기 ---
-        // lens-local 좌표를 fract로 bound 후 sin → 대형 렌즈서 sin 인자 폭주/줄무늬 붕괴 방지 (G5).
-        // specStrength를 곱해 off일 때 정확히 0 (F).
-        float2 hp = fract((p / minHalf) * 0.5 + 0.5);             // bounded ~[0,1)
+        // Ordered dither to break 8-bit Mach banding on the body ramp.
+        // fract-bound the coords before sin to avoid argument blow-up on large lenses.
+        float2 hp = fract((p / minHalf) * 0.5 + 0.5);
         float  dn = fract(sin(dot(hp, float2(12.9898, 78.233))) * 43758.5453) - 0.5;
 
-        // --- body(이동 핫스팟 + sheen + dither) <-> rim 선형 crossfade (monotonic, pure endpoint) ---
-        // rimMix=0 -> 순수 body(focal pool); rimMix=1 -> 순수 rim glint(과거 룩).
+        // Linear body<->rim crossfade (monotonic, pure endpoints).
         float body      = focalPool + bodySheen + dn * (1.0 / 255.0) * specStrength;
         float rimMix    = clamp(specRimMix, 0.0, 1.0);
         float highlight = body * (1.0 - rimMix) + (rim + back) * rimMix;
 
-        // Screen blend: 밝은 배경에서도 생존, [0,1]로 clamp → 1.0 초과 불가(스크린 블렌드 불변식 보장).
+        // Screen blend: survives bright backgrounds, clamp keeps it <= 1.0.
         pixel.rgb += half3((1.0 - pixel.rgb) * clamp(highlight, 0.0, 1.0));
     }
 
-    // Chromatic overlay — light-reactive iridescent sheen, independent of the white specular pool.
-    // 흰색 specular(screen-blend) 위에 별도로 얹는 무지갯빛 항. specular와 분리된 자체 게이트라
-    // chromaticIntensity==0이면 pixel.rgb 수정 0 → 기존 룩과 bit-exact, ALU 0 (uniform 분기).
-    // specular 게이트(edge/specStrength)와 독립 → specular off에서도 무지개만 켤 수 있다.
-    // 두 모드: 0 = Iridescent(박막 간섭, 빛/노멀 각도로 hue), 1 = Foil(빛 방향 투영, lightVec 움직이면 띠가 흐른다).
-    // hue·HSV→RGB 산술 체인은 전부 float/float3 — AGSL half(fp16)는 채도 만점 무지개에 밴딩이 심함.
-    // 블렌드는 tint-multiply(흰 카드도 chromaRGB로 채색); screen은 흰 배경(pixel≈1)에서 무지개가 사라짐.
+    // Chromatic overlay: light-reactive iridescent sheen, independent of the white specular pool.
+    // Own gate, so chromaticIntensity==0 is bit-exact off / ALU 0. Works even when specular is off.
+    //   mode 0 = Iridescent (thin-film, hue from light/normal angle)
+    //   mode 1 = Foil (light-direction projection, bands flow as lightVec moves)
+    // hue/HSV->RGB chain is float (AGSL half/fp16 bands hard on saturated rainbows).
+    // Blend is tint-multiply (tints even a white card); screen would erase the rainbow on white.
     if (chromaticIntensity > 0.0) {
-        // 공유 스칼라 재계산(specular 게이트 밖 → 독립). lightDir/halfDim/sdf/p는 main 스코프에서 그대로.
-        float2 cLightVec = normalize(lightDir);                       // 빛 방향(2D), specular의 lightVec와 동일식
-        float  cMinHalf  = min(halfDim.x, halfDim.y);                 // p 정규화 기준(specular minHalf와 동일)
-        float2 pNorm     = p / cMinHalf;                              // lens-local 정규화 좌표(~[-1,1]); px면 fract 앨리어싱
+        // Recompute shared scalars (independent of the specular gate).
+        float2 cLightVec = normalize(lightDir);
+        float  cMinHalf  = min(halfDim.x, halfDim.y);
+        float2 pNorm     = p / cMinHalf;
 
-        // bevel 노멀/광원 3D 재구성(Iridescent용 dot(N,L)). specular :183-192와 동일 수식, chroma-local 이름.
-        float2 cD2 = abs(p) - halfDim + float2(r);                    // boxRoundedSDF와 동일 기저
+        // Bevel normal + 3D light (for dot(cN,cL)), mirroring the specular math with chroma-local names.
+        float2 cD2 = abs(p) - halfDim + float2(r);
         float2 cS2 = float2(p.x >= 0.0 ? 1.0 : -1.0, p.y >= 0.0 ? 1.0 : -1.0);
         float2 cSpecDir;
         if (max(cD2.x, cD2.y) > 0.0) {
-            cSpecDir = cS2 * normalize(max(cD2, 0.0));                // 외부/코너: 해석적
+            cSpecDir = cS2 * normalize(max(cD2, 0.0));
         } else {
             float cw  = clamp(0.5 + 0.5 * (cD2.x - cD2.y) / SEAM_BLEND_PX, 0.0, 1.0);
             float2 cv = float2(cS2.x * cw, cS2.y * (1.0 - cw)) + float2(0.0, 1.0e-4);
-            cSpecDir  = normalize(cv);                                // 내부: seam-free softmax
+            cSpecDir  = normalize(cv);
         }
         float  cBevelPx = max(cMinHalf * specDomeFrac, 1.0);
         float  cT       = clamp(max(-sdf, 0.0) / cBevelPx, 0.0, 1.0);
         float  cNcos    = 1.0 - cT;
-        float  cNsin    = sqrt(max(1.0 - cNcos * cNcos, 0.0));        // n_cos~1 상쇄 가드(float)
+        float  cNsin    = sqrt(max(1.0 - cNcos * cNcos, 0.0));        // float: cancellation guard near cNcos~1
         float3 cN       = normalize(float3(cSpecDir * cNcos, cNsin + 1.0e-3));
         float3 cL       = normalize(float3(cLightVec, specLightZ));
 
-        // hue 합성 — 두 모드(전 체인 float).
-        //   Foil(mode 1, 불변): 표면을 빛에 투영한 선형 무지개 띠 → 빛 움직이면 띠가 흐른다.
-        //   Iridescent(mode 0, thin-film): 박막 간섭색. dot(cN,cL)=cos(입사각)이 광학 경로차(OPD)를
-        //     만들고, R/G/B 파장이 달라(파수 kRGB) 채널마다 다른 위상으로 보강/상쇄 → Newton 시퀀스
-        //     (은백→금→자홍→청록)가 산술이 아니라 물리에서 자연 발생. cN(bevel 노멀)이 면 위에서
-        //     변해 "두께 변조"를, cL이 빛 따라 돌아 위상 쓸림(gyro 반응)을 공짜로 준다.
-        // Foil: 기존 선형 hue → HSV 램프.
+        // Foil (mode 1): linear hue band projected onto the light direction -> HSV ramp.
         float hueF = fract(dot(pNorm, cLightVec) * chromaticBands + chromaticPhase);
         float3 foilRGB = clamp(
             abs(fract(float3(hueF) + float3(0.0, 2.0 / 3.0, 1.0 / 3.0)) * 6.0 - 3.0) - 1.0,
             0.0, 1.0);
-        // --- per-look 파라미터 선택 (chromaticMode → thin-film 세트), branchless step-mask ---
-        // 마스크는 정확히 0.0/1.0 (step 결과의 곱) → mode 0은 m0=1·나머지=0 → 모든 param이 베이스
-        // const와 IEEE bit 동일(x*1+0*…=x). ∴ Iridescent(mode 0) 무회귀 보장. mode 1(Foil)은 아래
-        // isFoil 경로로 분리돼 thinFilm 자체가 버려지므로 param 무관(불변).
+
+        // Per-look parameter select (chromaticMode -> thin-film set), branchless step-mask.
+        // Masks are exactly 0.0/1.0, so mode 0 -> base const bit-exact (x*1+0*..=x); mode 1 (Foil)
+        // discards thinFilm via isFoil below, so params are irrelevant there.
         float cMode  = chromaticMode;
-        float m0     = 1.0 - step(0.5, cMode);                       // mode 0 (Iridescent, 베이스)
+        float m0     = 1.0 - step(0.5, cMode);                       // mode 0 (base)
         float mOil   = step(1.5, cMode) * (1.0 - step(2.5, cMode));  // mode 2
         float mSoap  = step(2.5, cMode) * (1.0 - step(3.5, cMode));  // mode 3
         float mFoilM = step(3.5, cMode) * (1.0 - step(4.5, cMode));  // mode 4
-        float mPearl = step(4.5, cMode);                             // mode 5 (이상)
-        // 각 룩 세트를 마스크 가중합으로 고른다(분기 발산 0). mode 0/1에서 베이스 const 비트 보존.
+        float mPearl = step(4.5, cMode);                             // mode 5+
         float  lookGain    = CHROMA_OPD_GAIN * m0 + CHROMA_OIL_GAIN * mOil + CHROMA_SOAP_GAIN * mSoap
                            + CHROMA_FOILM_GAIN * mFoilM + CHROMA_PEARL_GAIN * mPearl;
         float3 lookKRGB    = CHROMA_KRGB * m0 + CHROMA_OIL_KRGB * mOil + CHROMA_SOAP_KRGB * mSoap
@@ -352,65 +314,53 @@ half4 main(float2 xy) {
         float  lookWashout = CHROMA_WASHOUT * m0 + CHROMA_OIL_WASHOUT * mOil + CHROMA_SOAP_WASHOUT * mSoap
                            + CHROMA_FOILM_WASHOUT * mFoilM + CHROMA_PEARL_WASHOUT * mPearl;
 
-        // Iridescent: 박막 간섭(Newton's rings). 광학 경로차 opd = thickness/cos(refr).
-        //   thickness = bevel 깊이 cT(중심0→림1; cNcos=1-cT) → 림으로 갈수록 막이 두꺼워 밴드 촘촘.
-        //   cosT = cos(입사각) = dot(cN,cL) → 빛이 돌면 위상 쓸림(gyro 반응). 1e-2 가드(grazing 발산).
-        // CHROMA_THICK_MIX로 두께링(공간)↔빛각도(반응)를 블렌드, GAIN이 면 위 Newton 밴드 수를 정한다.
+        // Iridescent thin-film (Newton's rings). opd = thickness/cos(refr).
+        //   thick = bevel depth cT (center 0 -> rim 1); cosT = dot(cN,cL) (light-reactive, gyro).
+        //   1e-2 guards grazing-angle blow-up. THICK_MIX blends thickness rings vs light angle.
         float cosT     = clamp(dot(cN, cL), 0.0, 1.0);
-        float thick    = 1.0 - cNcos;                                // = cT, bevel 깊이(중심0→림1)
-        float ringTerm = thick / max(1.0 - 0.6 * cosT, 1.0e-2);      // 두께/cos: Newton 링(빛 의존)
-        float opdDrive = mix(cosT, ringTerm, CHROMA_THICK_MIX);      // 빛각도↔두께링 블렌드
+        float thick    = 1.0 - cNcos;
+        float ringTerm = thick / max(1.0 - 0.6 * cosT, 1.0e-2);
+        float opdDrive = mix(cosT, ringTerm, CHROMA_THICK_MIX);
         float opd      = opdDrive * (chromaticCycles * lookGain) + CHROMA_OPD_BASE + chromaticPhase;
-        // per-channel 보강간섭(파장 역수비 kRGB). 0.5+0.5cos = [0,1] 중심 0.5(은백 기준 진동).
+        // Per-channel constructive interference; 0.5+0.5cos oscillates about silver.
         float3 interf = 0.5 + 0.5 * cos(6.28318530718 * opd * lookKRGB);
-        // 금속 floor: 채널이 0까지 안 떨어지게(형광 무지개=채널 하나 늘 0 → sticker). 진동폭만 살린다.
+        // Metal floor keeps channels off 0 (off-0 = metal, never neon).
         float3 metalRGB = lookFloor + (1.0 - lookFloor) * interf;
-        // 고차 coherence wash-out: OPD 클수록 파스텔→clean silver(흰 1.0 기준; metalRGB luma로 하면
-        // 저채도부가 베이지로 탁해진다). 약하게 둬 금속 채도 유지. sat=간섭색 보존율.
+        // Higher-order wash-out toward clean silver (white ref, not luma -> avoids beige muddying).
         float  sat       = exp(-opd * lookWashout);
-        float3 thinFilm  = mix(float3(1.0), metalRGB, clamp(sat, 0.0, 1.0)); // 은백(흰) ↔ 간섭색
-        // Fresnel rim 부스트: 가장자리(cT→1)서 thinFilm을 흰쪽으로 더 밝게(유리 림 광택).
-        //   MetallicFoil/Pearl만(mFoilM+mPearl 마스크) → Iridescent/Foil/Oil/Soap 불변.
-        //   cT=thick(중심0→림1). pow로 림 집중. 0..1 안에서 mix → 클램프 불필요.
-        float  rimSel    = mFoilM + mPearl;                          // 0/1 (해당 모드만)
+        float3 thinFilm  = mix(float3(1.0), metalRGB, clamp(sat, 0.0, 1.0));
+        // Fresnel rim boost: brighten toward white at the rim (cT->1). MetallicFoil/Pearl only.
+        float  rimSel    = mFoilM + mPearl;
         float  rimBoost  = rimSel * CHROMA_RIM_GAIN * pow(clamp(thick, 0.0, 1.0), CHROMA_RIM_POW);
-        thinFilm         = mix(thinFilm, float3(1.0), clamp(rimBoost, 0.0, 1.0)); // 림으로 갈수록 백광
-        // mode 1만 Foil(선형 띠)로 분기, 나머지(0,2,3,4,5)는 thin-film. step-window = 정확히 0/1 →
-        //   mode 1: mix(thinFilm, foilRGB, 1.0)=foilRGB(불변). mode 0: mix(...,0.0)=thinFilm(불변).
+        thinFilm         = mix(thinFilm, float3(1.0), clamp(rimBoost, 0.0, 1.0));
+        // mode 1 -> Foil, all others -> thin-film. step-window is exactly 0/1 (no regression).
         float  isFoil    = step(0.5, cMode) * (1.0 - step(1.5, cMode));
-        float3 chromaRGB = mix(thinFilm, foilRGB, isFoil);           // 1=Foil, 그외=thin-film 변형
+        float3 chromaRGB = mix(thinFilm, foilRGB, isFoil);
 
-        // focal-pool 모듈레이션 — specular의 raw pool²(정규화본; specStrength/Gain 곱 전)으로 무지개 세기 변조.
-        // specular 게이트 밖이라 pool을 저렴하게 재계산(length+smoothstep 몇 줄): focal/poolR 식은 specular와 동일.
-        float2 cFocal  = cLightVec * (cMinHalf * specFocalK);        // 빛 방향 오프셋(lensCenter=원점 기준)
-        float  cPoolR  = max(cMinHalf * specPoolFrac, 1.0);          // zero-width smoothstep 가드
-        float  cPool   = 1.0 - smoothstep(0.0, cPoolR, length(p - cFocal)); // 1 at focal, 0 at rim (edge0<edge1)
-        float  poolNorm = clamp(cPool * cPool, 0.0, 1.0);           // raw pool²(정규화) = modulator
-        // "빛 반사처럼 깔리는" 강화 — 무지개 세기를 focal-pool(빛 핫스팟)로 변조해 빛 따라 진해진다.
-        //   effMod = focal-pool 추종 세기. mode 0(Iridescent)/1(Foil)은 binding 값(chromaticModulate,
-        //   현재 0.3) 그대로 → bit-exact 무회귀(마스크 0/1, x*1+0*…=x). 신규 4종만 per-look(0.2~0.82)로
-        //   끌어올려 카드 위 빛 반사 지각을 강화. 새 식/uniform 0개(기존 cPool 재사용).
-        float  baseMod = m0 + isFoil;                               // mode 0 또는 1 → 1.0, 그외 0.0
+        // Focal-pool modulation: drive rainbow strength by the raw pool^2 (normalized, pre-gain).
+        float2 cFocal  = cLightVec * (cMinHalf * specFocalK);
+        float  cPoolR  = max(cMinHalf * specPoolFrac, 1.0);          // guard zero-width smoothstep
+        float  cPool   = 1.0 - smoothstep(0.0, cPoolR, length(p - cFocal)); // edge0<edge1
+        float  poolNorm = clamp(cPool * cPool, 0.0, 1.0);
+        // effMod = focal-pool follow strength. mode 0/1 keep the binding value (bit-exact);
+        // named looks raise it per-look. No new uniform (reuses cPool).
+        float  baseMod = m0 + isFoil;                               // mode 0 or 1 -> 1.0
         float  effMod  = chromaticModulate * baseMod
                        + CHROMA_OIL_MOD * mOil + CHROMA_SOAP_MOD * mSoap
                        + CHROMA_FOILM_MOD * mFoilM + CHROMA_PEARL_MOD * mPearl;
         float  chroma  = chromaticIntensity * mix(1.0, poolNorm, clamp(effMod, 0.0, 1.0));
 
-        // 두 경로가 정반대 블렌드를 원한다 → content alpha로 보간:
-        //   투명 베이스(a→0, 흰 카드): cOnWhite = chromaRGB. 흰(1,1,1)*무지개 = 순수 무지개. screen이면
-        //     흰 배경에서 1-(1-1)*(…)=1 로 무지개가 사라지므로 multiply(=흰*chromaRGB)가 맞다. 절대 불변.
-        //   불투명 베이스(a→1, 사진): cOnSrc = SCREEN(=어두워지지 않는 glow). multiply는 항상 값을 낮춰
-        //     (chromaRGB는 채널 하나가 항상 0) 어두운/컬러 픽셀을 탁하게 만든다(인물부 색조오염, 측정 -26%).
-        //     screen = pixel + (1-pixel)*chromaRGB*chroma 와 등가 → 항상 pixel 이상(밝아지는 방향),
-        //     1 self-limit(과포화/클립 없음), 흰 픽셀(=1)은 거의 불변. 어두운 인물부에도 무지개가 더해 보인다.
-        // 불투명 white(=1)는 screen이 1을 유지(흰 위에 glow를 더 못 얹음) — 물리적으로 옳고, 흰 '카드'는
-        // 투명 경로(a≈0)를 타므로 회귀 없음. chromaticIntensity==0이면 블록 미실행 → bit-exact off 보존.
+        // Two blends interpolated by content alpha:
+        //   transparent base (a->0, white card): multiply (white*chromaRGB = pure rainbow).
+        //     screen would erase it on white (1-(1-1)*..=1), so multiply is correct.
+        //   opaque base (a->1, photo): screen glow (never darkens). multiply would dim/mud
+        //     colored pixels since one chromaRGB channel is ~0.
         half  cChroma  = half(clamp(chroma, 0.0, 1.0));
-        half3 cChromaRGB = half3(chromaRGB) * cChroma;            // chroma 가중 무지개(공유 항)
-        half3 cOnWhite = half3(chromaRGB);                        // 흰 베이스(1,1,1) * chromaRGB = chromaRGB(불변)
-        half3 cOnSrc   = half3(1.0) - (half3(1.0) - pixel.rgb) * (half3(1.0) - cChromaRGB); // SCREEN glow
-        pixel.rgb = mix(cOnWhite, cOnSrc, pixel.a);              // a=0→흰 위 무지개, a=1→screen glow
-        pixel.a   = max(pixel.a, cChroma);                       // 투명 배경에서도 오버레이가 보이도록
+        half3 cChromaRGB = half3(chromaRGB) * cChroma;
+        half3 cOnWhite = half3(chromaRGB);
+        half3 cOnSrc   = half3(1.0) - (half3(1.0) - pixel.rgb) * (half3(1.0) - cChromaRGB); // SCREEN
+        pixel.rgb = mix(cOnWhite, cOnSrc, pixel.a);
+        pixel.a   = max(pixel.a, cChroma);                       // keep overlay visible over transparent bg
     }
 
     // Anti-aliased edge transition
@@ -420,9 +370,7 @@ half4 main(float2 xy) {
 }
 """
 
-  /**
-   * SKSL shader for Skia RuntimeEffect (iOS, macOS, Desktop, WASM).
-   */
+  /** SKSL shader for Skia RuntimeEffect (iOS, macOS, Desktop, WASM). */
   public const val SKSL: String = """
 uniform float2 resolution;
 uniform float2 lensCenter;
@@ -438,78 +386,65 @@ uniform float edge;
 uniform float2 lightDir;
 uniform float specStrength;
 uniform float specPower;
-uniform float specRimMix;     // 변경: was specSweep — body<->rim crossfade (D)
+uniform float specRimMix;     // body<->rim crossfade
 uniform float specWidthPx;
-uniform float specLightZ;      // NEW
-uniform float specDomeFrac;    // NEW
-uniform float specBodyPower;   // NEW
-uniform float specBodyGain;    // NEW
-uniform float specFocalK;      // NEW: focal-pool offset toward light (fraction of minHalf)
-uniform float specPoolFrac;    // NEW: focal-pool radius (fraction of minHalf)
-uniform float specPoolGain;    // NEW: focal-pool peak scale
-uniform float chromaticIntensity;  // NEW: 0 = off (bit-exact, ALU 0). 0..1 iridescent overlay strength
-uniform float chromaticMode;       // NEW: 0 = Iridescent (thin-film), 1 = Foil (flowing bands); float enum
-uniform float chromaticBands;      // NEW: Foil rainbow band count along the light direction (e.g. 3)
-uniform float chromaticCycles;     // NEW: Iridescent hue cycles across the light/normal angle (e.g. 1.5)
-uniform float chromaticPhase;      // NEW: static hue phase offset (radians-free, fract domain; e.g. 0)
-uniform float chromaticModulate;   // NEW: 0..1, modulate rainbow strength by the focal pool (e.g. 1)
+uniform float specLightZ;
+uniform float specDomeFrac;
+uniform float specBodyPower;
+uniform float specBodyGain;
+uniform float specFocalK;          // focal-pool offset toward light (fraction of minHalf)
+uniform float specPoolFrac;        // focal-pool radius (fraction of minHalf)
+uniform float specPoolGain;        // focal-pool peak scale
+uniform float chromaticIntensity;  // 0 = off (bit-exact, ALU 0). 0..1 overlay strength
+uniform float chromaticMode;       // float enum: 0 Iridescent, 1 Foil, 2..5 named looks
+uniform float chromaticBands;      // Foil rainbow band count along the light direction
+uniform float chromaticCycles;     // Iridescent hue cycles across the light/normal angle
+uniform float chromaticPhase;      // static hue phase offset (fract domain)
+uniform float chromaticModulate;   // 0..1, modulate rainbow strength by the focal pool
 uniform shader content;
 
 const float SMOOTH_EDGE_PX = 1.5;
-const float SEAM_BLEND_PX = 8.0;   // 대각 블렌드 반폭(px); 클수록 내부 크리스 부드러움
+const float SEAM_BLEND_PX = 8.0;   // diagonal-seam blend half-width (px)
 
-// --- Thin-film interference (Iridescent / Holographic) constants ---
-// OPD 모델: opd ≈ (thickness / cos(refr)) → Newton's rings. thickness=bevel 깊이 cT(중심0→림1),
-// cosT=cos(입사각, 빛 반응). 림으로 갈수록 막이 두꺼워 밴드가 촘촘(고전 박막), 빛이 돌면 위상 쓸림.
-const float CHROMA_OPD_GAIN  = 3.0;   // 면 위 Newton 밴드 수(높을수록 다밴드; 너무 크면 aliasing/busy)
-const float CHROMA_OPD_BASE  = 0.10;  // 기저 막 차수(중심 저OPD를 밝은 은백 0차에 두고 밖으로 색이 쌓임)
-// thickness↔light 가중: 1=순수 두께링, 0=순수 빛각도. 두 효과 블렌드(둘 다 holographic에 기여).
-const float CHROMA_THICK_MIX = 0.55;
-// per-channel 파수비(파장 역수 ~650/560/470nm). 벌릴수록 금→자홍→청록 Newton 분리가 또렷.
-const float3 CHROMA_KRGB     = float3(1.0, 1.18, 1.42);
-// 금속 floor: 채널이 0까지 안 떨어지게(형광 무지개 아님). 낮게 둬 채도 살리되 0은 아님.
-const float CHROMA_METAL_FLOOR = 0.12;
-// 고차 coherence wash-out 율. 클수록 빨리 은백(파스텔↑·busy↓). 외곽 고차 링을 silver로 진정.
-const float CHROMA_WASHOUT     = 0.16;
+// Thin-film interference (Iridescent / Holographic) base set.
+// opd ~ thickness/cos(refr) (Newton's rings): thickness = bevel depth (center 0 -> rim 1),
+// cosT = cos(incidence) (light-reactive). Thicker film at the rim -> denser bands.
+const float CHROMA_OPD_GAIN  = 3.0;   // Newton band count (too high -> aliasing/busy)
+const float CHROMA_OPD_BASE  = 0.10;  // base film order (low-OPD center sits at silver 0th)
+const float CHROMA_THICK_MIX = 0.55;  // 1 = pure thickness rings, 0 = pure light angle
+const float3 CHROMA_KRGB     = float3(1.0, 1.18, 1.42); // wavenumber ratio (~650/560/470nm)
+const float CHROMA_METAL_FLOOR = 0.12; // keep channels off 0 (metal, not neon)
+const float CHROMA_WASHOUT     = 0.16; // higher-order wash-out to silver
 
-// --- Named holographic looks (chromaticMode 2..5) ---
-// mode 0 (Iridescent) = 위 CHROMA_* 베이스 그대로(bit-exact 무회귀), mode 1 (Foil) = 선형 띠(불변).
-// 신규 4종은 같은 thin-film 경로를 타되 아래 per-look 세트(밴드밀도·채널분리·콘트라스트·파스텔율·
-// 빛추종)를 branchless step-mask로 고른다. 셰이더 안 mode 분기 → 새 uniform 0개(설계 B).
-// 각 세트는 실기기(S25) 실측으로 4종이 확연히 구분되게 벌렸다.
-// 필드: OPD_GAIN(밴드 수), KRGB(금↔청록 분리), METAL_FLOOR(콘트라스트; 낮을수록↑), WASHOUT(파스텔율;
-//       높을수록 은백), MOD(focal-pool 추종 = "빛 반사처럼 깔리는" 세기; 셰이더 내부 효과 modulate).
-// OilSlick: 촘촘 다밴드 + 넓은 분리 + 저washout(고채도) + 강한 빛추종 → 기름막.
+// Named holographic looks (chromaticMode 2..5). Same thin-film path, per-look set picked
+// by a branchless step-mask (no in-shader mode branch, no extra uniform). mode 0/1 keep the
+// base constants bit-exact. Fields: GAIN (band count), KRGB (gold<->cyan split), FLOOR
+// (contrast, lower = more), WASHOUT (pastel rate), MOD (focal-pool follow strength).
 const float CHROMA_OIL_GAIN       = 5.5;
 const float3 CHROMA_OIL_KRGB      = float3(1.0, 1.30, 1.72);
 const float CHROMA_OIL_FLOOR      = 0.05;
 const float CHROMA_OIL_WASHOUT    = 0.07;
 const float CHROMA_OIL_MOD        = 0.75;
-// SoapBubble: 넓은 띠(저밀도) + 높은 washout(파스텔·은백) + 약한 빛추종(면 균일) → 비눗방울.
 const float CHROMA_SOAP_GAIN      = 1.7;
 const float3 CHROMA_SOAP_KRGB     = float3(1.0, 1.11, 1.26);
 const float CHROMA_SOAP_FLOOR     = 0.22;
 const float CHROMA_SOAP_WASHOUT   = 0.50;
 const float CHROMA_SOAP_MOD       = 0.22;
-// MetallicFoil: 저washout(채도유지) + 저floor(콘트라스트↑) + 강한 빛추종 → 강한 고채도 금속박.
 const float CHROMA_FOILM_GAIN     = 3.6;
 const float3 CHROMA_FOILM_KRGB    = float3(1.0, 1.26, 1.62);
 const float CHROMA_FOILM_FLOOR    = 0.03;
 const float CHROMA_FOILM_WASHOUT  = 0.05;
 const float CHROMA_FOILM_MOD      = 0.82;
-// Pearl: 높은 washout(파스텔) + 높은 floor(저콘트라스트 은백) + 좁은 분리 → 은은한 진주.
 const float CHROMA_PEARL_GAIN     = 2.4;
 const float3 CHROMA_PEARL_KRGB    = float3(1.0, 1.07, 1.18);
 const float CHROMA_PEARL_FLOOR    = 0.46;
 const float CHROMA_PEARL_WASHOUT  = 0.58;
 const float CHROMA_PEARL_MOD      = 0.20;
-// Fresnel rim 부스트 — 가장자리(cT→1)서 무지개를 더 밝게(유리 림에 빛 걸림).
-// MetallicFoil/Pearl에만 가산(아래 mFoilM/mPearl 마스크). 저비용 1항.
+// Fresnel rim boost (cT->1), added for MetallicFoil/Pearl only.
 const float CHROMA_RIM_POW        = 3.0;
 const float CHROMA_RIM_GAIN       = 0.45;
 
-// Signed distance to a box with rounded corners
-// Negative = inside, Positive = outside, Zero = on boundary
+// Signed distance to a rounded-corner box. Negative inside, positive outside.
 float boxRoundedSDF(float2 p, float2 halfDim, float r) {
     float2 d = abs(p) - halfDim + float2(r);
     float exterior = length(max(d, 0.0));
@@ -517,7 +452,7 @@ float boxRoundedSDF(float2 p, float2 halfDim, float r) {
     return exterior + interior - r;
 }
 
-// Outward-facing direction vector from the lens surface
+// Outward-facing direction from the lens surface.
 float2 lensNormalDirection(float2 p, float2 halfDim, float r) {
     float2 d = abs(p) - halfDim + float2(r);
     float2 s = float2(p.x >= 0.0 ? 1.0 : -1.0, p.y >= 0.0 ? 1.0 : -1.0);
@@ -528,12 +463,12 @@ float2 lensNormalDirection(float2 p, float2 halfDim, float r) {
     return d.x > d.y ? float2(s.x, 0.0) : float2(0.0, s.y);
 }
 
-// Perceptual brightness (ITU-R BT.709 standard)
+// Perceptual brightness (ITU-R BT.709).
 float toBrightness(half3 c) {
     return dot(c, half3(0.2126, 0.7152, 0.0722));
 }
 
-// Color processing: vibrancy, intensity adjustment, and color overlay
+// Vibrancy, intensity adjustment, and color overlay.
 half3 processColor(half3 src, float vibrancy, float intensity, float4 overlay) {
     float mono = toBrightness(src);
     half3 vibrant = half3(clamp(mix(half3(mono), src, vibrancy), 0.0, 1.0));
@@ -594,143 +529,125 @@ half4 main(float2 xy) {
 
     pixel.rgb = processColor(pixel.rgb, saturation, contrast, tint);
 
-    // Specular highlight — a moving focal hotspot + a tight Blinn rim glint.
-    // 4 terms: focal pool (light pours across the face, dual-axis) + body sheen modeling fill
-    //          + tight Blinn rim glint + back-rim fill.
-    // 게이트가 specStrength도 검사 → NoGlow(specStrength==0)는 ALU 0 + bit-exact off (F).
-    // specStrength는 두 binding 모두 항상 set 되므로 게이트가 필요 uniform write를 막지 않음.
-    // specRimMix:   0 = 순수 body(focal pool), 1 = 순수 rim glint (crossfade)
-    // specPower:    rim/back lobe 샤프니스 (Blinn)
-    // specWidthPx:  rim band 두께, `edge`와 분리
-    // specStrength: peak highlight (screen-blended; <= 1.0)
-    // specLightZ/specDomeFrac/specBodyPower/specBodyGain: fake-3D bevel 라이팅
-    // specFocalK/specPoolFrac/specPoolGain: 빛이 면을 가로질러 흐르는 이동 핫스팟(양축)
+    // Specular highlight: moving focal pool + body sheen + tight Blinn rim glint + back-rim fill.
+    // Gate also checks specStrength so specStrength==0 is ALU 0 + bit-exact off.
+    //   specRimMix 0 = pure body (focal pool), 1 = pure rim glint
+    //   specPower  rim/back lobe sharpness (Blinn); specWidthPx rim band thickness
+    //   specStrength peak highlight (screen-blended, <= 1.0)
+    //   specLightZ/specDomeFrac/specBodyPower/specBodyGain  fake-3D bevel lighting
+    //   specFocalK/specPoolFrac/specPoolGain  dual-axis moving hotspot
     if (edge > 0.0 && specStrength > 0.0) {
         float2 lightVec = normalize(lightDir);
 
-        // --- seam-free in-plane direction (스페큘러 전용; 굴절이 읽는 'normal'은 불변) ---
-        // 굴절 경로(상단)는 hard-pick 'normal'을 그대로 사용한다(회귀 없음, G1).
-        // 여기서만 d.x==d.y 대각 크리스를 없앤 연속 방향을 따로 만든다.
-        // 둥근 사각형 내부는 L-inf 필드라 진짜 gradient는 대각에서 불연속 → 8px softmax로 블렌딩.
-        float2 d2 = abs(p) - halfDim + float2(r);                 // boxRoundedSDF와 동일 기저
+        // Seam-free in-plane direction (specular only; refraction's 'normal' is unchanged).
+        // Rounded-rect interior is an L-inf field, so the gradient is discontinuous on the
+        // diagonal -> blend with an 8px softmax.
+        float2 d2 = abs(p) - halfDim + float2(r);
         float2 s2 = float2(p.x >= 0.0 ? 1.0 : -1.0, p.y >= 0.0 ? 1.0 : -1.0);
         float2 specDir2;
         if (max(d2.x, d2.y) > 0.0) {
-            specDir2 = s2 * normalize(max(d2, 0.0));              // 외부/코너: 해석적
+            specDir2 = s2 * normalize(max(d2, 0.0));
         } else {
-            // 내부: w->1 x-우세, ->0 y-우세, =0.5 대각 seam. +1e-4 = dead-center normalize 특이점 가드.
+            // w->1 x-dominant, ->0 y-dominant, =0.5 diagonal seam. +1e-4 guards normalize at dead center.
             float w  = clamp(0.5 + 0.5 * (d2.x - d2.y) / SEAM_BLEND_PX, 0.0, 1.0);
             float2 v = float2(s2.x * w, s2.y * (1.0 - w)) + float2(0.0, 1.0e-4);
             specDir2 = normalize(v);
         }
 
-        // --- fake-3D surface normal from the rounded-rect bevel ---
+        // Fake-3D surface normal from the rounded-rect bevel.
         float minHalf = min(halfDim.x, halfDim.y);
         float bevelPx = max(minHalf * specDomeFrac, 1.0);
         float depthIn = max(-sdf, 0.0);
         float t       = clamp(depthIn / bevelPx, 0.0, 1.0);
-        float n_cos   = 1.0 - t;                                  // 면내 크기
-        float n_sin   = sqrt(max(1.0 - n_cos * n_cos, 0.0));      // float: n_cos~1 근처 치명적 상쇄
+        float n_cos   = 1.0 - t;
+        float n_sin   = sqrt(max(1.0 - n_cos * n_cos, 0.0));      // float: catastrophic cancellation near n_cos~1
         float3 N      = normalize(float3(specDir2 * n_cos, n_sin + 1.0e-3));
 
         float3 L = normalize(float3(lightVec, specLightZ));
         float3 V = float3(0.0, 0.0, 1.0);
 
-        // --- MOVING FOCAL HOTSPOT — "light pours across the face on both axes" ---
-        // 핫스팟을 lightVec 방향으로 minHalf*specFocalK 만큼 옮긴다: pitch(lightVec.y)=수직,
-        // roll(lightVec.x)=수평 이동 → 이동하는 밝은 풀(둘 다 축). N≈+Z로 붕괴하던 옛 body sheen과
-        // 달리 면 전체에서 빛 방향을 강하게 따른다. inside 마스크로 렌즈 밖/림은 페이드.
-        float2 focal     = lightVec * (minHalf * specFocalK);     // lensCenter(=원점) 기준 오프셋
-        float  poolR     = max(minHalf * specPoolFrac, 1.0);      // 0 가드(zero-width smoothstep 회피)
+        // Moving focal hotspot: shift the pool by minHalf*specFocalK along lightVec so it
+        // tracks the light on both axes (pitch=lightVec.y, roll=lightVec.x). inside fades the rim.
+        float2 focal     = lightVec * (minHalf * specFocalK);
+        float  poolR     = max(minHalf * specPoolFrac, 1.0);      // guard zero-width smoothstep
         float  poolD     = length(p - focal);
-        float  pool      = 1.0 - smoothstep(0.0, poolR, poolD);   // 1 at focal, 0 at rim (edge0<edge1)
-        float  inside    = 1.0 - smoothstep(-6.0, 0.0, sdf);      // 렌즈 안쪽만(밖/경계 페이드; edge0<edge1)
-        float  focalPool = pool * pool * specStrength * specPoolGain * inside; // pool^2 = 더 단단한 코어
+        float  pool      = 1.0 - smoothstep(0.0, poolR, poolD);   // edge0<edge1; 1 at focal, 0 at rim
+        float  inside    = 1.0 - smoothstep(-6.0, 0.0, sdf);      // lens interior only
+        float  focalPool = pool * pool * specStrength * specPoolGain * inside; // pool^2 = harder core
 
-        // --- broad body sheen (완만한 modeling fill, 핫스팟 위에 더함) ---
+        // Broad body sheen (modeling fill).
         float ndl       = max(dot(N, L), 0.0);
-        float bodySheen = pow(ndl, specBodyPower) * specStrength * specBodyGain; // float: pow는 fp16서 밴딩
+        float bodySheen = pow(ndl, specBodyPower) * specStrength * specBodyGain; // float: pow bands in fp16
 
-        // --- tight Blinn rim glint, rim band에 한정 ---
-        // specWidthPx==0이면 zero-width smoothstep = 구현정의 하드스텝 → max(...,1.0) 가드 (G6).
+        // Tight Blinn rim glint, limited to the rim band.
         float3 H       = normalize(L + V);
-        float  rimBand = smoothstep(-max(specWidthPx, 1.0), 0.0, sdf);
-        float  glint   = pow(max(dot(N, H), 0.0), specPower) * specStrength;     // float: pow bands in fp16
+        float  rimBand = smoothstep(-max(specWidthPx, 1.0), 0.0, sdf); // max(..,1) guards zero-width smoothstep
+        float  glint   = pow(max(dot(N, H), 0.0), specPower) * specStrength; // float: pow bands in fp16
         float  rim     = glint * rimBand;
 
-        // --- back-rim fill (반대편 광원, rim-locked, 1/4 가중) ---
+        // Back-rim fill (opposite light, rim-locked, 1/4 weight).
         float3 Lb   = normalize(float3(-lightVec, specLightZ));
         float  back  = pow(max(dot(N, Lb), 0.0), specPower) * specStrength * rimBand * 0.25; // float: pow
 
-        // --- ordered dither: 넓은 body 램프의 8-bit Mach 밴드 깨기 ---
-        // lens-local 좌표를 fract로 bound 후 sin → 대형 렌즈서 sin 인자 폭주/줄무늬 붕괴 방지 (G5).
-        // specStrength를 곱해 off일 때 정확히 0 (F).
-        float2 hp = fract((p / minHalf) * 0.5 + 0.5);             // bounded ~[0,1)
+        // Ordered dither to break 8-bit Mach banding on the body ramp.
+        // fract-bound the coords before sin to avoid argument blow-up on large lenses.
+        float2 hp = fract((p / minHalf) * 0.5 + 0.5);
         float  dn = fract(sin(dot(hp, float2(12.9898, 78.233))) * 43758.5453) - 0.5;
 
-        // --- body(이동 핫스팟 + sheen + dither) <-> rim 선형 crossfade (monotonic, pure endpoint) ---
-        // rimMix=0 -> 순수 body(focal pool); rimMix=1 -> 순수 rim glint(과거 룩).
+        // Linear body<->rim crossfade (monotonic, pure endpoints).
         float body      = focalPool + bodySheen + dn * (1.0 / 255.0) * specStrength;
         float rimMix    = clamp(specRimMix, 0.0, 1.0);
         float highlight = body * (1.0 - rimMix) + (rim + back) * rimMix;
 
-        // Screen blend: 밝은 배경에서도 생존, [0,1]로 clamp → 1.0 초과 불가(스크린 블렌드 불변식 보장).
+        // Screen blend: survives bright backgrounds, clamp keeps it <= 1.0.
         pixel.rgb += half3((1.0 - pixel.rgb) * clamp(highlight, 0.0, 1.0));
     }
 
-    // Chromatic overlay — light-reactive iridescent sheen, independent of the white specular pool.
-    // 흰색 specular(screen-blend) 위에 별도로 얹는 무지갯빛 항. specular와 분리된 자체 게이트라
-    // chromaticIntensity==0이면 pixel.rgb 수정 0 → 기존 룩과 bit-exact, ALU 0 (uniform 분기).
-    // specular 게이트(edge/specStrength)와 독립 → specular off에서도 무지개만 켤 수 있다.
-    // 두 모드: 0 = Iridescent(박막 간섭, 빛/노멀 각도로 hue), 1 = Foil(빛 방향 투영, lightVec 움직이면 띠가 흐른다).
-    // hue·HSV→RGB 산술 체인은 전부 float/float3 — AGSL half(fp16)는 채도 만점 무지개에 밴딩이 심함.
-    // 블렌드는 tint-multiply(흰 카드도 chromaRGB로 채색); screen은 흰 배경(pixel≈1)에서 무지개가 사라짐.
+    // Chromatic overlay: light-reactive iridescent sheen, independent of the white specular pool.
+    // Own gate, so chromaticIntensity==0 is bit-exact off / ALU 0. Works even when specular is off.
+    //   mode 0 = Iridescent (thin-film, hue from light/normal angle)
+    //   mode 1 = Foil (light-direction projection, bands flow as lightVec moves)
+    // hue/HSV->RGB chain is float (AGSL half/fp16 bands hard on saturated rainbows).
+    // Blend is tint-multiply (tints even a white card); screen would erase the rainbow on white.
     if (chromaticIntensity > 0.0) {
-        // 공유 스칼라 재계산(specular 게이트 밖 → 독립). lightDir/halfDim/sdf/p는 main 스코프에서 그대로.
-        float2 cLightVec = normalize(lightDir);                       // 빛 방향(2D), specular의 lightVec와 동일식
-        float  cMinHalf  = min(halfDim.x, halfDim.y);                 // p 정규화 기준(specular minHalf와 동일)
-        float2 pNorm     = p / cMinHalf;                              // lens-local 정규화 좌표(~[-1,1]); px면 fract 앨리어싱
+        // Recompute shared scalars (independent of the specular gate).
+        float2 cLightVec = normalize(lightDir);
+        float  cMinHalf  = min(halfDim.x, halfDim.y);
+        float2 pNorm     = p / cMinHalf;
 
-        // bevel 노멀/광원 3D 재구성(Iridescent용 dot(N,L)). specular :183-192와 동일 수식, chroma-local 이름.
-        float2 cD2 = abs(p) - halfDim + float2(r);                    // boxRoundedSDF와 동일 기저
+        // Bevel normal + 3D light (for dot(cN,cL)), mirroring the specular math with chroma-local names.
+        float2 cD2 = abs(p) - halfDim + float2(r);
         float2 cS2 = float2(p.x >= 0.0 ? 1.0 : -1.0, p.y >= 0.0 ? 1.0 : -1.0);
         float2 cSpecDir;
         if (max(cD2.x, cD2.y) > 0.0) {
-            cSpecDir = cS2 * normalize(max(cD2, 0.0));                // 외부/코너: 해석적
+            cSpecDir = cS2 * normalize(max(cD2, 0.0));
         } else {
             float cw  = clamp(0.5 + 0.5 * (cD2.x - cD2.y) / SEAM_BLEND_PX, 0.0, 1.0);
             float2 cv = float2(cS2.x * cw, cS2.y * (1.0 - cw)) + float2(0.0, 1.0e-4);
-            cSpecDir  = normalize(cv);                                // 내부: seam-free softmax
+            cSpecDir  = normalize(cv);
         }
         float  cBevelPx = max(cMinHalf * specDomeFrac, 1.0);
         float  cT       = clamp(max(-sdf, 0.0) / cBevelPx, 0.0, 1.0);
         float  cNcos    = 1.0 - cT;
-        float  cNsin    = sqrt(max(1.0 - cNcos * cNcos, 0.0));        // n_cos~1 상쇄 가드(float)
+        float  cNsin    = sqrt(max(1.0 - cNcos * cNcos, 0.0));        // float: cancellation guard near cNcos~1
         float3 cN       = normalize(float3(cSpecDir * cNcos, cNsin + 1.0e-3));
         float3 cL       = normalize(float3(cLightVec, specLightZ));
 
-        // hue 합성 — 두 모드(전 체인 float).
-        //   Foil(mode 1, 불변): 표면을 빛에 투영한 선형 무지개 띠 → 빛 움직이면 띠가 흐른다.
-        //   Iridescent(mode 0, thin-film): 박막 간섭색. dot(cN,cL)=cos(입사각)이 광학 경로차(OPD)를
-        //     만들고, R/G/B 파장이 달라(파수 kRGB) 채널마다 다른 위상으로 보강/상쇄 → Newton 시퀀스
-        //     (은백→금→자홍→청록)가 산술이 아니라 물리에서 자연 발생. cN(bevel 노멀)이 면 위에서
-        //     변해 "두께 변조"를, cL이 빛 따라 돌아 위상 쓸림(gyro 반응)을 공짜로 준다.
-        // Foil: 기존 선형 hue → HSV 램프.
+        // Foil (mode 1): linear hue band projected onto the light direction -> HSV ramp.
         float hueF = fract(dot(pNorm, cLightVec) * chromaticBands + chromaticPhase);
         float3 foilRGB = clamp(
             abs(fract(float3(hueF) + float3(0.0, 2.0 / 3.0, 1.0 / 3.0)) * 6.0 - 3.0) - 1.0,
             0.0, 1.0);
-        // --- per-look 파라미터 선택 (chromaticMode → thin-film 세트), branchless step-mask ---
-        // 마스크는 정확히 0.0/1.0 (step 결과의 곱) → mode 0은 m0=1·나머지=0 → 모든 param이 베이스
-        // const와 IEEE bit 동일(x*1+0*…=x). ∴ Iridescent(mode 0) 무회귀 보장. mode 1(Foil)은 아래
-        // isFoil 경로로 분리돼 thinFilm 자체가 버려지므로 param 무관(불변).
+
+        // Per-look parameter select (chromaticMode -> thin-film set), branchless step-mask.
+        // Masks are exactly 0.0/1.0, so mode 0 -> base const bit-exact (x*1+0*..=x); mode 1 (Foil)
+        // discards thinFilm via isFoil below, so params are irrelevant there.
         float cMode  = chromaticMode;
-        float m0     = 1.0 - step(0.5, cMode);                       // mode 0 (Iridescent, 베이스)
+        float m0     = 1.0 - step(0.5, cMode);                       // mode 0 (base)
         float mOil   = step(1.5, cMode) * (1.0 - step(2.5, cMode));  // mode 2
         float mSoap  = step(2.5, cMode) * (1.0 - step(3.5, cMode));  // mode 3
         float mFoilM = step(3.5, cMode) * (1.0 - step(4.5, cMode));  // mode 4
-        float mPearl = step(4.5, cMode);                             // mode 5 (이상)
-        // 각 룩 세트를 마스크 가중합으로 고른다(분기 발산 0). mode 0/1에서 베이스 const 비트 보존.
+        float mPearl = step(4.5, cMode);                             // mode 5+
         float  lookGain    = CHROMA_OPD_GAIN * m0 + CHROMA_OIL_GAIN * mOil + CHROMA_SOAP_GAIN * mSoap
                            + CHROMA_FOILM_GAIN * mFoilM + CHROMA_PEARL_GAIN * mPearl;
         float3 lookKRGB    = CHROMA_KRGB * m0 + CHROMA_OIL_KRGB * mOil + CHROMA_SOAP_KRGB * mSoap
@@ -740,65 +657,53 @@ half4 main(float2 xy) {
         float  lookWashout = CHROMA_WASHOUT * m0 + CHROMA_OIL_WASHOUT * mOil + CHROMA_SOAP_WASHOUT * mSoap
                            + CHROMA_FOILM_WASHOUT * mFoilM + CHROMA_PEARL_WASHOUT * mPearl;
 
-        // Iridescent: 박막 간섭(Newton's rings). 광학 경로차 opd = thickness/cos(refr).
-        //   thickness = bevel 깊이 cT(중심0→림1; cNcos=1-cT) → 림으로 갈수록 막이 두꺼워 밴드 촘촘.
-        //   cosT = cos(입사각) = dot(cN,cL) → 빛이 돌면 위상 쓸림(gyro 반응). 1e-2 가드(grazing 발산).
-        // CHROMA_THICK_MIX로 두께링(공간)↔빛각도(반응)를 블렌드, GAIN이 면 위 Newton 밴드 수를 정한다.
+        // Iridescent thin-film (Newton's rings). opd = thickness/cos(refr).
+        //   thick = bevel depth cT (center 0 -> rim 1); cosT = dot(cN,cL) (light-reactive, gyro).
+        //   1e-2 guards grazing-angle blow-up. THICK_MIX blends thickness rings vs light angle.
         float cosT     = clamp(dot(cN, cL), 0.0, 1.0);
-        float thick    = 1.0 - cNcos;                                // = cT, bevel 깊이(중심0→림1)
-        float ringTerm = thick / max(1.0 - 0.6 * cosT, 1.0e-2);      // 두께/cos: Newton 링(빛 의존)
-        float opdDrive = mix(cosT, ringTerm, CHROMA_THICK_MIX);      // 빛각도↔두께링 블렌드
+        float thick    = 1.0 - cNcos;
+        float ringTerm = thick / max(1.0 - 0.6 * cosT, 1.0e-2);
+        float opdDrive = mix(cosT, ringTerm, CHROMA_THICK_MIX);
         float opd      = opdDrive * (chromaticCycles * lookGain) + CHROMA_OPD_BASE + chromaticPhase;
-        // per-channel 보강간섭(파장 역수비 kRGB). 0.5+0.5cos = [0,1] 중심 0.5(은백 기준 진동).
+        // Per-channel constructive interference; 0.5+0.5cos oscillates about silver.
         float3 interf = 0.5 + 0.5 * cos(6.28318530718 * opd * lookKRGB);
-        // 금속 floor: 채널이 0까지 안 떨어지게(형광 무지개=채널 하나 늘 0 → sticker). 진동폭만 살린다.
+        // Metal floor keeps channels off 0 (off-0 = metal, never neon).
         float3 metalRGB = lookFloor + (1.0 - lookFloor) * interf;
-        // 고차 coherence wash-out: OPD 클수록 파스텔→clean silver(흰 1.0 기준; metalRGB luma로 하면
-        // 저채도부가 베이지로 탁해진다). 약하게 둬 금속 채도 유지. sat=간섭색 보존율.
+        // Higher-order wash-out toward clean silver (white ref, not luma -> avoids beige muddying).
         float  sat       = exp(-opd * lookWashout);
-        float3 thinFilm  = mix(float3(1.0), metalRGB, clamp(sat, 0.0, 1.0)); // 은백(흰) ↔ 간섭색
-        // Fresnel rim 부스트: 가장자리(cT→1)서 thinFilm을 흰쪽으로 더 밝게(유리 림 광택).
-        //   MetallicFoil/Pearl만(mFoilM+mPearl 마스크) → Iridescent/Foil/Oil/Soap 불변.
-        //   cT=thick(중심0→림1). pow로 림 집중. 0..1 안에서 mix → 클램프 불필요.
-        float  rimSel    = mFoilM + mPearl;                          // 0/1 (해당 모드만)
+        float3 thinFilm  = mix(float3(1.0), metalRGB, clamp(sat, 0.0, 1.0));
+        // Fresnel rim boost: brighten toward white at the rim (cT->1). MetallicFoil/Pearl only.
+        float  rimSel    = mFoilM + mPearl;
         float  rimBoost  = rimSel * CHROMA_RIM_GAIN * pow(clamp(thick, 0.0, 1.0), CHROMA_RIM_POW);
-        thinFilm         = mix(thinFilm, float3(1.0), clamp(rimBoost, 0.0, 1.0)); // 림으로 갈수록 백광
-        // mode 1만 Foil(선형 띠)로 분기, 나머지(0,2,3,4,5)는 thin-film. step-window = 정확히 0/1 →
-        //   mode 1: mix(thinFilm, foilRGB, 1.0)=foilRGB(불변). mode 0: mix(...,0.0)=thinFilm(불변).
+        thinFilm         = mix(thinFilm, float3(1.0), clamp(rimBoost, 0.0, 1.0));
+        // mode 1 -> Foil, all others -> thin-film. step-window is exactly 0/1 (no regression).
         float  isFoil    = step(0.5, cMode) * (1.0 - step(1.5, cMode));
-        float3 chromaRGB = mix(thinFilm, foilRGB, isFoil);           // 1=Foil, 그외=thin-film 변형
+        float3 chromaRGB = mix(thinFilm, foilRGB, isFoil);
 
-        // focal-pool 모듈레이션 — specular의 raw pool²(정규화본; specStrength/Gain 곱 전)으로 무지개 세기 변조.
-        // specular 게이트 밖이라 pool을 저렴하게 재계산(length+smoothstep 몇 줄): focal/poolR 식은 specular와 동일.
-        float2 cFocal  = cLightVec * (cMinHalf * specFocalK);        // 빛 방향 오프셋(lensCenter=원점 기준)
-        float  cPoolR  = max(cMinHalf * specPoolFrac, 1.0);          // zero-width smoothstep 가드
-        float  cPool   = 1.0 - smoothstep(0.0, cPoolR, length(p - cFocal)); // 1 at focal, 0 at rim (edge0<edge1)
-        float  poolNorm = clamp(cPool * cPool, 0.0, 1.0);           // raw pool²(정규화) = modulator
-        // "빛 반사처럼 깔리는" 강화 — 무지개 세기를 focal-pool(빛 핫스팟)로 변조해 빛 따라 진해진다.
-        //   effMod = focal-pool 추종 세기. mode 0(Iridescent)/1(Foil)은 binding 값(chromaticModulate,
-        //   현재 0.3) 그대로 → bit-exact 무회귀(마스크 0/1, x*1+0*…=x). 신규 4종만 per-look(0.2~0.82)로
-        //   끌어올려 카드 위 빛 반사 지각을 강화. 새 식/uniform 0개(기존 cPool 재사용).
-        float  baseMod = m0 + isFoil;                               // mode 0 또는 1 → 1.0, 그외 0.0
+        // Focal-pool modulation: drive rainbow strength by the raw pool^2 (normalized, pre-gain).
+        float2 cFocal  = cLightVec * (cMinHalf * specFocalK);
+        float  cPoolR  = max(cMinHalf * specPoolFrac, 1.0);          // guard zero-width smoothstep
+        float  cPool   = 1.0 - smoothstep(0.0, cPoolR, length(p - cFocal)); // edge0<edge1
+        float  poolNorm = clamp(cPool * cPool, 0.0, 1.0);
+        // effMod = focal-pool follow strength. mode 0/1 keep the binding value (bit-exact);
+        // named looks raise it per-look. No new uniform (reuses cPool).
+        float  baseMod = m0 + isFoil;                               // mode 0 or 1 -> 1.0
         float  effMod  = chromaticModulate * baseMod
                        + CHROMA_OIL_MOD * mOil + CHROMA_SOAP_MOD * mSoap
                        + CHROMA_FOILM_MOD * mFoilM + CHROMA_PEARL_MOD * mPearl;
         float  chroma  = chromaticIntensity * mix(1.0, poolNorm, clamp(effMod, 0.0, 1.0));
 
-        // 두 경로가 정반대 블렌드를 원한다 → content alpha로 보간:
-        //   투명 베이스(a→0, 흰 카드): cOnWhite = chromaRGB. 흰(1,1,1)*무지개 = 순수 무지개. screen이면
-        //     흰 배경에서 1-(1-1)*(…)=1 로 무지개가 사라지므로 multiply(=흰*chromaRGB)가 맞다. 절대 불변.
-        //   불투명 베이스(a→1, 사진): cOnSrc = SCREEN(=어두워지지 않는 glow). multiply는 항상 값을 낮춰
-        //     (chromaRGB는 채널 하나가 항상 0) 어두운/컬러 픽셀을 탁하게 만든다(인물부 색조오염, 측정 -26%).
-        //     screen = pixel + (1-pixel)*chromaRGB*chroma 와 등가 → 항상 pixel 이상(밝아지는 방향),
-        //     1 self-limit(과포화/클립 없음), 흰 픽셀(=1)은 거의 불변. 어두운 인물부에도 무지개가 더해 보인다.
-        // 불투명 white(=1)는 screen이 1을 유지(흰 위에 glow를 더 못 얹음) — 물리적으로 옳고, 흰 '카드'는
-        // 투명 경로(a≈0)를 타므로 회귀 없음. chromaticIntensity==0이면 블록 미실행 → bit-exact off 보존.
+        // Two blends interpolated by content alpha:
+        //   transparent base (a->0, white card): multiply (white*chromaRGB = pure rainbow).
+        //     screen would erase it on white (1-(1-1)*..=1), so multiply is correct.
+        //   opaque base (a->1, photo): screen glow (never darkens). multiply would dim/mud
+        //     colored pixels since one chromaRGB channel is ~0.
         half  cChroma  = half(clamp(chroma, 0.0, 1.0));
-        half3 cChromaRGB = half3(chromaRGB) * cChroma;            // chroma 가중 무지개(공유 항)
-        half3 cOnWhite = half3(chromaRGB);                        // 흰 베이스(1,1,1) * chromaRGB = chromaRGB(불변)
-        half3 cOnSrc   = half3(1.0) - (half3(1.0) - pixel.rgb) * (half3(1.0) - cChromaRGB); // SCREEN glow
-        pixel.rgb = mix(cOnWhite, cOnSrc, pixel.a);              // a=0→흰 위 무지개, a=1→screen glow
-        pixel.a   = max(pixel.a, cChroma);                       // 투명 배경에서도 오버레이가 보이도록
+        half3 cChromaRGB = half3(chromaRGB) * cChroma;
+        half3 cOnWhite = half3(chromaRGB);
+        half3 cOnSrc   = half3(1.0) - (half3(1.0) - pixel.rgb) * (half3(1.0) - cChromaRGB); // SCREEN
+        pixel.rgb = mix(cOnWhite, cOnSrc, pixel.a);
+        pixel.a   = max(pixel.a, cChroma);                       // keep overlay visible over transparent bg
     }
 
     // Anti-aliased edge transition

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassShaderSource.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassShaderSource.kt
@@ -70,6 +70,20 @@ uniform shader content;
 const float SMOOTH_EDGE_PX = 1.5;
 const float SEAM_BLEND_PX = 8.0;   // 대각 블렌드 반폭(px); 클수록 내부 크리스 부드러움
 
+// --- Thin-film interference (Iridescent / Holographic) constants ---
+// OPD 모델: opd ≈ (thickness / cos(refr)) → Newton's rings. thickness=bevel 깊이 cT(중심0→림1),
+// cosT=cos(입사각, 빛 반응). 림으로 갈수록 막이 두꺼워 밴드가 촘촘(고전 박막), 빛이 돌면 위상 쓸림.
+const float CHROMA_OPD_GAIN  = 3.0;   // 면 위 Newton 밴드 수(높을수록 다밴드; 너무 크면 aliasing/busy)
+const float CHROMA_OPD_BASE  = 0.10;  // 기저 막 차수(중심 저OPD를 밝은 은백 0차에 두고 밖으로 색이 쌓임)
+// thickness↔light 가중: 1=순수 두께링, 0=순수 빛각도. 두 효과 블렌드(둘 다 holographic에 기여).
+const float CHROMA_THICK_MIX = 0.55;
+// per-channel 파수비(파장 역수 ~650/560/470nm). 벌릴수록 금→자홍→청록 Newton 분리가 또렷.
+const float3 CHROMA_KRGB     = float3(1.0, 1.18, 1.42);
+// 금속 floor: 채널이 0까지 안 떨어지게(형광 무지개 아님). 낮게 둬 채도 살리되 0은 아님.
+const float CHROMA_METAL_FLOOR = 0.12;
+// 고차 coherence wash-out 율. 클수록 빨리 은백(파스텔↑·busy↓). 외곽 고차 링을 silver로 진정.
+const float CHROMA_WASHOUT     = 0.16;
+
 // Signed distance to a box with rounded corners
 // Negative = inside, Positive = outside, Zero = on boundary
 float boxRoundedSDF(float2 p, float2 halfDim, float r) {
@@ -271,15 +285,35 @@ half4 main(float2 xy) {
         float3 cN       = normalize(float3(cSpecDir * cNcos, cNsin + 1.0e-3));
         float3 cL       = normalize(float3(cLightVec, specLightZ));
 
-        // hue 합성 — 두 모드(전 체인 float). Foil: 표면을 빛에 투영 → 빛 움직이면 띠가 흐름.
-        //                                Iridescent: 빛/노멀 각도 → 박막 간섭처럼 hue가 돈다.
+        // hue 합성 — 두 모드(전 체인 float).
+        //   Foil(mode 1, 불변): 표면을 빛에 투영한 선형 무지개 띠 → 빛 움직이면 띠가 흐른다.
+        //   Iridescent(mode 0, thin-film): 박막 간섭색. dot(cN,cL)=cos(입사각)이 광학 경로차(OPD)를
+        //     만들고, R/G/B 파장이 달라(파수 kRGB) 채널마다 다른 위상으로 보강/상쇄 → Newton 시퀀스
+        //     (은백→금→자홍→청록)가 산술이 아니라 물리에서 자연 발생. cN(bevel 노멀)이 면 위에서
+        //     변해 "두께 변조"를, cL이 빛 따라 돌아 위상 쓸림(gyro 반응)을 공짜로 준다.
+        // Foil: 기존 선형 hue → HSV 램프.
         float hueF = fract(dot(pNorm, cLightVec) * chromaticBands + chromaticPhase);
-        float hueI = fract(dot(cN, cL) * chromaticCycles + chromaticPhase);
-        float hue  = mix(hueI, hueF, chromaticMode);                 // mode 0→Iridescent, 1→Foil
-        // 6-세그먼트 HSV(채도/명도=1)→RGB 램프(float3). half3로 받으면 fp16 양자화로 밴딩.
-        float3 chromaRGB = clamp(
-            abs(fract(float3(hue) + float3(0.0, 2.0 / 3.0, 1.0 / 3.0)) * 6.0 - 3.0) - 1.0,
+        float3 foilRGB = clamp(
+            abs(fract(float3(hueF) + float3(0.0, 2.0 / 3.0, 1.0 / 3.0)) * 6.0 - 3.0) - 1.0,
             0.0, 1.0);
+        // Iridescent: 박막 간섭(Newton's rings). 광학 경로차 opd = thickness/cos(refr).
+        //   thickness = bevel 깊이 cT(중심0→림1; cNcos=1-cT) → 림으로 갈수록 막이 두꺼워 밴드 촘촘.
+        //   cosT = cos(입사각) = dot(cN,cL) → 빛이 돌면 위상 쓸림(gyro 반응). 1e-2 가드(grazing 발산).
+        // CHROMA_THICK_MIX로 두께링(공간)↔빛각도(반응)를 블렌드, GAIN이 면 위 Newton 밴드 수를 정한다.
+        float cosT     = clamp(dot(cN, cL), 0.0, 1.0);
+        float thick    = 1.0 - cNcos;                                // = cT, bevel 깊이(중심0→림1)
+        float ringTerm = thick / max(1.0 - 0.6 * cosT, 1.0e-2);      // 두께/cos: Newton 링(빛 의존)
+        float opdDrive = mix(cosT, ringTerm, CHROMA_THICK_MIX);      // 빛각도↔두께링 블렌드
+        float opd      = opdDrive * (chromaticCycles * CHROMA_OPD_GAIN) + CHROMA_OPD_BASE + chromaticPhase;
+        // per-channel 보강간섭(파장 역수비 kRGB). 0.5+0.5cos = [0,1] 중심 0.5(은백 기준 진동).
+        float3 interf = 0.5 + 0.5 * cos(6.28318530718 * opd * CHROMA_KRGB);
+        // 금속 floor: 채널이 0까지 안 떨어지게(형광 무지개=채널 하나 늘 0 → sticker). 진동폭만 살린다.
+        float3 metalRGB = CHROMA_METAL_FLOOR + (1.0 - CHROMA_METAL_FLOOR) * interf;
+        // 고차 coherence wash-out: OPD 클수록 파스텔→clean silver(흰 1.0 기준; metalRGB luma로 하면
+        // 저채도부가 베이지로 탁해진다). 약하게 둬 금속 채도 유지. sat=간섭색 보존율.
+        float  sat       = exp(-opd * CHROMA_WASHOUT);
+        float3 thinFilm  = mix(float3(1.0), metalRGB, clamp(sat, 0.0, 1.0)); // 은백(흰) ↔ 간섭색
+        float3 chromaRGB = mix(thinFilm, foilRGB, chromaticMode);    // mode 0→thin-film, 1→Foil(불변)
 
         // focal-pool 모듈레이션 — specular의 raw pool²(정규화본; specStrength/Gain 곱 전)으로 무지개 세기 변조.
         // specular 게이트 밖이라 pool을 저렴하게 재계산(length+smoothstep 몇 줄): focal/poolR 식은 specular와 동일.
@@ -351,6 +385,20 @@ uniform shader content;
 const float SMOOTH_EDGE_PX = 1.5;
 const float SEAM_BLEND_PX = 8.0;   // 대각 블렌드 반폭(px); 클수록 내부 크리스 부드러움
 
+// --- Thin-film interference (Iridescent / Holographic) constants ---
+// OPD 모델: opd ≈ (thickness / cos(refr)) → Newton's rings. thickness=bevel 깊이 cT(중심0→림1),
+// cosT=cos(입사각, 빛 반응). 림으로 갈수록 막이 두꺼워 밴드가 촘촘(고전 박막), 빛이 돌면 위상 쓸림.
+const float CHROMA_OPD_GAIN  = 3.0;   // 면 위 Newton 밴드 수(높을수록 다밴드; 너무 크면 aliasing/busy)
+const float CHROMA_OPD_BASE  = 0.10;  // 기저 막 차수(중심 저OPD를 밝은 은백 0차에 두고 밖으로 색이 쌓임)
+// thickness↔light 가중: 1=순수 두께링, 0=순수 빛각도. 두 효과 블렌드(둘 다 holographic에 기여).
+const float CHROMA_THICK_MIX = 0.55;
+// per-channel 파수비(파장 역수 ~650/560/470nm). 벌릴수록 금→자홍→청록 Newton 분리가 또렷.
+const float3 CHROMA_KRGB     = float3(1.0, 1.18, 1.42);
+// 금속 floor: 채널이 0까지 안 떨어지게(형광 무지개 아님). 낮게 둬 채도 살리되 0은 아님.
+const float CHROMA_METAL_FLOOR = 0.12;
+// 고차 coherence wash-out 율. 클수록 빨리 은백(파스텔↑·busy↓). 외곽 고차 링을 silver로 진정.
+const float CHROMA_WASHOUT     = 0.16;
+
 // Signed distance to a box with rounded corners
 // Negative = inside, Positive = outside, Zero = on boundary
 float boxRoundedSDF(float2 p, float2 halfDim, float r) {
@@ -552,15 +600,35 @@ half4 main(float2 xy) {
         float3 cN       = normalize(float3(cSpecDir * cNcos, cNsin + 1.0e-3));
         float3 cL       = normalize(float3(cLightVec, specLightZ));
 
-        // hue 합성 — 두 모드(전 체인 float). Foil: 표면을 빛에 투영 → 빛 움직이면 띠가 흐름.
-        //                                Iridescent: 빛/노멀 각도 → 박막 간섭처럼 hue가 돈다.
+        // hue 합성 — 두 모드(전 체인 float).
+        //   Foil(mode 1, 불변): 표면을 빛에 투영한 선형 무지개 띠 → 빛 움직이면 띠가 흐른다.
+        //   Iridescent(mode 0, thin-film): 박막 간섭색. dot(cN,cL)=cos(입사각)이 광학 경로차(OPD)를
+        //     만들고, R/G/B 파장이 달라(파수 kRGB) 채널마다 다른 위상으로 보강/상쇄 → Newton 시퀀스
+        //     (은백→금→자홍→청록)가 산술이 아니라 물리에서 자연 발생. cN(bevel 노멀)이 면 위에서
+        //     변해 "두께 변조"를, cL이 빛 따라 돌아 위상 쓸림(gyro 반응)을 공짜로 준다.
+        // Foil: 기존 선형 hue → HSV 램프.
         float hueF = fract(dot(pNorm, cLightVec) * chromaticBands + chromaticPhase);
-        float hueI = fract(dot(cN, cL) * chromaticCycles + chromaticPhase);
-        float hue  = mix(hueI, hueF, chromaticMode);                 // mode 0→Iridescent, 1→Foil
-        // 6-세그먼트 HSV(채도/명도=1)→RGB 램프(float3). half3로 받으면 fp16 양자화로 밴딩.
-        float3 chromaRGB = clamp(
-            abs(fract(float3(hue) + float3(0.0, 2.0 / 3.0, 1.0 / 3.0)) * 6.0 - 3.0) - 1.0,
+        float3 foilRGB = clamp(
+            abs(fract(float3(hueF) + float3(0.0, 2.0 / 3.0, 1.0 / 3.0)) * 6.0 - 3.0) - 1.0,
             0.0, 1.0);
+        // Iridescent: 박막 간섭(Newton's rings). 광학 경로차 opd = thickness/cos(refr).
+        //   thickness = bevel 깊이 cT(중심0→림1; cNcos=1-cT) → 림으로 갈수록 막이 두꺼워 밴드 촘촘.
+        //   cosT = cos(입사각) = dot(cN,cL) → 빛이 돌면 위상 쓸림(gyro 반응). 1e-2 가드(grazing 발산).
+        // CHROMA_THICK_MIX로 두께링(공간)↔빛각도(반응)를 블렌드, GAIN이 면 위 Newton 밴드 수를 정한다.
+        float cosT     = clamp(dot(cN, cL), 0.0, 1.0);
+        float thick    = 1.0 - cNcos;                                // = cT, bevel 깊이(중심0→림1)
+        float ringTerm = thick / max(1.0 - 0.6 * cosT, 1.0e-2);      // 두께/cos: Newton 링(빛 의존)
+        float opdDrive = mix(cosT, ringTerm, CHROMA_THICK_MIX);      // 빛각도↔두께링 블렌드
+        float opd      = opdDrive * (chromaticCycles * CHROMA_OPD_GAIN) + CHROMA_OPD_BASE + chromaticPhase;
+        // per-channel 보강간섭(파장 역수비 kRGB). 0.5+0.5cos = [0,1] 중심 0.5(은백 기준 진동).
+        float3 interf = 0.5 + 0.5 * cos(6.28318530718 * opd * CHROMA_KRGB);
+        // 금속 floor: 채널이 0까지 안 떨어지게(형광 무지개=채널 하나 늘 0 → sticker). 진동폭만 살린다.
+        float3 metalRGB = CHROMA_METAL_FLOOR + (1.0 - CHROMA_METAL_FLOOR) * interf;
+        // 고차 coherence wash-out: OPD 클수록 파스텔→clean silver(흰 1.0 기준; metalRGB luma로 하면
+        // 저채도부가 베이지로 탁해진다). 약하게 둬 금속 채도 유지. sat=간섭색 보존율.
+        float  sat       = exp(-opd * CHROMA_WASHOUT);
+        float3 thinFilm  = mix(float3(1.0), metalRGB, clamp(sat, 0.0, 1.0)); // 은백(흰) ↔ 간섭색
+        float3 chromaRGB = mix(thinFilm, foilRGB, chromaticMode);    // mode 0→thin-film, 1→Foil(불변)
 
         // focal-pool 모듈레이션 — specular의 raw pool²(정규화본; specStrength/Gain 곱 전)으로 무지개 세기 변조.
         // specular 게이트 밖이라 pool을 저렴하게 재계산(length+smoothstep 몇 줄): focal/poolR 식은 specular와 동일.

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassShaderSource.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassShaderSource.kt
@@ -84,6 +84,42 @@ const float CHROMA_METAL_FLOOR = 0.12;
 // 고차 coherence wash-out 율. 클수록 빨리 은백(파스텔↑·busy↓). 외곽 고차 링을 silver로 진정.
 const float CHROMA_WASHOUT     = 0.16;
 
+// --- Named holographic looks (chromaticMode 2..5) ---
+// mode 0 (Iridescent) = 위 CHROMA_* 베이스 그대로(bit-exact 무회귀), mode 1 (Foil) = 선형 띠(불변).
+// 신규 4종은 같은 thin-film 경로를 타되 아래 per-look 세트(밴드밀도·채널분리·콘트라스트·파스텔율·
+// 빛추종)를 branchless step-mask로 고른다. 셰이더 안 mode 분기 → 새 uniform 0개(설계 B).
+// 각 세트는 실기기(S25) 실측으로 4종이 확연히 구분되게 벌렸다.
+// 필드: OPD_GAIN(밴드 수), KRGB(금↔청록 분리), METAL_FLOOR(콘트라스트; 낮을수록↑), WASHOUT(파스텔율;
+//       높을수록 은백), MOD(focal-pool 추종 = "빛 반사처럼 깔리는" 세기; 셰이더 내부 효과 modulate).
+// OilSlick: 촘촘 다밴드 + 넓은 분리 + 저washout(고채도) + 강한 빛추종 → 기름막.
+const float CHROMA_OIL_GAIN       = 5.5;
+const float3 CHROMA_OIL_KRGB      = float3(1.0, 1.30, 1.72);
+const float CHROMA_OIL_FLOOR      = 0.05;
+const float CHROMA_OIL_WASHOUT    = 0.07;
+const float CHROMA_OIL_MOD        = 0.75;
+// SoapBubble: 넓은 띠(저밀도) + 높은 washout(파스텔·은백) + 약한 빛추종(면 균일) → 비눗방울.
+const float CHROMA_SOAP_GAIN      = 1.7;
+const float3 CHROMA_SOAP_KRGB     = float3(1.0, 1.11, 1.26);
+const float CHROMA_SOAP_FLOOR     = 0.22;
+const float CHROMA_SOAP_WASHOUT   = 0.50;
+const float CHROMA_SOAP_MOD       = 0.22;
+// MetallicFoil: 저washout(채도유지) + 저floor(콘트라스트↑) + 강한 빛추종 → 강한 고채도 금속박.
+const float CHROMA_FOILM_GAIN     = 3.6;
+const float3 CHROMA_FOILM_KRGB    = float3(1.0, 1.26, 1.62);
+const float CHROMA_FOILM_FLOOR    = 0.03;
+const float CHROMA_FOILM_WASHOUT  = 0.05;
+const float CHROMA_FOILM_MOD      = 0.82;
+// Pearl: 높은 washout(파스텔) + 높은 floor(저콘트라스트 은백) + 좁은 분리 → 은은한 진주.
+const float CHROMA_PEARL_GAIN     = 2.4;
+const float3 CHROMA_PEARL_KRGB    = float3(1.0, 1.07, 1.18);
+const float CHROMA_PEARL_FLOOR    = 0.46;
+const float CHROMA_PEARL_WASHOUT  = 0.58;
+const float CHROMA_PEARL_MOD      = 0.20;
+// Fresnel rim 부스트 — 가장자리(cT→1)서 무지개를 더 밝게(유리 림에 빛 걸림).
+// MetallicFoil/Pearl에만 가산(아래 mFoilM/mPearl 마스크). 저비용 1항.
+const float CHROMA_RIM_POW        = 3.0;
+const float CHROMA_RIM_GAIN       = 0.45;
+
 // Signed distance to a box with rounded corners
 // Negative = inside, Positive = outside, Zero = on boundary
 float boxRoundedSDF(float2 p, float2 halfDim, float r) {
@@ -296,6 +332,26 @@ half4 main(float2 xy) {
         float3 foilRGB = clamp(
             abs(fract(float3(hueF) + float3(0.0, 2.0 / 3.0, 1.0 / 3.0)) * 6.0 - 3.0) - 1.0,
             0.0, 1.0);
+        // --- per-look 파라미터 선택 (chromaticMode → thin-film 세트), branchless step-mask ---
+        // 마스크는 정확히 0.0/1.0 (step 결과의 곱) → mode 0은 m0=1·나머지=0 → 모든 param이 베이스
+        // const와 IEEE bit 동일(x*1+0*…=x). ∴ Iridescent(mode 0) 무회귀 보장. mode 1(Foil)은 아래
+        // isFoil 경로로 분리돼 thinFilm 자체가 버려지므로 param 무관(불변).
+        float cMode  = chromaticMode;
+        float m0     = 1.0 - step(0.5, cMode);                       // mode 0 (Iridescent, 베이스)
+        float mOil   = step(1.5, cMode) * (1.0 - step(2.5, cMode));  // mode 2
+        float mSoap  = step(2.5, cMode) * (1.0 - step(3.5, cMode));  // mode 3
+        float mFoilM = step(3.5, cMode) * (1.0 - step(4.5, cMode));  // mode 4
+        float mPearl = step(4.5, cMode);                             // mode 5 (이상)
+        // 각 룩 세트를 마스크 가중합으로 고른다(분기 발산 0). mode 0/1에서 베이스 const 비트 보존.
+        float  lookGain    = CHROMA_OPD_GAIN * m0 + CHROMA_OIL_GAIN * mOil + CHROMA_SOAP_GAIN * mSoap
+                           + CHROMA_FOILM_GAIN * mFoilM + CHROMA_PEARL_GAIN * mPearl;
+        float3 lookKRGB    = CHROMA_KRGB * m0 + CHROMA_OIL_KRGB * mOil + CHROMA_SOAP_KRGB * mSoap
+                           + CHROMA_FOILM_KRGB * mFoilM + CHROMA_PEARL_KRGB * mPearl;
+        float  lookFloor   = CHROMA_METAL_FLOOR * m0 + CHROMA_OIL_FLOOR * mOil + CHROMA_SOAP_FLOOR * mSoap
+                           + CHROMA_FOILM_FLOOR * mFoilM + CHROMA_PEARL_FLOOR * mPearl;
+        float  lookWashout = CHROMA_WASHOUT * m0 + CHROMA_OIL_WASHOUT * mOil + CHROMA_SOAP_WASHOUT * mSoap
+                           + CHROMA_FOILM_WASHOUT * mFoilM + CHROMA_PEARL_WASHOUT * mPearl;
+
         // Iridescent: 박막 간섭(Newton's rings). 광학 경로차 opd = thickness/cos(refr).
         //   thickness = bevel 깊이 cT(중심0→림1; cNcos=1-cT) → 림으로 갈수록 막이 두꺼워 밴드 촘촘.
         //   cosT = cos(입사각) = dot(cN,cL) → 빛이 돌면 위상 쓸림(gyro 반응). 1e-2 가드(grazing 발산).
@@ -304,16 +360,25 @@ half4 main(float2 xy) {
         float thick    = 1.0 - cNcos;                                // = cT, bevel 깊이(중심0→림1)
         float ringTerm = thick / max(1.0 - 0.6 * cosT, 1.0e-2);      // 두께/cos: Newton 링(빛 의존)
         float opdDrive = mix(cosT, ringTerm, CHROMA_THICK_MIX);      // 빛각도↔두께링 블렌드
-        float opd      = opdDrive * (chromaticCycles * CHROMA_OPD_GAIN) + CHROMA_OPD_BASE + chromaticPhase;
+        float opd      = opdDrive * (chromaticCycles * lookGain) + CHROMA_OPD_BASE + chromaticPhase;
         // per-channel 보강간섭(파장 역수비 kRGB). 0.5+0.5cos = [0,1] 중심 0.5(은백 기준 진동).
-        float3 interf = 0.5 + 0.5 * cos(6.28318530718 * opd * CHROMA_KRGB);
+        float3 interf = 0.5 + 0.5 * cos(6.28318530718 * opd * lookKRGB);
         // 금속 floor: 채널이 0까지 안 떨어지게(형광 무지개=채널 하나 늘 0 → sticker). 진동폭만 살린다.
-        float3 metalRGB = CHROMA_METAL_FLOOR + (1.0 - CHROMA_METAL_FLOOR) * interf;
+        float3 metalRGB = lookFloor + (1.0 - lookFloor) * interf;
         // 고차 coherence wash-out: OPD 클수록 파스텔→clean silver(흰 1.0 기준; metalRGB luma로 하면
         // 저채도부가 베이지로 탁해진다). 약하게 둬 금속 채도 유지. sat=간섭색 보존율.
-        float  sat       = exp(-opd * CHROMA_WASHOUT);
+        float  sat       = exp(-opd * lookWashout);
         float3 thinFilm  = mix(float3(1.0), metalRGB, clamp(sat, 0.0, 1.0)); // 은백(흰) ↔ 간섭색
-        float3 chromaRGB = mix(thinFilm, foilRGB, chromaticMode);    // mode 0→thin-film, 1→Foil(불변)
+        // Fresnel rim 부스트: 가장자리(cT→1)서 thinFilm을 흰쪽으로 더 밝게(유리 림 광택).
+        //   MetallicFoil/Pearl만(mFoilM+mPearl 마스크) → Iridescent/Foil/Oil/Soap 불변.
+        //   cT=thick(중심0→림1). pow로 림 집중. 0..1 안에서 mix → 클램프 불필요.
+        float  rimSel    = mFoilM + mPearl;                          // 0/1 (해당 모드만)
+        float  rimBoost  = rimSel * CHROMA_RIM_GAIN * pow(clamp(thick, 0.0, 1.0), CHROMA_RIM_POW);
+        thinFilm         = mix(thinFilm, float3(1.0), clamp(rimBoost, 0.0, 1.0)); // 림으로 갈수록 백광
+        // mode 1만 Foil(선형 띠)로 분기, 나머지(0,2,3,4,5)는 thin-film. step-window = 정확히 0/1 →
+        //   mode 1: mix(thinFilm, foilRGB, 1.0)=foilRGB(불변). mode 0: mix(...,0.0)=thinFilm(불변).
+        float  isFoil    = step(0.5, cMode) * (1.0 - step(1.5, cMode));
+        float3 chromaRGB = mix(thinFilm, foilRGB, isFoil);           // 1=Foil, 그외=thin-film 변형
 
         // focal-pool 모듈레이션 — specular의 raw pool²(정규화본; specStrength/Gain 곱 전)으로 무지개 세기 변조.
         // specular 게이트 밖이라 pool을 저렴하게 재계산(length+smoothstep 몇 줄): focal/poolR 식은 specular와 동일.
@@ -321,7 +386,15 @@ half4 main(float2 xy) {
         float  cPoolR  = max(cMinHalf * specPoolFrac, 1.0);          // zero-width smoothstep 가드
         float  cPool   = 1.0 - smoothstep(0.0, cPoolR, length(p - cFocal)); // 1 at focal, 0 at rim (edge0<edge1)
         float  poolNorm = clamp(cPool * cPool, 0.0, 1.0);           // raw pool²(정규화) = modulator
-        float  chroma  = chromaticIntensity * mix(1.0, poolNorm, chromaticModulate);
+        // "빛 반사처럼 깔리는" 강화 — 무지개 세기를 focal-pool(빛 핫스팟)로 변조해 빛 따라 진해진다.
+        //   effMod = focal-pool 추종 세기. mode 0(Iridescent)/1(Foil)은 binding 값(chromaticModulate,
+        //   현재 0.3) 그대로 → bit-exact 무회귀(마스크 0/1, x*1+0*…=x). 신규 4종만 per-look(0.2~0.82)로
+        //   끌어올려 카드 위 빛 반사 지각을 강화. 새 식/uniform 0개(기존 cPool 재사용).
+        float  baseMod = m0 + isFoil;                               // mode 0 또는 1 → 1.0, 그외 0.0
+        float  effMod  = chromaticModulate * baseMod
+                       + CHROMA_OIL_MOD * mOil + CHROMA_SOAP_MOD * mSoap
+                       + CHROMA_FOILM_MOD * mFoilM + CHROMA_PEARL_MOD * mPearl;
+        float  chroma  = chromaticIntensity * mix(1.0, poolNorm, clamp(effMod, 0.0, 1.0));
 
         // 두 경로가 정반대 블렌드를 원한다 → content alpha로 보간:
         //   투명 베이스(a→0, 흰 카드): cOnWhite = chromaRGB. 흰(1,1,1)*무지개 = 순수 무지개. screen이면
@@ -399,6 +472,42 @@ const float CHROMA_METAL_FLOOR = 0.12;
 // 고차 coherence wash-out 율. 클수록 빨리 은백(파스텔↑·busy↓). 외곽 고차 링을 silver로 진정.
 const float CHROMA_WASHOUT     = 0.16;
 
+// --- Named holographic looks (chromaticMode 2..5) ---
+// mode 0 (Iridescent) = 위 CHROMA_* 베이스 그대로(bit-exact 무회귀), mode 1 (Foil) = 선형 띠(불변).
+// 신규 4종은 같은 thin-film 경로를 타되 아래 per-look 세트(밴드밀도·채널분리·콘트라스트·파스텔율·
+// 빛추종)를 branchless step-mask로 고른다. 셰이더 안 mode 분기 → 새 uniform 0개(설계 B).
+// 각 세트는 실기기(S25) 실측으로 4종이 확연히 구분되게 벌렸다.
+// 필드: OPD_GAIN(밴드 수), KRGB(금↔청록 분리), METAL_FLOOR(콘트라스트; 낮을수록↑), WASHOUT(파스텔율;
+//       높을수록 은백), MOD(focal-pool 추종 = "빛 반사처럼 깔리는" 세기; 셰이더 내부 효과 modulate).
+// OilSlick: 촘촘 다밴드 + 넓은 분리 + 저washout(고채도) + 강한 빛추종 → 기름막.
+const float CHROMA_OIL_GAIN       = 5.5;
+const float3 CHROMA_OIL_KRGB      = float3(1.0, 1.30, 1.72);
+const float CHROMA_OIL_FLOOR      = 0.05;
+const float CHROMA_OIL_WASHOUT    = 0.07;
+const float CHROMA_OIL_MOD        = 0.75;
+// SoapBubble: 넓은 띠(저밀도) + 높은 washout(파스텔·은백) + 약한 빛추종(면 균일) → 비눗방울.
+const float CHROMA_SOAP_GAIN      = 1.7;
+const float3 CHROMA_SOAP_KRGB     = float3(1.0, 1.11, 1.26);
+const float CHROMA_SOAP_FLOOR     = 0.22;
+const float CHROMA_SOAP_WASHOUT   = 0.50;
+const float CHROMA_SOAP_MOD       = 0.22;
+// MetallicFoil: 저washout(채도유지) + 저floor(콘트라스트↑) + 강한 빛추종 → 강한 고채도 금속박.
+const float CHROMA_FOILM_GAIN     = 3.6;
+const float3 CHROMA_FOILM_KRGB    = float3(1.0, 1.26, 1.62);
+const float CHROMA_FOILM_FLOOR    = 0.03;
+const float CHROMA_FOILM_WASHOUT  = 0.05;
+const float CHROMA_FOILM_MOD      = 0.82;
+// Pearl: 높은 washout(파스텔) + 높은 floor(저콘트라스트 은백) + 좁은 분리 → 은은한 진주.
+const float CHROMA_PEARL_GAIN     = 2.4;
+const float3 CHROMA_PEARL_KRGB    = float3(1.0, 1.07, 1.18);
+const float CHROMA_PEARL_FLOOR    = 0.46;
+const float CHROMA_PEARL_WASHOUT  = 0.58;
+const float CHROMA_PEARL_MOD      = 0.20;
+// Fresnel rim 부스트 — 가장자리(cT→1)서 무지개를 더 밝게(유리 림에 빛 걸림).
+// MetallicFoil/Pearl에만 가산(아래 mFoilM/mPearl 마스크). 저비용 1항.
+const float CHROMA_RIM_POW        = 3.0;
+const float CHROMA_RIM_GAIN       = 0.45;
+
 // Signed distance to a box with rounded corners
 // Negative = inside, Positive = outside, Zero = on boundary
 float boxRoundedSDF(float2 p, float2 halfDim, float r) {
@@ -611,6 +720,26 @@ half4 main(float2 xy) {
         float3 foilRGB = clamp(
             abs(fract(float3(hueF) + float3(0.0, 2.0 / 3.0, 1.0 / 3.0)) * 6.0 - 3.0) - 1.0,
             0.0, 1.0);
+        // --- per-look 파라미터 선택 (chromaticMode → thin-film 세트), branchless step-mask ---
+        // 마스크는 정확히 0.0/1.0 (step 결과의 곱) → mode 0은 m0=1·나머지=0 → 모든 param이 베이스
+        // const와 IEEE bit 동일(x*1+0*…=x). ∴ Iridescent(mode 0) 무회귀 보장. mode 1(Foil)은 아래
+        // isFoil 경로로 분리돼 thinFilm 자체가 버려지므로 param 무관(불변).
+        float cMode  = chromaticMode;
+        float m0     = 1.0 - step(0.5, cMode);                       // mode 0 (Iridescent, 베이스)
+        float mOil   = step(1.5, cMode) * (1.0 - step(2.5, cMode));  // mode 2
+        float mSoap  = step(2.5, cMode) * (1.0 - step(3.5, cMode));  // mode 3
+        float mFoilM = step(3.5, cMode) * (1.0 - step(4.5, cMode));  // mode 4
+        float mPearl = step(4.5, cMode);                             // mode 5 (이상)
+        // 각 룩 세트를 마스크 가중합으로 고른다(분기 발산 0). mode 0/1에서 베이스 const 비트 보존.
+        float  lookGain    = CHROMA_OPD_GAIN * m0 + CHROMA_OIL_GAIN * mOil + CHROMA_SOAP_GAIN * mSoap
+                           + CHROMA_FOILM_GAIN * mFoilM + CHROMA_PEARL_GAIN * mPearl;
+        float3 lookKRGB    = CHROMA_KRGB * m0 + CHROMA_OIL_KRGB * mOil + CHROMA_SOAP_KRGB * mSoap
+                           + CHROMA_FOILM_KRGB * mFoilM + CHROMA_PEARL_KRGB * mPearl;
+        float  lookFloor   = CHROMA_METAL_FLOOR * m0 + CHROMA_OIL_FLOOR * mOil + CHROMA_SOAP_FLOOR * mSoap
+                           + CHROMA_FOILM_FLOOR * mFoilM + CHROMA_PEARL_FLOOR * mPearl;
+        float  lookWashout = CHROMA_WASHOUT * m0 + CHROMA_OIL_WASHOUT * mOil + CHROMA_SOAP_WASHOUT * mSoap
+                           + CHROMA_FOILM_WASHOUT * mFoilM + CHROMA_PEARL_WASHOUT * mPearl;
+
         // Iridescent: 박막 간섭(Newton's rings). 광학 경로차 opd = thickness/cos(refr).
         //   thickness = bevel 깊이 cT(중심0→림1; cNcos=1-cT) → 림으로 갈수록 막이 두꺼워 밴드 촘촘.
         //   cosT = cos(입사각) = dot(cN,cL) → 빛이 돌면 위상 쓸림(gyro 반응). 1e-2 가드(grazing 발산).
@@ -619,16 +748,25 @@ half4 main(float2 xy) {
         float thick    = 1.0 - cNcos;                                // = cT, bevel 깊이(중심0→림1)
         float ringTerm = thick / max(1.0 - 0.6 * cosT, 1.0e-2);      // 두께/cos: Newton 링(빛 의존)
         float opdDrive = mix(cosT, ringTerm, CHROMA_THICK_MIX);      // 빛각도↔두께링 블렌드
-        float opd      = opdDrive * (chromaticCycles * CHROMA_OPD_GAIN) + CHROMA_OPD_BASE + chromaticPhase;
+        float opd      = opdDrive * (chromaticCycles * lookGain) + CHROMA_OPD_BASE + chromaticPhase;
         // per-channel 보강간섭(파장 역수비 kRGB). 0.5+0.5cos = [0,1] 중심 0.5(은백 기준 진동).
-        float3 interf = 0.5 + 0.5 * cos(6.28318530718 * opd * CHROMA_KRGB);
+        float3 interf = 0.5 + 0.5 * cos(6.28318530718 * opd * lookKRGB);
         // 금속 floor: 채널이 0까지 안 떨어지게(형광 무지개=채널 하나 늘 0 → sticker). 진동폭만 살린다.
-        float3 metalRGB = CHROMA_METAL_FLOOR + (1.0 - CHROMA_METAL_FLOOR) * interf;
+        float3 metalRGB = lookFloor + (1.0 - lookFloor) * interf;
         // 고차 coherence wash-out: OPD 클수록 파스텔→clean silver(흰 1.0 기준; metalRGB luma로 하면
         // 저채도부가 베이지로 탁해진다). 약하게 둬 금속 채도 유지. sat=간섭색 보존율.
-        float  sat       = exp(-opd * CHROMA_WASHOUT);
+        float  sat       = exp(-opd * lookWashout);
         float3 thinFilm  = mix(float3(1.0), metalRGB, clamp(sat, 0.0, 1.0)); // 은백(흰) ↔ 간섭색
-        float3 chromaRGB = mix(thinFilm, foilRGB, chromaticMode);    // mode 0→thin-film, 1→Foil(불변)
+        // Fresnel rim 부스트: 가장자리(cT→1)서 thinFilm을 흰쪽으로 더 밝게(유리 림 광택).
+        //   MetallicFoil/Pearl만(mFoilM+mPearl 마스크) → Iridescent/Foil/Oil/Soap 불변.
+        //   cT=thick(중심0→림1). pow로 림 집중. 0..1 안에서 mix → 클램프 불필요.
+        float  rimSel    = mFoilM + mPearl;                          // 0/1 (해당 모드만)
+        float  rimBoost  = rimSel * CHROMA_RIM_GAIN * pow(clamp(thick, 0.0, 1.0), CHROMA_RIM_POW);
+        thinFilm         = mix(thinFilm, float3(1.0), clamp(rimBoost, 0.0, 1.0)); // 림으로 갈수록 백광
+        // mode 1만 Foil(선형 띠)로 분기, 나머지(0,2,3,4,5)는 thin-film. step-window = 정확히 0/1 →
+        //   mode 1: mix(thinFilm, foilRGB, 1.0)=foilRGB(불변). mode 0: mix(...,0.0)=thinFilm(불변).
+        float  isFoil    = step(0.5, cMode) * (1.0 - step(1.5, cMode));
+        float3 chromaRGB = mix(thinFilm, foilRGB, isFoil);           // 1=Foil, 그외=thin-film 변형
 
         // focal-pool 모듈레이션 — specular의 raw pool²(정규화본; specStrength/Gain 곱 전)으로 무지개 세기 변조.
         // specular 게이트 밖이라 pool을 저렴하게 재계산(length+smoothstep 몇 줄): focal/poolR 식은 specular와 동일.
@@ -636,7 +774,15 @@ half4 main(float2 xy) {
         float  cPoolR  = max(cMinHalf * specPoolFrac, 1.0);          // zero-width smoothstep 가드
         float  cPool   = 1.0 - smoothstep(0.0, cPoolR, length(p - cFocal)); // 1 at focal, 0 at rim (edge0<edge1)
         float  poolNorm = clamp(cPool * cPool, 0.0, 1.0);           // raw pool²(정규화) = modulator
-        float  chroma  = chromaticIntensity * mix(1.0, poolNorm, chromaticModulate);
+        // "빛 반사처럼 깔리는" 강화 — 무지개 세기를 focal-pool(빛 핫스팟)로 변조해 빛 따라 진해진다.
+        //   effMod = focal-pool 추종 세기. mode 0(Iridescent)/1(Foil)은 binding 값(chromaticModulate,
+        //   현재 0.3) 그대로 → bit-exact 무회귀(마스크 0/1, x*1+0*…=x). 신규 4종만 per-look(0.2~0.82)로
+        //   끌어올려 카드 위 빛 반사 지각을 강화. 새 식/uniform 0개(기존 cPool 재사용).
+        float  baseMod = m0 + isFoil;                               // mode 0 또는 1 → 1.0, 그외 0.0
+        float  effMod  = chromaticModulate * baseMod
+                       + CHROMA_OIL_MOD * mOil + CHROMA_SOAP_MOD * mSoap
+                       + CHROMA_FOILM_MOD * mFoilM + CHROMA_PEARL_MOD * mPearl;
+        float  chroma  = chromaticIntensity * mix(1.0, poolNorm, clamp(effMod, 0.0, 1.0));
 
         // 두 경로가 정반대 블렌드를 원한다 → content alpha로 보간:
         //   투명 베이스(a→0, 흰 카드): cOnWhite = chromaRGB. 흰(1,1,1)*무지개 = 순수 무지개. screen이면

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassShaderSource.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/LiquidGlassShaderSource.kt
@@ -285,12 +285,21 @@ half4 main(float2 xy) {
         // specular 게이트 밖이라 pool을 저렴하게 재계산(length+smoothstep 몇 줄): focal/poolR 식은 specular와 동일.
         float2 cFocal  = cLightVec * (cMinHalf * specFocalK);        // 빛 방향 오프셋(lensCenter=원점 기준)
         float  cPoolR  = max(cMinHalf * specPoolFrac, 1.0);          // zero-width smoothstep 가드
-        float  cPool   = smoothstep(cPoolR, 0.0, length(p - cFocal));// 1 at focal, 0 at rim
+        float  cPool   = 1.0 - smoothstep(0.0, cPoolR, length(p - cFocal)); // 1 at focal, 0 at rim (edge0<edge1)
         float  poolNorm = clamp(cPool * cPool, 0.0, 1.0);           // raw pool²(정규화) = modulator
         float  chroma  = chromaticIntensity * mix(1.0, poolNorm, chromaticModulate);
 
-        // tint-multiply 블렌드: chroma=0→불변, chroma=1→pixel*chromaRGB. 흰 배경이 chromaRGB로 물든다.
-        pixel.rgb = mix(pixel.rgb, pixel.rgb * half3(chromaRGB), clamp(chroma, 0.0, 1.0));
+        // tint-multiply 블렌드: chroma=0→불변, chroma=1→pixel*chromaRGB.
+        // 흰 카드는 background()가 liquidGlass 레이어 '뒤'에 그려져 content.eval()이 그 영역을 투명(a≈0)으로
+        // 돌려준다 → multiply는 보여줄 픽셀이 없다. 오버레이를 '얹는 재질'로 보이게: 빛나는 베이스(흰색이 깔린
+        // 것으로 가정)에 chromaRGB를 곱한 값과, 실제 content(불투명 사진 등) 위 tint-multiply를 content alpha로
+        // 보간하고, alpha를 chroma 만큼 끌어올린다. 불투명 content(a=1)면 정확히 기존 tint-multiply와 동일(무회귀).
+        // chromaticIntensity==0이면 이 블록 자체가 실행되지 않아 bit-exact off 보존.
+        half  cChroma  = half(clamp(chroma, 0.0, 1.0));
+        half3 cOnWhite = half3(chromaRGB);                         // 흰 베이스(1,1,1) * chromaRGB = chromaRGB
+        half3 cOnSrc   = mix(pixel.rgb, pixel.rgb * half3(chromaRGB), cChroma); // 불투명 content 위 동작(불변)
+        pixel.rgb = mix(cOnWhite, cOnSrc, pixel.a);               // a=0→흰 위 무지개, a=1→기존 multiply
+        pixel.a   = max(pixel.a, cChroma);                        // 투명 배경에서도 오버레이가 보이도록
     }
 
     // Anti-aliased edge transition
@@ -553,12 +562,21 @@ half4 main(float2 xy) {
         // specular 게이트 밖이라 pool을 저렴하게 재계산(length+smoothstep 몇 줄): focal/poolR 식은 specular와 동일.
         float2 cFocal  = cLightVec * (cMinHalf * specFocalK);        // 빛 방향 오프셋(lensCenter=원점 기준)
         float  cPoolR  = max(cMinHalf * specPoolFrac, 1.0);          // zero-width smoothstep 가드
-        float  cPool   = smoothstep(cPoolR, 0.0, length(p - cFocal));// 1 at focal, 0 at rim
+        float  cPool   = 1.0 - smoothstep(0.0, cPoolR, length(p - cFocal)); // 1 at focal, 0 at rim (edge0<edge1)
         float  poolNorm = clamp(cPool * cPool, 0.0, 1.0);           // raw pool²(정규화) = modulator
         float  chroma  = chromaticIntensity * mix(1.0, poolNorm, chromaticModulate);
 
-        // tint-multiply 블렌드: chroma=0→불변, chroma=1→pixel*chromaRGB. 흰 배경이 chromaRGB로 물든다.
-        pixel.rgb = mix(pixel.rgb, pixel.rgb * half3(chromaRGB), clamp(chroma, 0.0, 1.0));
+        // tint-multiply 블렌드: chroma=0→불변, chroma=1→pixel*chromaRGB.
+        // 흰 카드는 background()가 liquidGlass 레이어 '뒤'에 그려져 content.eval()이 그 영역을 투명(a≈0)으로
+        // 돌려준다 → multiply는 보여줄 픽셀이 없다. 오버레이를 '얹는 재질'로 보이게: 빛나는 베이스(흰색이 깔린
+        // 것으로 가정)에 chromaRGB를 곱한 값과, 실제 content(불투명 사진 등) 위 tint-multiply를 content alpha로
+        // 보간하고, alpha를 chroma 만큼 끌어올린다. 불투명 content(a=1)면 정확히 기존 tint-multiply와 동일(무회귀).
+        // chromaticIntensity==0이면 이 블록 자체가 실행되지 않아 bit-exact off 보존.
+        half  cChroma  = half(clamp(chroma, 0.0, 1.0));
+        half3 cOnWhite = half3(chromaRGB);                         // 흰 베이스(1,1,1) * chromaRGB = chromaRGB
+        half3 cOnSrc   = mix(pixel.rgb, pixel.rgb * half3(chromaRGB), cChroma); // 불투명 content 위 동작(불변)
+        pixel.rgb = mix(cOnWhite, cOnSrc, pixel.a);               // a=0→흰 위 무지개, a=1→기존 multiply
+        pixel.a   = max(pixel.a, cChroma);                        // 투명 배경에서도 오버레이가 보이도록
     }
 
     // Anti-aliased edge transition

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/TransformLight.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/TransformLight.kt
@@ -1,0 +1,126 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.cloudy
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.geometry.Offset
+import kotlin.math.PI
+import kotlin.math.sin
+
+/**
+ * Creates a transform-driven [LiquidGlassLight] whose direction tracks the **target composable's own
+ * 3D rotation** (the `rotationX` / `rotationY` it is drawn with via `Modifier.graphicsLayer`), so the
+ * Liquid Glass specular highlight responds to the surface tilting in space — no gyroscope, no sensor,
+ * no platform code. Unlike `rememberGyroLightSource`, this is fully deterministic and runs on every
+ * target including Desktop and Web.
+ *
+ * ## Ownership (the caller owns the `graphicsLayer`)
+ * This factory does **not** rotate anything. The caller applies the rotation on the target itself:
+ *
+ * ```kotlin
+ * var rx by remember { mutableFloatStateOf(0f) }
+ * var ry by remember { mutableFloatStateOf(0f) }
+ * val light = rememberTransformLightSource(rotationX = { rx }, rotationY = { ry })
+ * Box(
+ *   Modifier
+ *     .graphicsLayer { rotationX = rx; rotationY = ry; cameraDistance = 12f * density }
+ *     .liquidGlass(light = light, /* … */),
+ * )
+ * ```
+ *
+ * The same `rx` / `ry` that drive the layer drive the light, so the highlight stays consistent with
+ * the visible tilt. This keeps the holder identity stable (only its value changes), so a per-frame
+ * rotation update invalidates the **draw** without recomposing the modifier — the same guarantee the
+ * gyro source gives.
+ *
+ * ## Sign convention (screen space, y-down)
+ * - **`rotationY`** (yaw about the screen X axis... i.e. about the vertical screen-Y axis): positive
+ *   `rotationY` slides the hotspot toward **+x** (screen-right).
+ * - **`rotationX`** (pitch about the horizontal screen-X axis): positive `rotationX` slides the
+ *   hotspot toward **-y** (screen-up, because screen space is y-down).
+ *
+ * A flat surface (`rotationX == 0 && rotationY == 0`) yields the normalized [base] exactly — the same
+ * resting invariant as the gyro projection.
+ *
+ * @param rotationX Deferred read of the target's current `rotationX` in **degrees** (pitch). Passed
+ *   as a lambda so per-frame updates re-emit through `snapshotFlow` without recomposing this factory.
+ * @param rotationY Deferred read of the target's current `rotationY` in **degrees** (yaw).
+ * @param base The resting light direction used when the surface is flat. Defaults to
+ *   [LiquidGlassDefaults.LIGHT_DIR]. Normalized internally, so magnitude is irrelevant.
+ * @param gain How strongly rotation displaces the light from [base]. Higher = more sweep.
+ * @return A [LiquidGlassLight] suitable for [Modifier.liquidGlass]'s / [Modifier.liquidGlassTuned]'s
+ *   `light` parameter.
+ */
+@ExperimentalLiquidGlassMotion
+@Composable
+public fun rememberTransformLightSource(
+  rotationX: () -> Float,
+  rotationY: () -> Float,
+  base: Offset = LiquidGlassDefaults.LIGHT_DIR,
+  gain: Float = 1.2f,
+): LiquidGlassLight {
+  val dir = remember { mutableStateOf(transformToLight(rotationX(), rotationY(), base, gain)) }
+  // Deferred reads inside snapshotFlow: per-frame rotation changes re-emit and update the holder
+  // value (draw invalidation) without recomposing this factory. Re-keyed only on base/gain.
+  LaunchedEffect(base, gain) {
+    snapshotFlow { transformToLight(rotationX(), rotationY(), base, gain) }
+      .collect { dir.value = it }
+  }
+  // Stable holder identity; only dir.value changes per frame.
+  return remember(dir) { LiquidGlassLight(dir) }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Pure math — platform-independent so it is unit-testable (commonTest) and free of Compose state.
+// ---------------------------------------------------------------------------------------------
+
+/** Degrees → radians as a single-precision factor (mirrors the gyro math's float-only style). */
+private val DEG_TO_RAD: Float = (PI / 180.0).toFloat()
+
+/**
+ * Projects the target's 3D rotation (in degrees) onto a screen-space light direction (y-down).
+ *
+ * A flat surface (`rotationXDeg == 0 && rotationYDeg == 0`) returns the normalized [base] exactly,
+ * the same invariant as `gravityToLight(0, 0, …)`. Otherwise the in-plane displacement is the sine
+ * of each rotation, scaled by [gain]:
+ * - `+rotationY` → hotspot slides toward **+x** (screen-right).
+ * - `+rotationX` → hotspot slides toward **-y** (screen-up; screen space is y-down).
+ *
+ * [base] is normalized first so the sweep magnitude is consistent regardless of base length.
+ *
+ * @param rotationXDeg pitch about the screen-X axis, in degrees.
+ * @param rotationYDeg yaw about the screen-Y axis, in degrees.
+ */
+internal fun transformToLight(
+  rotationXDeg: Float,
+  rotationYDeg: Float,
+  base: Offset,
+  gain: Float,
+): Offset {
+  val b = normalizeOr(base, Offset(-1f, -1f))
+  val rx = rotationXDeg * DEG_TO_RAD // pitch about screen-X
+  val ry = rotationYDeg * DEG_TO_RAD // yaw about screen-Y
+  return Offset(
+    b.x + gain * sin(ry), // +rotationY -> hotspot slides +x (right)
+    b.y - gain * sin(rx), // +rotationX -> hotspot slides -y (up; screen y-down)
+  )
+}

--- a/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/ChromaticOverlayTest.kt
+++ b/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/ChromaticOverlayTest.kt
@@ -125,9 +125,9 @@ internal class ChromaticOverlayTest :
         LiquidGlassDefaults.NoChromatic.intensity.shouldBe(0f)
       }
 
-      test("Holographic is a foil overlay at the default intensity") {
+      test("Holographic is an iridescent thin-film overlay at the default intensity") {
         LiquidGlassDefaults.Holographic.intensity.shouldBe(LiquidGlassDefaults.CHROMATIC_INTENSITY)
-        LiquidGlassDefaults.Holographic.mode.shouldBe(ChromaticMode.Foil)
+        LiquidGlassDefaults.Holographic.mode.shouldBe(ChromaticMode.Iridescent)
       }
     }
   })

--- a/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/ChromaticOverlayTest.kt
+++ b/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/ChromaticOverlayTest.kt
@@ -105,10 +105,19 @@ internal class ChromaticOverlayTest :
     }
 
     context("ChromaticMode") {
-      test("has exactly two modes in declared order") {
-        ChromaticMode.entries.size.shouldBe(2)
-        ChromaticMode.entries[0].shouldBe(ChromaticMode.Iridescent)
-        ChromaticMode.entries[1].shouldBe(ChromaticMode.Foil)
+      test("has exactly six modes in declared order") {
+        // The binding maps each entry to its ordinal as a float (0f..5f), so this order is the
+        // shader contract — reordering would silently remap the looks.
+        ChromaticMode.entries.shouldBe(
+          listOf(
+            ChromaticMode.Iridescent,
+            ChromaticMode.Foil,
+            ChromaticMode.OilSlick,
+            ChromaticMode.SoapBubble,
+            ChromaticMode.MetallicFoil,
+            ChromaticMode.Pearl,
+          ),
+        )
       }
     }
 
@@ -128,6 +137,26 @@ internal class ChromaticOverlayTest :
       test("Holographic is an iridescent thin-film overlay at the default intensity") {
         LiquidGlassDefaults.Holographic.intensity.shouldBe(LiquidGlassDefaults.CHROMATIC_INTENSITY)
         LiquidGlassDefaults.Holographic.mode.shouldBe(ChromaticMode.Iridescent)
+      }
+
+      test("OilSlick is the OilSlick mode at the default intensity") {
+        LiquidGlassDefaults.OilSlick.intensity.shouldBe(LiquidGlassDefaults.CHROMATIC_INTENSITY)
+        LiquidGlassDefaults.OilSlick.mode.shouldBe(ChromaticMode.OilSlick)
+      }
+
+      test("SoapBubble is the SoapBubble mode at the default intensity") {
+        LiquidGlassDefaults.SoapBubble.intensity.shouldBe(LiquidGlassDefaults.CHROMATIC_INTENSITY)
+        LiquidGlassDefaults.SoapBubble.mode.shouldBe(ChromaticMode.SoapBubble)
+      }
+
+      test("MetallicFoil is the MetallicFoil mode raised to a stronger intensity") {
+        LiquidGlassDefaults.MetallicFoil.intensity.shouldBe(0.75f)
+        LiquidGlassDefaults.MetallicFoil.mode.shouldBe(ChromaticMode.MetallicFoil)
+      }
+
+      test("Pearl is the Pearl mode lowered to a subtle intensity") {
+        LiquidGlassDefaults.Pearl.intensity.shouldBe(0.45f)
+        LiquidGlassDefaults.Pearl.mode.shouldBe(ChromaticMode.Pearl)
       }
     }
   })

--- a/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/ChromaticOverlayTest.kt
+++ b/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/ChromaticOverlayTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalLiquidGlassMaterial::class)
+
+package com.skydoves.cloudy
+
+import androidx.compose.ui.graphics.Color
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Unit tests for [ChromaticOverlay], [ChromaticMode], and the chromatic [LiquidGlassDefaults].
+ *
+ * Tests verify:
+ * - The hand-written equals/hashCode contract (incl. -0.0f normalization)
+ * - The factory's defensive `.toList()` copy of `spectrum`
+ * - Default presets ([LiquidGlassDefaults.NoChromatic], [LiquidGlassDefaults.Holographic])
+ */
+internal class ChromaticOverlayTest :
+  FunSpec({
+
+    context("ChromaticOverlay equals / hashCode") {
+      test("equal instances are equal and share a hash code") {
+        val a = ChromaticOverlay(intensity = 0.6f, mode = ChromaticMode.Foil)
+        val b = ChromaticOverlay(intensity = 0.6f, mode = ChromaticMode.Foil)
+        a.shouldBe(b)
+        a.hashCode().shouldBe(b.hashCode())
+      }
+
+      test("differing intensity is not equal") {
+        val a = ChromaticOverlay(intensity = 0.6f, mode = ChromaticMode.Foil)
+        val b = ChromaticOverlay(intensity = 0.3f, mode = ChromaticMode.Foil)
+        a.shouldNotBe(b)
+      }
+
+      test("differing mode is not equal") {
+        val a = ChromaticOverlay(intensity = 0.6f, mode = ChromaticMode.Foil)
+        val b = ChromaticOverlay(intensity = 0.6f, mode = ChromaticMode.Iridescent)
+        a.shouldNotBe(b)
+      }
+
+      test("differing spectrum is not equal") {
+        val a = ChromaticOverlay(intensity = 0.6f, spectrum = listOf(Color.Red))
+        val b = ChromaticOverlay(intensity = 0.6f, spectrum = listOf(Color.Blue))
+        a.shouldNotBe(b)
+      }
+
+      test("structurally-equal spectrum lists are equal") {
+        // Different list instances, same contents -> structural list equality.
+        val a = ChromaticOverlay(intensity = 0.6f, spectrum = listOf(Color.Red, Color.Green))
+        val b = ChromaticOverlay(intensity = 0.6f, spectrum = listOf(Color.Red, Color.Green))
+        a.shouldBe(b)
+        a.hashCode().shouldBe(b.hashCode())
+      }
+
+      test("-0.0f and 0.0f intensity compare equal AND hash equal") {
+        // equals() uses `==` (so -0.0f == 0.0f), but Float.hashCode() hashes bits and would differ.
+        // The -0.0f -> 0.0f normalization in hashCode() keeps the equals/hashCode contract.
+        val zero = ChromaticOverlay(intensity = 0.0f, mode = ChromaticMode.Iridescent)
+        val negZero = ChromaticOverlay(intensity = -0.0f, mode = ChromaticMode.Iridescent)
+        zero.shouldBe(negZero)
+        zero.hashCode().shouldBe(negZero.hashCode())
+      }
+
+      test("equals is reflexive and null-safe") {
+        val a = ChromaticOverlay(intensity = 0.6f)
+        a.shouldBe(a)
+        a.equals(null).shouldBe(false)
+        a.equals("not an overlay").shouldBe(false)
+      }
+    }
+
+    context("ChromaticOverlay factory") {
+      test("factory defensively copies the spectrum (.toList())") {
+        // Mutating the caller's original list after construction must not affect the holder, so the
+        // @Immutable contract holds.
+        val original = mutableListOf(Color.Red, Color.Green)
+        val overlay = ChromaticOverlay(intensity = 0.6f, spectrum = original)
+        original.add(Color.Blue)
+        overlay.spectrum.shouldBe(listOf(Color.Red, Color.Green))
+        overlay.spectrum.size.shouldBe(2)
+      }
+
+      test("default factory values match the chromatic defaults") {
+        val overlay = ChromaticOverlay()
+        overlay.intensity.shouldBe(LiquidGlassDefaults.CHROMATIC_INTENSITY)
+        overlay.mode.shouldBe(ChromaticMode.Iridescent)
+        overlay.spectrum.shouldBe(LiquidGlassDefaults.HOLOGRAPHIC_SPECTRUM)
+        overlay.customBrush.shouldBe(null)
+      }
+    }
+
+    context("ChromaticMode") {
+      test("has exactly two modes in declared order") {
+        ChromaticMode.entries.size.shouldBe(2)
+        ChromaticMode.entries[0].shouldBe(ChromaticMode.Iridescent)
+        ChromaticMode.entries[1].shouldBe(ChromaticMode.Foil)
+      }
+    }
+
+    context("LiquidGlassDefaults chromatic") {
+      test("CHROMATIC_INTENSITY is the documented mid value") {
+        LiquidGlassDefaults.CHROMATIC_INTENSITY.shouldBe(0.6f)
+      }
+
+      test("HOLOGRAPHIC_SPECTRUM is a non-empty rainbow") {
+        LiquidGlassDefaults.HOLOGRAPHIC_SPECTRUM.size.shouldBe(7)
+      }
+
+      test("NoChromatic disables the sheen (zero intensity)") {
+        LiquidGlassDefaults.NoChromatic.intensity.shouldBe(0f)
+      }
+
+      test("Holographic is a foil overlay at the default intensity") {
+        LiquidGlassDefaults.Holographic.intensity.shouldBe(LiquidGlassDefaults.CHROMATIC_INTENSITY)
+        LiquidGlassDefaults.Holographic.mode.shouldBe(ChromaticMode.Foil)
+      }
+    }
+  })

--- a/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/GyroMathTest.kt
+++ b/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/GyroMathTest.kt
@@ -1,0 +1,122 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.cloudy
+
+import androidx.compose.ui.geometry.Offset
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.floats.plusOrMinus
+import io.kotest.matchers.shouldBe
+import kotlin.math.abs
+
+/**
+ * Unit tests for the platform-independent gyro light math in `GyroLight.kt`. Sensors cannot run in
+ * unit tests, so the testable surface is the pure functions the platform providers delegate to.
+ */
+internal class GyroMathTest :
+  FunSpec({
+
+    context("emaStep") {
+      test("converges to a constant target") {
+        var s = Offset(0f, 0f)
+        val target = Offset(1f, 1f)
+        repeat(50) { s = emaStep(s, target, 0.2f) }
+        s.x.shouldBe(1f plusOrMinus 0.01f)
+        s.y.shouldBe(1f plusOrMinus 0.01f)
+      }
+
+      test("a smaller alpha damps a single spike more than a larger alpha") {
+        val prev = Offset(0f, 0f)
+        val spike = Offset(1f, 0f)
+        val low = emaStep(prev, spike, 0.1f)
+        val high = emaStep(prev, spike, 0.9f)
+        (low.x < high.x).shouldBe(true)
+      }
+    }
+
+    context("gravityToLight (Android, m/s²)") {
+      test("flat device returns the base direction unchanged") {
+        val base = Offset(-1f, -1f)
+        gravityToLight(0f, 0f, base, 1.2f).shouldBe(base.let { normalizeOr(it, it) })
+      }
+
+      test("tilt sign: positive in-plane gravity x shifts the light negative on x") {
+        // base normalized is (-0.707, -0.707); -gx/9.81 with gx>0 is negative.
+        val base = Offset(-1f, -1f)
+        val flat = gravityToLight(0f, 0f, base, 1.2f)
+        val tilted = gravityToLight(5f, 0f, base, 1.2f)
+        (tilted.x < flat.x).shouldBe(true)
+      }
+    }
+
+    context("projectGravityPortrait (iOS, G units)") {
+      test("flat device returns the base direction unchanged") {
+        val base = Offset(-1f, -1f)
+        projectGravityPortrait(0f, 0f, base, 1.2f).shouldBe(base.let { normalizeOr(it, it) })
+      }
+
+      test("G-unit gravity is not divided, so sweep is ~10x stronger than the m/s² helper") {
+        val base = Offset(-1f, -1f)
+        val ios = projectGravityPortrait(0.5f, 0f, base, 1.2f)
+        val android = gravityToLight(0.5f, 0f, base, 1.2f)
+        val iosDelta = abs(ios.x - normalizeOr(base, base).x)
+        val androidDelta = abs(android.x - normalizeOr(base, base).x)
+        (iosDelta > androidDelta * 5f).shouldBe(true)
+      }
+
+      test("tilt sign: lowering the right edge (gx>0) shifts the light toward screen-right") {
+        val base = Offset(-1f, -1f)
+        val flat = projectGravityPortrait(0f, 0f, base, 1.2f)
+        val tilted = projectGravityPortrait(0.5f, 0f, base, 1.2f)
+        (tilted.x > flat.x).shouldBe(true)
+      }
+    }
+
+    context("normalizeOr") {
+      test("returns the unit vector of a non-zero offset") {
+        val n = normalizeOr(Offset(3f, 4f), Offset(-1f, -1f))
+        n.x.shouldBe(0.6f plusOrMinus 0.001f)
+        n.y.shouldBe(0.8f plusOrMinus 0.001f)
+      }
+
+      test("falls back when the offset is ~zero") {
+        val fallback = Offset(-1f, -1f)
+        normalizeOr(Offset(0f, 0f), fallback).shouldBe(fallback)
+      }
+    }
+
+    context("shouldRunSensor truth table") {
+      test("runs only when enabled, motion allowed, sensor present, shader path active") {
+        shouldRunSensor(enabled = true, reduceMotion = false, hasSensor = true, shaderPathActive = true)
+          .shouldBe(true)
+      }
+      test("reduce motion disables it") {
+        shouldRunSensor(enabled = true, reduceMotion = true, hasSensor = true, shaderPathActive = true)
+          .shouldBe(false)
+      }
+      test("disabled disables it") {
+        shouldRunSensor(enabled = false, reduceMotion = false, hasSensor = true, shaderPathActive = true)
+          .shouldBe(false)
+      }
+      test("no sensor disables it") {
+        shouldRunSensor(enabled = true, reduceMotion = false, hasSensor = false, shaderPathActive = true)
+          .shouldBe(false)
+      }
+      test("inactive shader path disables it") {
+        shouldRunSensor(enabled = true, reduceMotion = false, hasSensor = true, shaderPathActive = false)
+          .shouldBe(false)
+      }
+    }
+  })

--- a/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/GyroMathTest.kt
+++ b/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/GyroMathTest.kt
@@ -99,23 +99,48 @@ internal class GyroMathTest :
 
     context("shouldRunSensor truth table") {
       test("runs only when enabled, motion allowed, sensor present, shader path active") {
-        shouldRunSensor(enabled = true, reduceMotion = false, hasSensor = true, shaderPathActive = true)
+        shouldRunSensor(
+          enabled = true,
+          reduceMotion = false,
+          hasSensor = true,
+          shaderPathActive = true,
+        )
           .shouldBe(true)
       }
       test("reduce motion disables it") {
-        shouldRunSensor(enabled = true, reduceMotion = true, hasSensor = true, shaderPathActive = true)
+        shouldRunSensor(
+          enabled = true,
+          reduceMotion = true,
+          hasSensor = true,
+          shaderPathActive = true,
+        )
           .shouldBe(false)
       }
       test("disabled disables it") {
-        shouldRunSensor(enabled = false, reduceMotion = false, hasSensor = true, shaderPathActive = true)
+        shouldRunSensor(
+          enabled = false,
+          reduceMotion = false,
+          hasSensor = true,
+          shaderPathActive = true,
+        )
           .shouldBe(false)
       }
       test("no sensor disables it") {
-        shouldRunSensor(enabled = true, reduceMotion = false, hasSensor = false, shaderPathActive = true)
+        shouldRunSensor(
+          enabled = true,
+          reduceMotion = false,
+          hasSensor = false,
+          shaderPathActive = true,
+        )
           .shouldBe(false)
       }
       test("inactive shader path disables it") {
-        shouldRunSensor(enabled = true, reduceMotion = false, hasSensor = true, shaderPathActive = false)
+        shouldRunSensor(
+          enabled = true,
+          reduceMotion = false,
+          hasSensor = true,
+          shaderPathActive = false,
+        )
           .shouldBe(false)
       }
     }

--- a/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/LiquidGlassHighlightMathTest.kt
+++ b/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/LiquidGlassHighlightMathTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.cloudy
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.IntSize
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.floats.plusOrMinus
+import io.kotest.matchers.shouldBe
+
+/**
+ * Unit tests for the platform-independent focal-pool geometry in `LiquidGlassHighlight.kt`. The draw
+ * helpers in both platform bindings call [highlightPoolCenter] / [highlightPoolRadius] directly, so
+ * these pin the exact center placement and radius clamp the shipped highlight uses. Screen space is
+ * y-down (matches the shader and the gyro/transform light projection).
+ */
+internal class LiquidGlassHighlightMathTest :
+  FunSpec({
+
+    val size = IntSize(400, 200) // minDim = 200
+    val poolFrac = HIGHLIGHT_POOL_FRAC
+    val focalK = HIGHLIGHT_FOCAL_K
+
+    context("highlightPoolRadius") {
+      test("radius is minDim * poolFrac in the normal case") {
+        highlightPoolRadius(size, poolFrac).shouldBe((200f * poolFrac) plusOrMinus 1e-3f)
+      }
+
+      test("uses the smaller dimension (min, not max)") {
+        // 200 is the min dim of 400x200, so radius keys off 200 regardless of width.
+        highlightPoolRadius(IntSize(50, 200), poolFrac)
+          .shouldBe((50f * poolFrac) plusOrMinus 1e-3f)
+      }
+
+      test("clamps to 1f when minDim is 0 (zero-width gradient guard)") {
+        highlightPoolRadius(IntSize(0, 0), poolFrac).shouldBe(1f)
+        highlightPoolRadius(IntSize(400, 0), poolFrac).shouldBe(1f)
+      }
+
+      test("clamps to 1f when minDim * poolFrac would be below 1f") {
+        // 1px * 0.7 = 0.7 -> clamps up to 1f.
+        highlightPoolRadius(IntSize(1, 1), poolFrac).shouldBe(1f)
+      }
+    }
+
+    context("highlightPoolCenter direction & sign (y-down)") {
+      val halfW = size.width / 2f
+      val halfH = size.height / 2f
+
+      test("flat default dir (-1,-1) shifts the center up-left") {
+        val c = highlightPoolCenter(size, Offset(-1f, -1f), focalK)
+        (c.x < halfW).shouldBe(true) // left
+        (c.y < halfH).shouldBe(true) // up (screen y-down)
+      }
+
+      test("center for (-1,-1) equals size/2 + normalize(-1,-1) * minDim * focalK") {
+        val c = highlightPoolCenter(size, Offset(-1f, -1f), focalK)
+        val n = normalizeOr(Offset(-1f, -1f), Offset(-1f, -1f))
+        val expected = Offset(halfW, halfH) + n * (200f * focalK)
+        c.x.shouldBe(expected.x plusOrMinus 1e-3f)
+        c.y.shouldBe(expected.y plusOrMinus 1e-3f)
+      }
+
+      test("+x light direction pushes center.x right (> w/2)") {
+        val c = highlightPoolCenter(size, Offset(1f, 0f), focalK)
+        (c.x > halfW).shouldBe(true)
+      }
+
+      test("+y light direction (y-down) pushes center.y down (> h/2)") {
+        val c = highlightPoolCenter(size, Offset(0f, 1f), focalK)
+        (c.y > halfH).shouldBe(true)
+      }
+    }
+
+    context("highlightPoolCenter axis independence") {
+      val halfW = size.width / 2f
+      val halfH = size.height / 2f
+
+      test("a pure-x dir leaves center.y at h/2") {
+        highlightPoolCenter(size, Offset(1f, 0f), focalK).y.shouldBe(halfH plusOrMinus 1e-3f)
+      }
+
+      test("a pure-y dir leaves center.x at w/2") {
+        highlightPoolCenter(size, Offset(0f, 1f), focalK).x.shouldBe(halfW plusOrMinus 1e-3f)
+      }
+    }
+
+    context("highlightPoolCenter magnitude independence (reuses normalizeOr)") {
+      test("(-1,-1) and (-1000,-1000) give the same center") {
+        val small = highlightPoolCenter(size, Offset(-1f, -1f), focalK)
+        val large = highlightPoolCenter(size, Offset(-1000f, -1000f), focalK)
+        small.x.shouldBe(large.x plusOrMinus 1e-3f)
+        small.y.shouldBe(large.y plusOrMinus 1e-3f)
+      }
+    }
+  })

--- a/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/LiquidGlassTest.kt
+++ b/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/LiquidGlassTest.kt
@@ -15,6 +15,7 @@
  */
 package com.skydoves.cloudy
 
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import io.kotest.core.spec.style.FunSpec
@@ -71,6 +72,31 @@ internal class LiquidGlassTest :
         LiquidGlassDefaults.EDGE.shouldBe(0.2f)
       }
 
+      test("should have valid default glow intensity") {
+        // Reproduces the historical hardcoded SPEC_STRENGTH.
+        LiquidGlassDefaults.GLOW_INTENSITY.shouldBe(0.7f)
+      }
+
+      test("should have valid default glow sharpness") {
+        // Reproduces the historical hardcoded SPEC_POWER.
+        LiquidGlassDefaults.GLOW_SHARPNESS.shouldBe(10.0f)
+      }
+
+      test("default Glow should carry the default intensity and sharpness") {
+        LiquidGlassDefaults.Glow.intensity.shouldBe(0.7f)
+        LiquidGlassDefaults.Glow.sharpness.shouldBe(10.0f)
+      }
+
+      test("NoGlow should have zero intensity") {
+        LiquidGlassDefaults.NoGlow.intensity.shouldBe(0f)
+      }
+
+      test("should have valid default light direction") {
+        // Unnormalized raw value; the shader applies normalize(). At the default the single
+        // glint rests toward screen bottom-left (the -135° direction in pixel space, y-down).
+        LiquidGlassDefaults.LIGHT_DIR.shouldBe(Offset(-1f, -1f))
+      }
+
       test("should have correct minimum Android API levels") {
         LiquidGlassDefaults.MIN_ANDROID_API_FULL.shouldBe(33)
         LiquidGlassDefaults.MIN_ANDROID_API_FALLBACK.shouldBe(23)
@@ -125,6 +151,35 @@ internal class LiquidGlassTest :
 
       test("should contain edge uniform") {
         LiquidGlassShaderSource.AGSL.contains("uniform float edge").shouldBe(true)
+      }
+
+      test("should contain lightDir uniform") {
+        LiquidGlassShaderSource.AGSL.contains("uniform float2 lightDir").shouldBe(true)
+      }
+
+      test("should contain specular tuning uniforms") {
+        // The SPEC_* compile-time consts were promoted to uniforms so they can be tuned per draw.
+        LiquidGlassShaderSource.AGSL.contains("uniform float specStrength").shouldBe(true)
+        LiquidGlassShaderSource.AGSL.contains("uniform float specPower").shouldBe(true)
+        LiquidGlassShaderSource.AGSL.contains("uniform float specRimMix").shouldBe(true)
+        LiquidGlassShaderSource.AGSL.contains("uniform float specWidthPx").shouldBe(true)
+        LiquidGlassShaderSource.AGSL.contains("uniform float specLightZ").shouldBe(true)
+        LiquidGlassShaderSource.AGSL.contains("uniform float specDomeFrac").shouldBe(true)
+        LiquidGlassShaderSource.AGSL.contains("uniform float specBodyPower").shouldBe(true)
+        LiquidGlassShaderSource.AGSL.contains("uniform float specBodyGain").shouldBe(true)
+      }
+
+      test("should drive specular from the lightDir uniform, not a hardcoded vector") {
+        LiquidGlassShaderSource.AGSL.contains("normalize(lightDir)").shouldBe(true)
+        LiquidGlassShaderSource.AGSL.contains("normalize(float2(-1.0, -1.0))").shouldBe(false)
+      }
+
+      test("should synthesize a fake-3D bevel normal for the specular term") {
+        // radial-mix 경로 제거 → SDF-bevel 노멀 + body/rim crossfade.
+        LiquidGlassShaderSource.AGSL.contains("specBodyPower").shouldBe(true)
+        LiquidGlassShaderSource.AGSL.contains("float3(specDir2 * n_cos").shouldBe(true)
+        LiquidGlassShaderSource.AGSL.contains("mix(normal, radial").shouldBe(false)
+        LiquidGlassShaderSource.AGSL.contains("abs(dot(normal, lightVec))").shouldBe(false) // 유지(여전히 통과)
       }
 
       test("should contain content shader input") {
@@ -202,6 +257,35 @@ internal class LiquidGlassTest :
         LiquidGlassShaderSource.SKSL.contains("uniform float edge").shouldBe(true)
       }
 
+      test("should contain lightDir uniform") {
+        LiquidGlassShaderSource.SKSL.contains("uniform float2 lightDir").shouldBe(true)
+      }
+
+      test("should contain specular tuning uniforms") {
+        // The SPEC_* compile-time consts were promoted to uniforms so they can be tuned per draw.
+        LiquidGlassShaderSource.SKSL.contains("uniform float specStrength").shouldBe(true)
+        LiquidGlassShaderSource.SKSL.contains("uniform float specPower").shouldBe(true)
+        LiquidGlassShaderSource.SKSL.contains("uniform float specRimMix").shouldBe(true)
+        LiquidGlassShaderSource.SKSL.contains("uniform float specWidthPx").shouldBe(true)
+        LiquidGlassShaderSource.SKSL.contains("uniform float specLightZ").shouldBe(true)
+        LiquidGlassShaderSource.SKSL.contains("uniform float specDomeFrac").shouldBe(true)
+        LiquidGlassShaderSource.SKSL.contains("uniform float specBodyPower").shouldBe(true)
+        LiquidGlassShaderSource.SKSL.contains("uniform float specBodyGain").shouldBe(true)
+      }
+
+      test("should drive specular from the lightDir uniform, not a hardcoded vector") {
+        LiquidGlassShaderSource.SKSL.contains("normalize(lightDir)").shouldBe(true)
+        LiquidGlassShaderSource.SKSL.contains("normalize(float2(-1.0, -1.0))").shouldBe(false)
+      }
+
+      test("should synthesize a fake-3D bevel normal for the specular term") {
+        // radial-mix 경로 제거 → SDF-bevel 노멀 + body/rim crossfade.
+        LiquidGlassShaderSource.SKSL.contains("specBodyPower").shouldBe(true)
+        LiquidGlassShaderSource.SKSL.contains("float3(specDir2 * n_cos").shouldBe(true)
+        LiquidGlassShaderSource.SKSL.contains("mix(normal, radial").shouldBe(false)
+        LiquidGlassShaderSource.SKSL.contains("abs(dot(normal, lightVec))").shouldBe(false) // 유지(여전히 통과)
+      }
+
       test("should contain content shader input") {
         LiquidGlassShaderSource.SKSL.contains("uniform shader content").shouldBe(true)
       }
@@ -248,6 +332,14 @@ internal class LiquidGlassTest :
           LiquidGlassShaderSource.AGSL.contains(uniform).shouldBe(true)
           LiquidGlassShaderSource.SKSL.contains(uniform).shouldBe(true)
         }
+      }
+
+      test("AGSL and SKSL should both declare the lightDir uniform") {
+        // Assert the full declaration (not the bare token) on both shaders: the bare
+        // "lightDir" is already satisfied by the normalize(lightDir) usage, so it would
+        // pass even if one shader were missing the declaration — defeating the parity guard.
+        LiquidGlassShaderSource.AGSL.contains("uniform float2 lightDir").shouldBe(true)
+        LiquidGlassShaderSource.SKSL.contains("uniform float2 lightDir").shouldBe(true)
       }
 
       test("AGSL and SKSL should have same helper functions") {

--- a/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/LiquidGlassTest.kt
+++ b/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/LiquidGlassTest.kt
@@ -167,6 +167,9 @@ internal class LiquidGlassTest :
         LiquidGlassShaderSource.AGSL.contains("uniform float specDomeFrac").shouldBe(true)
         LiquidGlassShaderSource.AGSL.contains("uniform float specBodyPower").shouldBe(true)
         LiquidGlassShaderSource.AGSL.contains("uniform float specBodyGain").shouldBe(true)
+        LiquidGlassShaderSource.AGSL.contains("uniform float specFocalK").shouldBe(true)
+        LiquidGlassShaderSource.AGSL.contains("uniform float specPoolFrac").shouldBe(true)
+        LiquidGlassShaderSource.AGSL.contains("uniform float specPoolGain").shouldBe(true)
       }
 
       test("should drive specular from the lightDir uniform, not a hardcoded vector") {
@@ -179,7 +182,8 @@ internal class LiquidGlassTest :
         LiquidGlassShaderSource.AGSL.contains("specBodyPower").shouldBe(true)
         LiquidGlassShaderSource.AGSL.contains("float3(specDir2 * n_cos").shouldBe(true)
         LiquidGlassShaderSource.AGSL.contains("mix(normal, radial").shouldBe(false)
-        LiquidGlassShaderSource.AGSL.contains("abs(dot(normal, lightVec))").shouldBe(false) // 유지(여전히 통과)
+        // 유지(여전히 통과)
+        LiquidGlassShaderSource.AGSL.contains("abs(dot(normal, lightVec))").shouldBe(false)
       }
 
       test("should contain content shader input") {
@@ -271,6 +275,9 @@ internal class LiquidGlassTest :
         LiquidGlassShaderSource.SKSL.contains("uniform float specDomeFrac").shouldBe(true)
         LiquidGlassShaderSource.SKSL.contains("uniform float specBodyPower").shouldBe(true)
         LiquidGlassShaderSource.SKSL.contains("uniform float specBodyGain").shouldBe(true)
+        LiquidGlassShaderSource.SKSL.contains("uniform float specFocalK").shouldBe(true)
+        LiquidGlassShaderSource.SKSL.contains("uniform float specPoolFrac").shouldBe(true)
+        LiquidGlassShaderSource.SKSL.contains("uniform float specPoolGain").shouldBe(true)
       }
 
       test("should drive specular from the lightDir uniform, not a hardcoded vector") {
@@ -283,7 +290,8 @@ internal class LiquidGlassTest :
         LiquidGlassShaderSource.SKSL.contains("specBodyPower").shouldBe(true)
         LiquidGlassShaderSource.SKSL.contains("float3(specDir2 * n_cos").shouldBe(true)
         LiquidGlassShaderSource.SKSL.contains("mix(normal, radial").shouldBe(false)
-        LiquidGlassShaderSource.SKSL.contains("abs(dot(normal, lightVec))").shouldBe(false) // 유지(여전히 통과)
+        // 유지(여전히 통과)
+        LiquidGlassShaderSource.SKSL.contains("abs(dot(normal, lightVec))").shouldBe(false)
       }
 
       test("should contain content shader input") {

--- a/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/LiquidGlassTest.kt
+++ b/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/LiquidGlassTest.kt
@@ -189,11 +189,10 @@ internal class LiquidGlassTest :
       }
 
       test("should synthesize a fake-3D bevel normal for the specular term") {
-        // radial-mix 경로 제거 → SDF-bevel 노멀 + body/rim crossfade.
+        // SDF-bevel normal + body/rim crossfade (no radial-mix path).
         LiquidGlassShaderSource.AGSL.contains("specBodyPower").shouldBe(true)
         LiquidGlassShaderSource.AGSL.contains("float3(specDir2 * n_cos").shouldBe(true)
         LiquidGlassShaderSource.AGSL.contains("mix(normal, radial").shouldBe(false)
-        // 유지(여전히 통과)
         LiquidGlassShaderSource.AGSL.contains("abs(dot(normal, lightVec))").shouldBe(false)
       }
 
@@ -308,11 +307,10 @@ internal class LiquidGlassTest :
       }
 
       test("should synthesize a fake-3D bevel normal for the specular term") {
-        // radial-mix 경로 제거 → SDF-bevel 노멀 + body/rim crossfade.
+        // SDF-bevel normal + body/rim crossfade (no radial-mix path).
         LiquidGlassShaderSource.SKSL.contains("specBodyPower").shouldBe(true)
         LiquidGlassShaderSource.SKSL.contains("float3(specDir2 * n_cos").shouldBe(true)
         LiquidGlassShaderSource.SKSL.contains("mix(normal, radial").shouldBe(false)
-        // 유지(여전히 통과)
         LiquidGlassShaderSource.SKSL.contains("abs(dot(normal, lightVec))").shouldBe(false)
       }
 

--- a/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/LiquidGlassTest.kt
+++ b/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/LiquidGlassTest.kt
@@ -172,6 +172,17 @@ internal class LiquidGlassTest :
         LiquidGlassShaderSource.AGSL.contains("uniform float specPoolGain").shouldBe(true)
       }
 
+      test("should contain chromatic overlay uniforms") {
+        // All 6 chromatic uniforms must be declared; the bindings write every one each draw, so a
+        // missing declaration would read garbage (AGSL).
+        LiquidGlassShaderSource.AGSL.contains("uniform float chromaticIntensity").shouldBe(true)
+        LiquidGlassShaderSource.AGSL.contains("uniform float chromaticMode").shouldBe(true)
+        LiquidGlassShaderSource.AGSL.contains("uniform float chromaticBands").shouldBe(true)
+        LiquidGlassShaderSource.AGSL.contains("uniform float chromaticCycles").shouldBe(true)
+        LiquidGlassShaderSource.AGSL.contains("uniform float chromaticPhase").shouldBe(true)
+        LiquidGlassShaderSource.AGSL.contains("uniform float chromaticModulate").shouldBe(true)
+      }
+
       test("should drive specular from the lightDir uniform, not a hardcoded vector") {
         LiquidGlassShaderSource.AGSL.contains("normalize(lightDir)").shouldBe(true)
         LiquidGlassShaderSource.AGSL.contains("normalize(float2(-1.0, -1.0))").shouldBe(false)
@@ -278,6 +289,17 @@ internal class LiquidGlassTest :
         LiquidGlassShaderSource.SKSL.contains("uniform float specFocalK").shouldBe(true)
         LiquidGlassShaderSource.SKSL.contains("uniform float specPoolFrac").shouldBe(true)
         LiquidGlassShaderSource.SKSL.contains("uniform float specPoolGain").shouldBe(true)
+      }
+
+      test("should contain chromatic overlay uniforms") {
+        // All 6 chromatic uniforms must be declared; Skia throws on any unset declared uniform, so
+        // the bindings write every one each draw.
+        LiquidGlassShaderSource.SKSL.contains("uniform float chromaticIntensity").shouldBe(true)
+        LiquidGlassShaderSource.SKSL.contains("uniform float chromaticMode").shouldBe(true)
+        LiquidGlassShaderSource.SKSL.contains("uniform float chromaticBands").shouldBe(true)
+        LiquidGlassShaderSource.SKSL.contains("uniform float chromaticCycles").shouldBe(true)
+        LiquidGlassShaderSource.SKSL.contains("uniform float chromaticPhase").shouldBe(true)
+        LiquidGlassShaderSource.SKSL.contains("uniform float chromaticModulate").shouldBe(true)
       }
 
       test("should drive specular from the lightDir uniform, not a hardcoded vector") {

--- a/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/TransformLightMathTest.kt
+++ b/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/TransformLightMathTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.cloudy
+
+import androidx.compose.ui.geometry.Offset
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.floats.plusOrMinus
+import io.kotest.matchers.shouldBe
+import kotlin.math.abs
+
+/**
+ * Unit tests for the platform-independent transform-light math in `TransformLight.kt`. The factory
+ * needs Compose state, so the testable surface is the pure [transformToLight] projection the factory
+ * delegates to. Pins the exact sign polarity of the screen-space (y-down) mapping.
+ */
+internal class TransformLightMathTest :
+  FunSpec({
+
+    val base = Offset(-1f, -1f)
+    // base normalized once for displacement-from-rest comparisons.
+    val flat = normalizeOr(base, base)
+
+    context("transformToLight resting invariant") {
+      test("flat surface returns the normalized base direction unchanged") {
+        transformToLight(0f, 0f, base, 1.2f).shouldBe(flat)
+      }
+
+      test("flat surface is independent of gain") {
+        transformToLight(0f, 0f, base, 5f).shouldBe(flat)
+        transformToLight(0f, 0f, base, 0.1f).shouldBe(flat)
+      }
+    }
+
+    context("rotationY drives screen-x") {
+      test("positive rotationY slides the light toward +x (screen-right)") {
+        val tilted = transformToLight(0f, 30f, base, 1.2f)
+        (tilted.x > flat.x).shouldBe(true)
+      }
+
+      test("negative rotationY slides the light toward -x (screen-left)") {
+        val tilted = transformToLight(0f, -30f, base, 1.2f)
+        (tilted.x < flat.x).shouldBe(true)
+      }
+
+      test("rotationY leaves screen-y at the base value") {
+        transformToLight(0f, 30f, base, 1.2f).y.shouldBe(flat.y plusOrMinus 1e-4f)
+      }
+    }
+
+    context("rotationX drives screen-y (y-down)") {
+      test("positive rotationX DECREASES light.y (hotspot slides up)") {
+        val tilted = transformToLight(30f, 0f, base, 1.2f)
+        (tilted.y < flat.y).shouldBe(true)
+      }
+
+      test("negative rotationX INCREASES light.y (hotspot slides down)") {
+        val tilted = transformToLight(-30f, 0f, base, 1.2f)
+        (tilted.y > flat.y).shouldBe(true)
+      }
+
+      test("rotationX leaves screen-x at the base value") {
+        transformToLight(30f, 0f, base, 1.2f).x.shouldBe(flat.x plusOrMinus 1e-4f)
+      }
+    }
+
+    context("gain scales the displacement monotonically") {
+      test("larger gain displaces the light further from rest") {
+        val low = transformToLight(0f, 30f, base, 0.5f)
+        val high = transformToLight(0f, 30f, base, 2.0f)
+        val lowDelta = abs(low.x - flat.x)
+        val highDelta = abs(high.x - flat.x)
+        (highDelta > lowDelta).shouldBe(true)
+      }
+
+      test("displacement is exactly linear in gain") {
+        val g1 = transformToLight(0f, 30f, base, 1f)
+        val g2 = transformToLight(0f, 30f, base, 2f)
+        val d1 = g1.x - flat.x
+        val d2 = g2.x - flat.x
+        d2.shouldBe((d1 * 2f) plusOrMinus 1e-4f)
+      }
+    }
+
+    context("base normalization") {
+      test("any-magnitude base maps to the same direction (reuses normalizeOr)") {
+        val small = transformToLight(0f, 30f, Offset(-1f, -1f), 1.2f)
+        val large = transformToLight(0f, 30f, Offset(-1000f, -1000f), 1.2f)
+        small.x.shouldBe(large.x plusOrMinus 1e-3f)
+        small.y.shouldBe(large.y plusOrMinus 1e-3f)
+      }
+    }
+
+    context("symmetry about the base") {
+      test("(a, b) and (-a, -b) mirror across the base direction") {
+        val pos = transformToLight(20f, 35f, base, 1.2f)
+        val neg = transformToLight(-20f, -35f, base, 1.2f)
+        // Each component is base ± the same displacement, so the two results are symmetric about base.
+        ((pos.x - flat.x)).shouldBe((-(neg.x - flat.x)) plusOrMinus 1e-4f)
+        ((pos.y - flat.y)).shouldBe((-(neg.y - flat.y)) plusOrMinus 1e-4f)
+      }
+    }
+  })

--- a/cloudy/src/desktopMain/kotlin/com/skydoves/cloudy/GyroLight.desktop.kt
+++ b/cloudy/src/desktopMain/kotlin/com/skydoves/cloudy/GyroLight.desktop.kt
@@ -1,0 +1,33 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.cloudy
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.geometry.Offset
+
+/** Desktop (JVM) has no motion sensor: the light stays fixed at [base]. */
+@Composable
+internal actual fun rememberTiltSource(
+  enabled: Boolean,
+  hz: Int,
+  base: Offset,
+  tiltGain: Float,
+  out: MutableState<Offset>,
+) {
+  SideEffect { out.value = base }
+}

--- a/cloudy/src/iosMain/kotlin/com/skydoves/cloudy/GyroLight.ios.kt
+++ b/cloudy/src/iosMain/kotlin/com/skydoves/cloudy/GyroLight.ios.kt
@@ -25,9 +25,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.geometry.Offset
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.useContents
+import platform.CoreMotion.CMAttitudeReferenceFrameXArbitraryCorrectedZVertical
 import platform.CoreMotion.CMDeviceMotion
 import platform.CoreMotion.CMMotionManager
-import platform.CoreMotion.CMAttitudeReferenceFrameXArbitraryCorrectedZVertical
 import platform.Foundation.NSNotificationCenter
 import platform.Foundation.NSOperationQueue
 import platform.Foundation.NSProcessInfo

--- a/cloudy/src/iosMain/kotlin/com/skydoves/cloudy/GyroLight.ios.kt
+++ b/cloudy/src/iosMain/kotlin/com/skydoves/cloudy/GyroLight.ios.kt
@@ -1,0 +1,155 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.skydoves.cloudy
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.geometry.Offset
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.useContents
+import platform.CoreMotion.CMDeviceMotion
+import platform.CoreMotion.CMMotionManager
+import platform.CoreMotion.CMAttitudeReferenceFrameXArbitraryCorrectedZVertical
+import platform.Foundation.NSNotificationCenter
+import platform.Foundation.NSOperationQueue
+import platform.Foundation.NSProcessInfo
+import platform.UIKit.UIAccessibilityIsReduceMotionEnabled
+import platform.UIKit.UIAccessibilityReduceMotionStatusDidChangeNotification
+import platform.darwin.dispatch_async
+import platform.darwin.dispatch_get_main_queue
+
+/**
+ * iOS tilt source. Streams a smoothed, throttled portrait-space light direction from CoreMotion's
+ * device-motion gravity vector. No-op when disabled, when Reduce Motion is on, or when device
+ * motion is unavailable (e.g. the simulator).
+ *
+ * The consuming app's `Info.plist` must declare `NSMotionUsageDescription`, or recent iOS
+ * terminates the app on the first device-motion read.
+ *
+ * v1 projects gravity assuming portrait orientation; landscape is not yet remapped.
+ */
+@Composable
+internal actual fun rememberTiltSource(
+  enabled: Boolean,
+  hz: Int,
+  base: Offset,
+  tiltGain: Float,
+  out: MutableState<Offset>,
+) {
+  // Read Reduce Motion BEFORE any motion start, so a reduce-motion user never starts updates (and
+  // never triggers the NSMotionUsageDescription prompt). Re-read on the live notification below.
+  val reduceMotion = remember { UIAccessibilityIsReduceMotionEnabled() }
+
+  DisposableEffect(enabled, hz, tiltGain, reduceMotion) {
+    if (!enabled || reduceMotion || !SharedMotionManager.deviceMotionAvailable) {
+      out.value = base
+      return@DisposableEffect onDispose { }
+    }
+
+    // Per-subscriber math state — confined to the shared serial queue (the only caller).
+    var smooth = base
+    var lastSent = base
+    var lastEmitNs = 0L
+    val minEmitNs = 1_000_000_000L / hz
+    val alpha = 0.2f
+    val epsilon = 0.003f
+
+    val token = SharedMotionManager.acquire(intervalSec = 1.0 / hz.coerceAtLeast(1)) { motion ->
+      val raw = motion.gravity().useContents {
+        projectGravityPortrait(x.toFloat(), y.toFloat(), base, tiltGain)
+      }
+      smooth = emaStep(smooth, raw, alpha)
+      val now = (NSProcessInfo.processInfo.systemUptime * 1e9).toLong()
+      if (now - lastEmitNs < minEmitNs) return@acquire // 30 Hz throttle
+      val o = normalizeOr(smooth, base)
+      if ((o - lastSent).getDistance() < epsilon) return@acquire // ε-gate
+      smooth = o // snap EMA onto the emitted unit vector so a still phone truly stops emitting
+      lastEmitNs = now
+      lastSent = o
+      dispatch_async(dispatch_get_main_queue()) { out.value = o } // Compose write on main
+    }
+
+    // Live Reduce Motion: when turned ON, stop and freeze immediately (accessibility-sensitive).
+    // The resume path is handled by this DisposableEffect re-running once `reduceMotion` flips.
+    val observer = NSNotificationCenter.defaultCenter.addObserverForName(
+      name = UIAccessibilityReduceMotionStatusDidChangeNotification,
+      `object` = null,
+      queue = NSOperationQueue.mainQueue,
+    ) { _ ->
+      if (UIAccessibilityIsReduceMotionEnabled()) {
+        SharedMotionManager.release(token)
+        out.value = base
+      }
+    }
+
+    onDispose {
+      SharedMotionManager.release(token)
+      NSNotificationCenter.defaultCenter.removeObserver(observer)
+      out.value = base
+    }
+  }
+}
+
+/**
+ * App-wide single [CMMotionManager] with ref-counted, token-keyed subscribers. Only this object
+ * calls start/stopDeviceMotionUpdates: updates start on the 0→1 subscriber transition and stop on
+ * N→0, so no screen can stop another's stream. All subscriber-map mutation and the start/stop
+ * happen on the shared serial [queue], so no lock is needed.
+ */
+private object SharedMotionManager {
+  private val manager = CMMotionManager()
+  private val queue = NSOperationQueue().apply { maxConcurrentOperationCount = 1 }
+  private val subscribers = mutableMapOf<Any, (CMDeviceMotion) -> Unit>()
+
+  val deviceMotionAvailable: Boolean get() = manager.deviceMotionAvailable
+
+  fun acquire(intervalSec: Double, onMotion: (CMDeviceMotion) -> Unit): Any {
+    val token = Any()
+    queue.addOperationWithBlock {
+      // Fastest requested interval wins; each subscriber still throttles its own emit.
+      val current = manager.deviceMotionUpdateInterval
+      if (current <= 0.0 || intervalSec < current) {
+        manager.deviceMotionUpdateInterval = intervalSec
+      }
+      val wasEmpty = subscribers.isEmpty()
+      subscribers[token] = onMotion
+      if (wasEmpty) {
+        manager.startDeviceMotionUpdatesUsingReferenceFrame(
+          CMAttitudeReferenceFrameXArbitraryCorrectedZVertical,
+          queue,
+        ) { motion, _ ->
+          motion ?: return@startDeviceMotionUpdatesUsingReferenceFrame
+          subscribers.values.forEach { it(motion) }
+        }
+      }
+    }
+    return token
+  }
+
+  fun release(token: Any) {
+    queue.addOperationWithBlock {
+      subscribers.remove(token)
+      if (subscribers.isEmpty()) {
+        manager.stopDeviceMotionUpdates()
+      }
+    }
+  }
+}

--- a/cloudy/src/macosMain/kotlin/com/skydoves/cloudy/GyroLight.macos.kt
+++ b/cloudy/src/macosMain/kotlin/com/skydoves/cloudy/GyroLight.macos.kt
@@ -1,0 +1,33 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.cloudy
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.geometry.Offset
+
+/** macOS has no device-tilt sensor: the light stays fixed at [base]. */
+@Composable
+internal actual fun rememberTiltSource(
+  enabled: Boolean,
+  hz: Int,
+  base: Offset,
+  tiltGain: Float,
+  out: MutableState<Offset>,
+) {
+  SideEffect { out.value = base }
+}

--- a/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/CloudyBackground.skiko.kt
+++ b/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/CloudyBackground.skiko.kt
@@ -23,9 +23,11 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.BlurEffect
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TileMode
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
@@ -68,6 +70,7 @@ public actual fun Modifier.cloudy(
   @IntRange(from = 0) radius: Int,
   progressive: CloudyProgressive,
   tint: Color,
+  light: LiquidGlassLight?,
   enabled: Boolean,
   @Suppress("UNUSED_PARAMETER") cpuBlurEnabled: Boolean,
   onStateChanged: (CloudyState) -> Unit,
@@ -91,6 +94,7 @@ public actual fun Modifier.cloudy(
       radius = radius,
       progressive = progressive,
       tint = tint,
+      light = light,
       onStateChanged = onStateChanged,
     ),
   )
@@ -177,6 +181,7 @@ private data class CloudyBackgroundModifierElement(
   val radius: Int,
   val progressive: CloudyProgressive,
   val tint: Color,
+  val light: LiquidGlassLight?,
   val onStateChanged: (CloudyState) -> Unit,
 ) : ModifierNodeElement<CloudyBackgroundModifierNode>() {
 
@@ -186,6 +191,7 @@ private data class CloudyBackgroundModifierElement(
     properties["radius"] = radius
     properties["progressive"] = progressive
     properties["tint"] = tint
+    properties["light"] = light
   }
 
   override fun create(): CloudyBackgroundModifierNode = CloudyBackgroundModifierNode(
@@ -193,11 +199,12 @@ private data class CloudyBackgroundModifierElement(
     radius = radius,
     progressive = progressive,
     tint = tint,
+    light = light,
     onStateChanged = onStateChanged,
   )
 
   override fun update(node: CloudyBackgroundModifierNode) {
-    node.update(sky, radius, progressive, tint, onStateChanged)
+    node.update(sky, radius, progressive, tint, light, onStateChanged)
   }
 }
 
@@ -206,6 +213,7 @@ private class CloudyBackgroundModifierNode(
   private var radius: Int,
   private var progressive: CloudyProgressive,
   private var tint: Color,
+  private var light: LiquidGlassLight?,
   private var onStateChanged: (CloudyState) -> Unit,
 ) : Modifier.Node(),
   DrawModifierNode,
@@ -215,22 +223,32 @@ private class CloudyBackgroundModifierNode(
   private var positionInRoot: Offset = Offset.Zero
   private var size: IntSize = IntSize.Zero
 
+  // Specular highlight brush cache. The light direction is read at gyro rate (~30Hz), so the
+  // pool center moves most frames; rebuild the Brush only when center/radius actually change to
+  // avoid per-frame Brush allocation on the draw hot path. (The colorStops array is already a const.)
+  private var cachedBrush: Brush? = null
+  private var cachedCenter: Offset = Offset.Unspecified
+  private var cachedRadius: Float = -1f
+
   fun update(
     sky: Sky,
     radius: Int,
     progressive: CloudyProgressive,
     tint: Color,
+    light: LiquidGlassLight?,
     onStateChanged: (CloudyState) -> Unit,
   ) {
     val needsRedraw = this.sky != sky ||
       this.radius != radius ||
       this.progressive != progressive ||
-      this.tint != tint
+      this.tint != tint ||
+      this.light != light
 
     this.sky = sky
     this.radius = radius
     this.progressive = progressive
     this.tint = tint
+    this.light = light
     this.onStateChanged = onStateChanged
 
     if (needsRedraw && isAttached) {
@@ -342,11 +360,50 @@ private class CloudyBackgroundModifierNode(
         if (snapshot.tintColor != Color.Transparent) {
           drawRect(color = snapshot.tintColor, blendMode = BlendMode.SrcOver)
         }
+
+        // Experimental specular highlight over the blurred backdrop (no-op when light == null)
+        if (light != null) drawHighlight()
       }
 
       onStateChanged(CloudyState.Success.Applied)
     } finally {
       context.releaseGraphicsLayer(blurLayer)
     }
+  }
+
+  /**
+   * Draws the moving specular highlight over the already-blurred backdrop. Called only from the
+   * blurred path, inside its existing [clipRect]. Composited with the default `SrcOver` blend:
+   * warm-white over a bright backdrop self-attenuates just like the shader's Screen blend, and is
+   * identical to Screen at the dark end (the blend already used for tint, and matches the Android
+   * binding's choice).
+   *
+   * Reads the Node's [light] (must be non-null here) and [size] fields and reuses [cachedBrush]
+   * unless the pool center/radius moved this frame.
+   */
+  private fun DrawScope.drawHighlight() {
+    val light = light ?: return
+    // Node's measured IntSize field — qualified so it isn't shadowed by DrawScope.size (canvas Size).
+    val lensSize = this@CloudyBackgroundModifierNode.size
+    if (minOf(lensSize.width, lensSize.height) <= 0) return
+    // Pure geometry lives in commonMain so the shipped path is the unit-tested path.
+    val center = highlightPoolCenter(lensSize, light.direction.value, HIGHLIGHT_FOCAL_K)
+    val radius = highlightPoolRadius(lensSize, HIGHLIGHT_POOL_FRAC)
+    val brush = if (center != cachedCenter || radius != cachedRadius) {
+      Brush.radialGradient(
+        colorStops = HIGHLIGHT_STOPS,
+        center = center,
+        radius = radius,
+        tileMode = TileMode.Clamp,
+      ).also {
+        cachedBrush = it
+        cachedCenter = center
+        cachedRadius = radius
+      }
+    } else {
+      cachedBrush!!
+    }
+    // default SrcOver blend (faithful to the shader's Screen at this alpha range)
+    drawRect(brush = brush)
   }
 }

--- a/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/LiquidGlass.skiko.kt
+++ b/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/LiquidGlass.skiko.kt
@@ -209,10 +209,16 @@ private fun Modifier.liquidGlassImpl(
       // come from the public ChromaticOverlay; the remaining 4 are held at the shader's tuned
       // defaults (bands/cycles/phase/modulate) as constants here.
       shaderBuilder.uniform("chromaticIntensity", chromatic.intensity)
-      shaderBuilder.uniform(
-        "chromaticMode",
-        if (chromatic.mode == ChromaticMode.Foil) 1f else 0f,
-      )
+      // Exhaustive when (no else) so adding a ChromaticMode without a float breaks the build here.
+      val chromaticModeF = when (chromatic.mode) {
+        ChromaticMode.Iridescent -> 0f
+        ChromaticMode.Foil -> 1f
+        ChromaticMode.OilSlick -> 2f
+        ChromaticMode.SoapBubble -> 3f
+        ChromaticMode.MetallicFoil -> 4f
+        ChromaticMode.Pearl -> 5f
+      }
+      shaderBuilder.uniform("chromaticMode", chromaticModeF)
       shaderBuilder.uniform("chromaticBands", 3f)
       shaderBuilder.uniform("chromaticCycles", 1.5f)
       shaderBuilder.uniform("chromaticPhase", 0f)

--- a/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/LiquidGlass.skiko.kt
+++ b/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/LiquidGlass.skiko.kt
@@ -35,6 +35,7 @@ import org.jetbrains.skia.RuntimeShaderBuilder
  *
  * **Note:** For blur effects, use [Modifier.cloudy] separately.
  */
+@ExperimentalLiquidGlassMaterial
 @Composable
 public actual fun Modifier.liquidGlass(
   lensCenter: Offset,
@@ -49,6 +50,7 @@ public actual fun Modifier.liquidGlass(
   edge: Float,
   light: LiquidGlassLight,
   glow: LiquidGlassGlow,
+  chromatic: ChromaticOverlay,
   enabled: Boolean,
 ): Modifier = liquidGlassImpl(
   lensCenter = lensCenter,
@@ -65,9 +67,11 @@ public actual fun Modifier.liquidGlass(
   // The stable public surface only exposes the two perceptual knobs; widen to the full 4-knob
   // tuning (extra knobs at their tuned defaults) for the single uniform-writing path below.
   tuning = glow.toTuning(),
+  chromatic = chromatic,
   enabled = enabled,
 )
 
+@OptIn(ExperimentalLiquidGlassMaterial::class)
 @ExperimentalLiquidGlassMotion
 @Composable
 public actual fun Modifier.liquidGlassTuned(
@@ -105,6 +109,9 @@ public actual fun Modifier.liquidGlassTuned(
     rimMix = glowRimMix,
     widthPx = glowWidthPx,
   ),
+  // liquidGlassTuned tunes the specular glint only; it does not expose the chromatic overlay, so
+  // forward the no-op preset (the binding still writes all 6 chromatic uniforms gate-free below).
+  chromatic = LiquidGlassDefaults.NoChromatic,
   enabled = enabled,
 )
 
@@ -112,6 +119,7 @@ public actual fun Modifier.liquidGlassTuned(
  * Single entry point shared by [liquidGlass] and [liquidGlassTuned]. Takes the full internal
  * [GlowTuning] so there is exactly one uniform-writing code path.
  */
+@OptIn(ExperimentalLiquidGlassMaterial::class)
 @Composable
 private fun Modifier.liquidGlassImpl(
   lensCenter: Offset,
@@ -126,6 +134,7 @@ private fun Modifier.liquidGlassImpl(
   edge: Float,
   light: LiquidGlassLight,
   tuning: GlowTuning,
+  chromatic: ChromaticOverlay,
   enabled: Boolean,
 ): Modifier {
   // Validation
@@ -195,6 +204,19 @@ private fun Modifier.liquidGlassImpl(
       shaderBuilder.uniform("specFocalK", tuning.focalK)
       shaderBuilder.uniform("specPoolFrac", tuning.poolFrac)
       shaderBuilder.uniform("specPoolGain", tuning.poolGain)
+      // Chromatic overlay — Skia throws on any unset declared uniform, so write all 6 every draw
+      // (gate-free). intensity == 0 keeps the term bit-exact off in-shader. Only intensity + mode
+      // come from the public ChromaticOverlay; the remaining 4 are held at the shader's tuned
+      // defaults (bands/cycles/phase/modulate) as constants here.
+      shaderBuilder.uniform("chromaticIntensity", chromatic.intensity)
+      shaderBuilder.uniform(
+        "chromaticMode",
+        if (chromatic.mode == ChromaticMode.Foil) 1f else 0f,
+      )
+      shaderBuilder.uniform("chromaticBands", 3f)
+      shaderBuilder.uniform("chromaticCycles", 1.5f)
+      shaderBuilder.uniform("chromaticPhase", 0f)
+      shaderBuilder.uniform("chromaticModulate", 1f)
 
       // Create ImageFilter with RuntimeShader
       // "content" binds to the underlying content (null input = source content)

--- a/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/LiquidGlass.skiko.kt
+++ b/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/LiquidGlass.skiko.kt
@@ -216,7 +216,7 @@ private fun Modifier.liquidGlassImpl(
       shaderBuilder.uniform("chromaticBands", 3f)
       shaderBuilder.uniform("chromaticCycles", 1.5f)
       shaderBuilder.uniform("chromaticPhase", 0f)
-      shaderBuilder.uniform("chromaticModulate", 1f)
+      shaderBuilder.uniform("chromaticModulate", 0.3f)
 
       // Create ImageFilter with RuntimeShader
       // "content" binds to the underlying content (null input = source content)

--- a/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/LiquidGlass.skiko.kt
+++ b/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/LiquidGlass.skiko.kt
@@ -47,6 +47,85 @@ public actual fun Modifier.liquidGlass(
   contrast: Float,
   tint: Color,
   edge: Float,
+  light: LiquidGlassLight,
+  glow: LiquidGlassGlow,
+  enabled: Boolean,
+): Modifier = liquidGlassImpl(
+  lensCenter = lensCenter,
+  lensSize = lensSize,
+  cornerRadius = cornerRadius,
+  refraction = refraction,
+  curve = curve,
+  dispersion = dispersion,
+  saturation = saturation,
+  contrast = contrast,
+  tint = tint,
+  edge = edge,
+  light = light,
+  // The stable public surface only exposes the two perceptual knobs; widen to the full 4-knob
+  // tuning (extra knobs at their tuned defaults) for the single uniform-writing path below.
+  tuning = glow.toTuning(),
+  enabled = enabled,
+)
+
+@ExperimentalLiquidGlassMotion
+@Composable
+public actual fun Modifier.liquidGlassTuned(
+  lensCenter: Offset,
+  lensSize: Size,
+  cornerRadius: Float,
+  refraction: Float,
+  curve: Float,
+  dispersion: Float,
+  saturation: Float,
+  contrast: Float,
+  tint: Color,
+  edge: Float,
+  light: LiquidGlassLight,
+  glowIntensity: Float,
+  glowSharpness: Float,
+  glowRimMix: Float,
+  glowWidthPx: Float,
+  enabled: Boolean,
+): Modifier = liquidGlassImpl(
+  lensCenter = lensCenter,
+  lensSize = lensSize,
+  cornerRadius = cornerRadius,
+  refraction = refraction,
+  curve = curve,
+  dispersion = dispersion,
+  saturation = saturation,
+  contrast = contrast,
+  tint = tint,
+  edge = edge,
+  light = light,
+  tuning = GlowTuning(
+    intensity = glowIntensity,
+    sharpness = glowSharpness,
+    rimMix = glowRimMix,
+    widthPx = glowWidthPx,
+  ),
+  enabled = enabled,
+)
+
+/**
+ * Single entry point shared by [liquidGlass] and [liquidGlassTuned]. Takes the full internal
+ * [GlowTuning] so there is exactly one uniform-writing code path.
+ */
+@Composable
+private fun Modifier.liquidGlassImpl(
+  lensCenter: Offset,
+  lensSize: Size,
+  cornerRadius: Float,
+  refraction: Float,
+  curve: Float,
+  dispersion: Float,
+  saturation: Float,
+  contrast: Float,
+  tint: Color,
+  edge: Float,
+  light: LiquidGlassLight,
+  tuning: GlowTuning,
   enabled: Boolean,
 ): Modifier {
   // Validation
@@ -96,6 +175,26 @@ public actual fun Modifier.liquidGlass(
       shaderBuilder.uniform("contrast", contrast)
       shaderBuilder.uniform("tint", tint.red, tint.green, tint.blue, tint.alpha)
       shaderBuilder.uniform("edge", edge)
+      // Draw-phase read: holder identity is stable, so a high-frequency light source
+      // invalidates the draw without recomposing. Always set — Skia throws if any declared
+      // uniform is missing before makeRuntimeShader.
+      val lightDir = light.direction.value
+      shaderBuilder.uniform("lightDir", lightDir.x, lightDir.y)
+      // Specular glint tuning — Skia throws on any unset declared uniform, so write all eight
+      // every draw (gate-free), right alongside lightDir.
+      shaderBuilder.uniform("specStrength", tuning.intensity)
+      shaderBuilder.uniform("specPower", tuning.sharpness)
+      shaderBuilder.uniform("specRimMix", tuning.rimMix)         // 변경: was specSweep / tuning.travel
+      shaderBuilder.uniform("specWidthPx", tuning.widthPx)
+      // Skia는 선언됐는데 unset인 uniform에 throw → bevel 4 + focal 3 모두 write.
+      shaderBuilder.uniform("specLightZ", tuning.lightZ)
+      shaderBuilder.uniform("specDomeFrac", tuning.domeFrac)
+      shaderBuilder.uniform("specBodyPower", tuning.bodyPower)
+      shaderBuilder.uniform("specBodyGain", tuning.bodyGain)
+      // Moving focal hotspot (dual-axis) — same gate-free contract.
+      shaderBuilder.uniform("specFocalK", tuning.focalK)
+      shaderBuilder.uniform("specPoolFrac", tuning.poolFrac)
+      shaderBuilder.uniform("specPoolGain", tuning.poolGain)
 
       // Create ImageFilter with RuntimeShader
       // "content" binds to the underlying content (null input = source content)

--- a/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/LiquidGlass.skiko.kt
+++ b/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/LiquidGlass.skiko.kt
@@ -184,7 +184,7 @@ private fun Modifier.liquidGlassImpl(
       // every draw (gate-free), right alongside lightDir.
       shaderBuilder.uniform("specStrength", tuning.intensity)
       shaderBuilder.uniform("specPower", tuning.sharpness)
-      shaderBuilder.uniform("specRimMix", tuning.rimMix)         // 변경: was specSweep / tuning.travel
+      shaderBuilder.uniform("specRimMix", tuning.rimMix) // 변경: was specSweep / tuning.travel
       shaderBuilder.uniform("specWidthPx", tuning.widthPx)
       // Skia는 선언됐는데 unset인 uniform에 throw → bevel 4 + focal 3 모두 write.
       shaderBuilder.uniform("specLightZ", tuning.lightZ)

--- a/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/LiquidGlass.skiko.kt
+++ b/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/LiquidGlass.skiko.kt
@@ -193,9 +193,9 @@ private fun Modifier.liquidGlassImpl(
       // every draw (gate-free), right alongside lightDir.
       shaderBuilder.uniform("specStrength", tuning.intensity)
       shaderBuilder.uniform("specPower", tuning.sharpness)
-      shaderBuilder.uniform("specRimMix", tuning.rimMix) // 변경: was specSweep / tuning.travel
+      shaderBuilder.uniform("specRimMix", tuning.rimMix)
       shaderBuilder.uniform("specWidthPx", tuning.widthPx)
-      // Skia는 선언됐는데 unset인 uniform에 throw → bevel 4 + focal 3 모두 write.
+      // Skia throws on any declared-but-unset uniform, so write every one.
       shaderBuilder.uniform("specLightZ", tuning.lightZ)
       shaderBuilder.uniform("specDomeFrac", tuning.domeFrac)
       shaderBuilder.uniform("specBodyPower", tuning.bodyPower)

--- a/cloudy/src/wasmJsMain/kotlin/com/skydoves/cloudy/GyroLight.wasmJs.kt
+++ b/cloudy/src/wasmJsMain/kotlin/com/skydoves/cloudy/GyroLight.wasmJs.kt
@@ -1,0 +1,33 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.cloudy
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.geometry.Offset
+
+/** Web (wasmJs) does not wire device motion here: the light stays fixed at [base]. */
+@Composable
+internal actual fun rememberTiltSource(
+  enabled: Boolean,
+  hz: Int,
+  base: Offset,
+  tiltGain: Float,
+  out: MutableState<Offset>,
+) {
+  SideEffect { out.value = base }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ androidxActivity = "1.12.2"
 androidxCompose = "1.10.0"
 androidxComposeConstraintLayout = "1.1.1"
 androidxCore = "1.17.0"
+androidxLifecycle = "2.9.2"
 androidxTest = "1.7.0"
 androidxJunit = "1.3.0"
 androidxMacroBenchmark = "1.4.1"
@@ -57,6 +58,7 @@ androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidxActivity" }
 androidx-compose-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout-compose", version.ref = "androidxComposeConstraintLayout" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCore" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidxLifecycle" }
 androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "androidxProfileinstaller" }
 androidx-benchmark-macro = { group = "androidx.benchmark", name = "benchmark-macro-junit4", version.ref = "androidxMacroBenchmark" }
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTest" }


### PR DESCRIPTION
## Summary

Adds **Chromatic Overlay** to Liquid Glass: a light-reactive iridescent sheen that a caller can layer on the glass surface. Tilt the device (or drag) and a rainbow foil flows across the card. This is the "Pure White / holographic card" look.

> **Stacked on [#119](https://github.com/skydoves/Cloudy/pull/119).** Base is `feature/gyro-specular`, so this diff is chromatic-only and builds on the motion lighting from that PR. Merge #119 first; GitHub will retarget this to `main` automatically.

## What it adds

- **`ChromaticOverlay`** — an `@Immutable` material descriptor: `intensity`, `mode` (`Iridescent` thin-film vs `Foil` flowing bands), `spectrum`, and an optional `customBrush`. Built via `ChromaticOverlay(...)`; presets in `LiquidGlassDefaults` (`NoChromatic`, `Holographic`).
- **`Modifier.liquidGlass(chromatic = ...)`** — new parameter, defaults to `NoChromatic` so existing surfaces render unchanged. Gated by a new `@ExperimentalLiquidGlassMaterial` opt-in.
- The overlay rides the existing light direction (`LiquidGlassLight`), so the same gyro/transform source that drives the specular glint also sweeps the rainbow.

## How it renders

The hue is synthesized per-pixel in the AGSL/SKSL shader (no extra texture):
- **Foil**: `hue = fract(dot(p, lightVec) * bands)` — bands flow as the light moves.
- **Iridescent**: `hue = fract(dot(N, L) * cycles)` — hue shifts with the surface/light angle.

The hue→RGB ramp runs in `float` precision (fp16 bands visibly on a saturated rainbow), composited so a white surface takes on the color rather than washing out. The shader path is full-quality on API 33+/Skia; below that the parameter is accepted but ignored (same as the other shader effects).

`chromaticIntensity == 0` skips the whole block, so `NoChromatic` is bit-identical to today with zero added cost.

## Bugs fixed along the way

While validating on an API 35 emulator the overlay was invisible. Three root causes, all fixed here:

1. **Reversed `smoothstep` edges** in the chromatic focal pool — `smoothstep(edge0, edge1, x)` with `edge0 > edge1` is undefined in GLSL ES and returns 0 on the emulator's GL→Metal translator, zeroing the rainbow. Rewritten as `1.0 - smoothstep(0, R, x)`. (The same bug in the specular pool/inside is fixed in #119, since it predates this work.)
2. **`chromaticModulate` default** pinned the sheen to the focal hotspot (~5–10% of the surface). Lowered so it spreads across the card with a focal emphasis.
3. **Alpha compositing** — a white `Modifier.background` sits behind the `liquidGlass` layer, so `content.eval()` returns it transparent and the tint-multiply had nothing to color. The overlay now shows on a transparent base and stays bit-exact over opaque content (e.g. a photo).

## Demo

`ChromaticCardScreen` (menu → "Chromatic Card"): a white card with three material chips (Pure White / Holographic / Custom), an intensity slider, an Iridescent/Foil switch, and gyro-or-drag lighting. Verified on an API 35 emulator — the rainbow sheen fills the card (the emulator has no motion sensor, so the light is fixed at the resting direction; on a device, tilting sweeps it).

## Tests

- `ChromaticOverlayTest` — equality/hashCode (including `-0.0f` normalization) and defaults.
- `LiquidGlassTest` — chromatic uniforms present in both AGSL and SKSL.

## Notes

- `cloudy.api` regenerated for android and desktop (`apiCheck` passes).
- New public API is behind `@ExperimentalLiquidGlassMaterial`. Adding the `chromatic` parameter changes the `liquidGlass` JVM signature (binary, not source); `NoChromatic` default keeps it source-compatible.
- `customBrush` / `spectrum` are carried on the type for the consumer/blur path and future use; the shader path synthesizes hue directly.
