### PR TITLE
Prepare for release 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you're using Version Catalog, you can configure the dependency by adding it t
 ```toml
 [versions]
 #...
-cloudy = "0.5.0"
+cloudy = "0.6.0"
 
 [libraries]
 #...
@@ -62,7 +62,7 @@ Add the dependency below to your **module**'s `build.gradle.kts` file:
 
 ```gradle
 dependencies {
-    implementation("com.github.skydoves:cloudy:0.5.0")
+    implementation("com.github.skydoves:cloudy:0.6.0")
     
     // if you're using Version Catalog
     implementation(libs.compose.cloudy)

--- a/buildSrc/src/main/kotlin/com/skydoves/cloudy/Configuration.kt
+++ b/buildSrc/src/main/kotlin/com/skydoves/cloudy/Configuration.kt
@@ -5,10 +5,10 @@ object Configuration {
   const val targetSdk = 36
   const val minSdk = 23
   const val majorVersion = 0
-  const val minorVersion = 5
+  const val minorVersion = 6
   const val patchVersion = 0
   const val versionName = "$majorVersion.$minorVersion.$patchVersion"
-  const val versionCode = 14
+  const val versionCode = 15
   const val snapshotVersionName = "$majorVersion.$minorVersion.${patchVersion + 1}-SNAPSHOT"
   const val artifactGroup = "com.github.skydoves"
 }


### PR DESCRIPTION
Prepare for release 0.6.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated library version to 0.6.0, including updated version catalog entries and internal version constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->