### PR TITLE
fix: stabilize backdrop blur (idle loop, #112 cyclic-RenderNode crash, scroll/animation tracking)

### DIFF
--- a/cloudy/api/android/cloudy.api
+++ b/cloudy/api/android/cloudy.api
@@ -1,5 +1,5 @@
 public final class com/skydoves/cloudy/CloudyBackground_androidKt {
-	public static final fun cloudy-NpZTi58 (Landroidx/compose/ui/Modifier;Lcom/skydoves/cloudy/Sky;ILcom/skydoves/cloudy/CloudyProgressive;JZZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Landroidx/compose/ui/Modifier;
+	public static final fun cloudy-mxsUjTo (Landroidx/compose/ui/Modifier;Lcom/skydoves/cloudy/Sky;ILcom/skydoves/cloudy/CloudyProgressive;JZZLandroidx/compose/ui/graphics/Shape;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Landroidx/compose/ui/Modifier;
 	public static final fun sky (Landroidx/compose/ui/Modifier;Lcom/skydoves/cloudy/Sky;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/Modifier;
 }
 
@@ -192,6 +192,7 @@ public final class com/skydoves/cloudy/RememberCloudyStateKt {
 public final class com/skydoves/cloudy/Sky {
 	public static final field $stable I
 	public final fun invalidate ()V
+	public final fun invalidate (J)V
 }
 
 public final class com/skydoves/cloudy/SkyKt {

--- a/cloudy/api/desktop/cloudy.api
+++ b/cloudy/api/desktop/cloudy.api
@@ -1,5 +1,5 @@
 public final class com/skydoves/cloudy/CloudyBackground_skikoKt {
-	public static final fun cloudy-NpZTi58 (Landroidx/compose/ui/Modifier;Lcom/skydoves/cloudy/Sky;ILcom/skydoves/cloudy/CloudyProgressive;JZZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Landroidx/compose/ui/Modifier;
+	public static final fun cloudy-mxsUjTo (Landroidx/compose/ui/Modifier;Lcom/skydoves/cloudy/Sky;ILcom/skydoves/cloudy/CloudyProgressive;JZZLandroidx/compose/ui/graphics/Shape;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Landroidx/compose/ui/Modifier;
 	public static final fun sky (Landroidx/compose/ui/Modifier;Lcom/skydoves/cloudy/Sky;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/Modifier;
 }
 
@@ -194,6 +194,7 @@ public final class com/skydoves/cloudy/RememberCloudyStateKt {
 public final class com/skydoves/cloudy/Sky {
 	public static final field $stable I
 	public final fun invalidate ()V
+	public final fun invalidate (J)V
 }
 
 public final class com/skydoves/cloudy/SkyKt {

--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
@@ -43,10 +43,13 @@ import androidx.compose.ui.graphics.drawscope.clipPath
 import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
-import androidx.compose.ui.graphics.RenderEffect as ComposeRenderEffect
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScrollModifierNode
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
+import androidx.compose.ui.node.DelegatingNode
 import androidx.compose.ui.node.DrawModifierNode
 import androidx.compose.ui.node.GlobalPositionAwareModifierNode
 import androidx.compose.ui.node.LayoutAwareModifierNode
@@ -57,6 +60,7 @@ import androidx.compose.ui.node.requireGraphicsContext
 import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.toSize
 import com.skydoves.cloudy.internals.SkySnapshot
 import com.skydoves.cloudy.internals.render.RenderScriptToolkit
@@ -65,6 +69,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.cancellation.CancellationException
+import androidx.compose.ui.graphics.RenderEffect as ComposeRenderEffect
 
 private const val TAG = "CloudyBackground"
 
@@ -140,19 +145,50 @@ private data class SkyModifierElement(val sky: Sky) : ModifierNodeElement<SkyMod
 }
 
 private class SkyModifierNode(var sky: Sky) :
-  Modifier.Node(),
+  DelegatingNode(),
   DrawModifierNode,
   GlobalPositionAwareModifierNode {
 
   private var graphicsLayer: GraphicsLayer? = null
   private var positionInRoot: Offset = Offset.Zero
 
-  // Throttle version increments to reduce blur processing frequency
-  private var lastVersionIncrementTime: Long = 0L
+  // Stable invalidator the frame driver pumps each scroll frame to re-capture the moved backdrop.
+  // Also advances contentVersion so the API < 31 bitmap-blur cache (keyed on it) recomputes while
+  // scrolling. Safe from the original idle loop: this runs ONLY inside the driver's active refresh
+  // window (which self-terminates), never on an idle draw, so the snapshot write cannot self-sustain.
+  private val recapture: () -> Unit = {
+    if (isAttached) {
+      sky.incrementContentVersion()
+      invalidateDraw()
+    }
+  }
 
-  companion object {
-    // Only increment version every 100ms to prevent excessive blur updates
-    private const val VERSION_INCREMENT_INTERVAL_MS = 100L
+  // Forward descendant scroll/fling deltas to the frame driver: this is the precise "the backdrop is
+  // moving now" signal the draw phase lacks (a LazyColumn scroll does not re-invoke this recorder's
+  // draw). The driver re-captures + re-blurs while scrolling, then parks so the app idles.
+  private val scrollConnection = object : NestedScrollConnection {
+    override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+      sky.frameDriver.onScrollActivity()
+      return Offset.Zero
+    }
+
+    override suspend fun onPreFling(available: Velocity): Velocity {
+      sky.frameDriver.onScrollActivity()
+      return Velocity.Zero
+    }
+
+    override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
+      sky.frameDriver.onScrollActivity()
+      return Velocity.Zero
+    }
+  }
+
+  init {
+    delegate(nestedScrollModifierNode(scrollConnection, dispatcher = null))
+  }
+
+  override fun onAttach() {
+    sky.frameDriver.attachRecorder(coroutineScope, recapture)
   }
 
   override fun onGloballyPositioned(coordinates: LayoutCoordinates) {
@@ -165,43 +201,27 @@ private class SkyModifierNode(var sky: Sky) :
 
   override fun ContentDrawScope.draw() {
     val context = requireGraphicsContext()
-    val newlyCreated = graphicsLayer == null
     val layer = graphicsLayer ?: context.createGraphicsLayer().also {
       graphicsLayer = it
     }
 
-    // Record the background into `layer`, the source a descendant `cloudy` overlay samples
-    // and blurs. `isCapturing` is set so the overlay draws nothing during this pass: it must be
-    // ABSENT from the blur source. Otherwise the overlay would draw its blur layer into `layer`,
-    // and that blur layer in turn samples `layer` — a cyclic RenderNode graph that overflows the
-    // render thread stack (https://github.com/skydoves/Cloudy/issues/112).
-    sky.isCapturing = true
-    try {
+    // Record the background into `layer`, the source a `cloudy` overlay of this sky samples and
+    // blurs. `sky.capturing` marks the sky as recording so its overlays draw nothing during this
+    // pass: an overlay must be ABSENT from the blur source. Otherwise the overlay would draw its
+    // blur layer into the layer being recorded, and that blur layer in turn samples a backdrop
+    // layer — a cyclic RenderNode graph that overflows the render thread stack
+    // (https://github.com/skydoves/Cloudy/issues/112).
+    sky.capturing {
       layer.record {
         this@draw.drawContent()
       }
-    } finally {
-      sky.isCapturing = false
     }
 
-    // `layer` is reused across draws, so publish it to the snapshot state ONCE (when first
-    // created). Re-assigning the same instance every draw would write snapshot state that the
-    // descendant overlay reads in its own draw, invalidating it and triggering an endless redraw
-    // loop that keeps the window producing frames even while idle.
-    if (newlyCreated) {
-      sky.backgroundLayer = layer
-    }
-
-    // Re-recording `layer` above re-captures the current backdrop, so bump the content version
-    // that the legacy (API < 31) bitmap path keys its cache on. Throttle it: an unconditional
-    // per-draw bump writes snapshot state read during the overlay's draw, which re-invalidates
-    // the overlay and self-perpetuates the redraw loop, so the app never goes idle. Rate-limiting
-    // lets the tree settle to zero frames once the backdrop stops changing.
-    val now = System.currentTimeMillis()
-    if (now - lastVersionIncrementTime >= VERSION_INCREMENT_INTERVAL_MS) {
-      lastVersionIncrementTime = now
-      sky.incrementContentVersion()
-    }
+    // Publish the just-captured backdrop. A PLAIN (non-snapshot) field, written every draw: the
+    // overlay re-reads it each time it draws and the frame driver is what re-runs the overlay, so
+    // no snapshot observation is needed. Writing it as snapshot state per draw is what created the
+    // original idle redraw loop (the descendant overlay observed the write and forced a frame).
+    sky.backgroundLayer = layer
 
     // Draw the subtree to the window. `isCapturing` is now false, so the overlay paints its
     // blurred backdrop (sampling `layer`, which contains no reference back to the overlay) and
@@ -211,6 +231,7 @@ private class SkyModifierNode(var sky: Sky) :
   }
 
   override fun onDetach() {
+    sky.frameDriver.detachRecorder(coroutineScope)
     graphicsLayer?.let { requireGraphicsContext().releaseGraphicsLayer(it) }
     graphicsLayer = null
     sky.backgroundLayer = null
@@ -273,13 +294,17 @@ private class CloudyBackgroundModifierNode(
   private var positionInRoot: Offset = Offset.Zero
   private var size: IntSize = IntSize.Zero
 
+  // Stable re-blur invalidator the frame driver pumps each frame the backdrop moves. A field (not a
+  // fresh lambda per call) so the driver can identity-match it on add/remove.
+  private val reblur: () -> Unit = { if (isAttached) invalidateDraw() }
+
   // Cached GPU blur layer + RenderEffect (API 31+). Reused across draws; the effect is rebuilt only
   // when the blur radius changes (it is size-independent), so a steady-state frame allocates nothing.
   private var blurLayer: GraphicsLayer? = null
   private var cachedBlurEffect: ComposeRenderEffect? = null
   private var cachedBlurRadius: Float = -1f
 
-  // Reusable Path for the shape clip, rebuilt only when the outline changes.
+  // Reusable Path for the shape clip, rebuilt only when shape/size/layoutDirection change.
   private var clipPathCache: Path? = null
 
   // Legacy blur state (API < 31)
@@ -314,6 +339,11 @@ private class CloudyBackgroundModifierNode(
       this.cpuBlurEnabled != cpuBlurEnabled ||
       this.shape != shape
 
+    if (this.sky != sky && isAttached) {
+      this.sky.frameDriver.removeOverlay(reblur)
+      sky.frameDriver.addOverlay(reblur)
+    }
+
     this.sky = sky
     this.radius = radius
     this.progressive = progressive
@@ -336,6 +366,10 @@ private class CloudyBackgroundModifierNode(
     }
   }
 
+  override fun onAttach() {
+    sky.frameDriver.addOverlay(reblur)
+  }
+
   override fun onGloballyPositioned(coordinates: LayoutCoordinates) {
     positionInRoot = coordinates.positionInRoot()
   }
@@ -345,12 +379,11 @@ private class CloudyBackgroundModifierNode(
   }
 
   override fun ContentDrawScope.draw() {
-    // When `sky` is an ancestor of this overlay, the sky's capture pass re-enters this draw
-    // while recording the blur source into `backgroundLayer`. This overlay must be ABSENT from
-    // that source: if it drew here, its blur layer (which samples `backgroundLayer`) would be
-    // recorded into `backgroundLayer`, forming a cyclic RenderNode graph that crashes the render
-    // thread (https://github.com/skydoves/Cloudy/issues/112). Draw nothing during capture; the
-    // overlay paints itself in the sky's on-screen pass, when `isCapturing` is false.
+    // Draw nothing while this sky is recording: the overlay must be absent from the blur source,
+    // else its blur layer (which samples the backdrop) is recorded into the backdrop — a cyclic
+    // RenderNode graph that crashes the render thread (issues/112). A `cloudy` surface is
+    // background-only; its foreground lives outside the recorder, so nothing is lost here. See
+    // [Sky.isCapturing].
     if (sky.isCapturing) {
       return
     }
@@ -720,6 +753,7 @@ private class CloudyBackgroundModifierNode(
   }
 
   override fun onDetach() {
+    sky.frameDriver.removeOverlay(reblur)
     blurLayer?.let { requireGraphicsContext().releaseGraphicsLayer(it) }
     blurLayer = null
     cachedBlurEffect = null

--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
@@ -484,20 +484,23 @@ private class CloudyBackgroundModifierNode(
    * Following the Haze library approach.
    */
   private fun ContentDrawScope.drawScrimFallback(layer: GraphicsLayer, snapshot: SkySnapshot) {
-    // 1. Draw the background region without blur
-    drawContext.canvas.save()
-    drawContext.canvas.translate(-snapshot.offsetX, -snapshot.offsetY)
-    drawLayer(layer)
-    drawContext.canvas.restore()
-
-    // 2. Apply scrim overlay (use tint if specified, otherwise use default scrim color)
     val scrimColor = if (snapshot.tintColor == Color.Transparent) {
       CloudyDefaults.DefaultScrimColor
     } else {
       snapshot.tintColor
     }
 
+    // Clip BOTH the sampled backdrop and the scrim to the shape: otherwise a rounded shape leaks the
+    // unblurred rectangular backdrop outside the corners (the scrim alone would be clipped, the
+    // backdrop under it would not).
     clipToShape {
+      // 1. Draw the background region without blur.
+      drawContext.canvas.save()
+      drawContext.canvas.translate(-snapshot.offsetX, -snapshot.offsetY)
+      drawLayer(layer)
+      drawContext.canvas.restore()
+
+      // 2. Apply scrim overlay (use tint if specified, otherwise use default scrim color).
       drawRect(color = scrimColor, blendMode = BlendMode.SrcOver)
     }
 

--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
@@ -30,13 +30,20 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.asComposeRenderEffect
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.clipPath
 import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.graphics.RenderEffect as ComposeRenderEffect
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
@@ -82,6 +89,7 @@ public actual fun Modifier.cloudy(
   tint: Color,
   enabled: Boolean,
   cpuBlurEnabled: Boolean,
+  shape: Shape,
   onStateChanged: (CloudyState) -> Unit,
 ): Modifier {
   require(radius >= 0) { "Blur radius must be non-negative, but was $radius" }
@@ -108,6 +116,7 @@ public actual fun Modifier.cloudy(
       progressive = progressive,
       tint = tint,
       cpuBlurEnabled = cpuBlurEnabled,
+      shape = shape,
       onStateChanged = onStateChanged,
     ),
   )
@@ -218,6 +227,7 @@ private data class CloudyBackgroundModifierElement(
   val progressive: CloudyProgressive,
   val tint: Color,
   val cpuBlurEnabled: Boolean,
+  val shape: Shape,
   val onStateChanged: (CloudyState) -> Unit,
 ) : ModifierNodeElement<CloudyBackgroundModifierNode>() {
 
@@ -228,6 +238,7 @@ private data class CloudyBackgroundModifierElement(
     properties["progressive"] = progressive
     properties["tint"] = tint
     properties["cpuBlurEnabled"] = cpuBlurEnabled
+    properties["shape"] = shape
   }
 
   override fun create(): CloudyBackgroundModifierNode = CloudyBackgroundModifierNode(
@@ -236,11 +247,12 @@ private data class CloudyBackgroundModifierElement(
     progressive = progressive,
     tint = tint,
     cpuBlurEnabled = cpuBlurEnabled,
+    shape = shape,
     onStateChanged = onStateChanged,
   )
 
   override fun update(node: CloudyBackgroundModifierNode) {
-    node.update(sky, radius, progressive, tint, cpuBlurEnabled, onStateChanged)
+    node.update(sky, radius, progressive, tint, cpuBlurEnabled, shape, onStateChanged)
   }
 }
 
@@ -250,6 +262,7 @@ private class CloudyBackgroundModifierNode(
   private var progressive: CloudyProgressive,
   private var tint: Color,
   private var cpuBlurEnabled: Boolean,
+  private var shape: Shape,
   private var onStateChanged: (CloudyState) -> Unit,
 ) : Modifier.Node(),
   DrawModifierNode,
@@ -259,6 +272,15 @@ private class CloudyBackgroundModifierNode(
 
   private var positionInRoot: Offset = Offset.Zero
   private var size: IntSize = IntSize.Zero
+
+  // Cached GPU blur layer + RenderEffect (API 31+). Reused across draws; the effect is rebuilt only
+  // when the blur radius changes (it is size-independent), so a steady-state frame allocates nothing.
+  private var blurLayer: GraphicsLayer? = null
+  private var cachedBlurEffect: ComposeRenderEffect? = null
+  private var cachedBlurRadius: Float = -1f
+
+  // Reusable Path for the shape clip, rebuilt only when the outline changes.
+  private var clipPathCache: Path? = null
 
   // Legacy blur state (API < 31)
   private var blurredBitmap: PlatformBitmap? = null
@@ -282,19 +304,22 @@ private class CloudyBackgroundModifierNode(
     progressive: CloudyProgressive,
     tint: Color,
     cpuBlurEnabled: Boolean,
+    shape: Shape,
     onStateChanged: (CloudyState) -> Unit,
   ) {
     val needsRedraw = this.sky != sky ||
       this.radius != radius ||
       this.progressive != progressive ||
       this.tint != tint ||
-      this.cpuBlurEnabled != cpuBlurEnabled
+      this.cpuBlurEnabled != cpuBlurEnabled ||
+      this.shape != shape
 
     this.sky = sky
     this.radius = radius
     this.progressive = progressive
     this.tint = tint
     this.cpuBlurEnabled = cpuBlurEnabled
+    this.shape = shape
     this.onStateChanged = onStateChanged
 
     if (needsRedraw) {
@@ -399,6 +424,27 @@ private class CloudyBackgroundModifierNode(
   }
 
   /**
+   * Clips [block] to [shape]'s outline so the blurred fill follows rounded corners instead of a
+   * hard rectangle. For [RectangleShape] this is a plain rectangular clip (the existing behavior),
+   * so default callers are unaffected. Rounded/path outlines clip via [clipPath] so the blur has
+   * no inner seam against the surface's rounded edge.
+   */
+  private fun ContentDrawScope.clipToShape(block: DrawScope.() -> Unit) {
+    // `size` here is the draw scope's size (the composite area), already a Size in pixels.
+    when (val outline = shape.createOutline(size, layoutDirection, this)) {
+      is Outline.Rectangle -> clipRect { block() }
+      is Outline.Rounded -> {
+        // Reuse the cached Path; rebuild it only when the outline changes.
+        val path = (clipPathCache ?: Path().also { clipPathCache = it })
+        path.rewind()
+        path.addRoundRect(outline.roundRect)
+        clipPath(path) { block() }
+      }
+      is Outline.Generic -> clipPath(outline.path) { block() }
+    }
+  }
+
+  /**
    * Draws a scrim (semi-transparent overlay) instead of blur.
    *
    * This is used when CPU blur is disabled on API 30 and below for better performance.
@@ -418,7 +464,7 @@ private class CloudyBackgroundModifierNode(
       snapshot.tintColor
     }
 
-    clipRect {
+    clipToShape {
       drawRect(color = scrimColor, blendMode = BlendMode.SrcOver)
     }
 
@@ -439,40 +485,50 @@ private class CloudyBackgroundModifierNode(
     // internally); pass the requested radius through directly.
     val blurRadius = snapshot.radius.toFloat()
 
-    // Create blur effect
-    val blurEffect = RenderEffect
-      .createBlurEffect(blurRadius, blurRadius, Shader.TileMode.CLAMP)
-      .asComposeRenderEffect()
-
+    // Reuse the blur layer and RenderEffect across draws; rebuild the effect only when the radius
+    // or layer size changes. Allocating a GraphicsLayer + RenderEffect every frame churns native
+    // memory and re-uploads GPU state needlessly.
     val context = requireGraphicsContext()
-    val blurLayer = context.createGraphicsLayer()
+    val blurLayer = this@CloudyBackgroundModifierNode.blurLayer
+      ?: context.createGraphicsLayer().also { this@CloudyBackgroundModifierNode.blurLayer = it }
 
-    try {
-      // Record the clipped background region with blur
-      blurLayer.record {
-        // Translate to sample correct region from background
-        drawContext.canvas.save()
-        drawContext.canvas.translate(-snapshot.offsetX, -snapshot.offsetY)
-        drawLayer(layer)
-        drawContext.canvas.restore()
-      }
-
-      blurLayer.renderEffect = blurEffect
-
-      // Clip to current bounds and draw the blurred layer
-      clipRect {
-        drawLayer(blurLayer)
-
-        // Apply tint
-        if (snapshot.tintColor != Color.Transparent) {
-          drawRect(color = snapshot.tintColor, blendMode = BlendMode.SrcOver)
+    val blurEffect = if (cachedBlurEffect == null || cachedBlurRadius != blurRadius) {
+      RenderEffect
+        .createBlurEffect(blurRadius, blurRadius, Shader.TileMode.CLAMP)
+        .asComposeRenderEffect()
+        .also {
+          cachedBlurEffect = it
+          cachedBlurRadius = blurRadius
         }
-      }
-
-      onStateChanged(CloudyState.Success.Applied)
-    } finally {
-      context.releaseGraphicsLayer(blurLayer)
+    } else {
+      cachedBlurEffect
     }
+
+    // Record the clipped background region with blur
+    blurLayer.record {
+      // Translate to sample correct region from background
+      drawContext.canvas.save()
+      drawContext.canvas.translate(-snapshot.offsetX, -snapshot.offsetY)
+      drawLayer(layer)
+      drawContext.canvas.restore()
+    }
+
+    if (blurLayer.renderEffect != blurEffect) {
+      blurLayer.renderEffect = blurEffect
+    }
+
+    // Clip to the surface shape (rounded corners included) and draw the blurred layer, so the
+    // blurred fill follows the rounded edge instead of leaving a hard rectangular inner box.
+    clipToShape {
+      drawLayer(blurLayer)
+
+      // Apply tint
+      if (snapshot.tintColor != Color.Transparent) {
+        drawRect(color = snapshot.tintColor, blendMode = BlendMode.SrcOver)
+      }
+    }
+
+    onStateChanged(CloudyState.Success.Applied)
   }
 
   private var hasLoggedProgressiveWarning = false
@@ -497,7 +553,7 @@ private class CloudyBackgroundModifierNode(
 
     // Draw cached blur if valid
     if (cacheValid) {
-      clipRect {
+      clipToShape {
         drawImage(
           image = cached.bitmap.asImageBitmap(),
           dstSize = androidx.compose.ui.unit.IntSize(size.width.toInt(), size.height.toInt()),
@@ -512,7 +568,7 @@ private class CloudyBackgroundModifierNode(
 
     // Show cached blur while processing new one
     if (cached != null && !cached.bitmap.isRecycled) {
-      clipRect {
+      clipToShape {
         drawImage(
           image = cached.bitmap.asImageBitmap(),
           dstSize = androidx.compose.ui.unit.IntSize(size.width.toInt(), size.height.toInt()),
@@ -664,6 +720,11 @@ private class CloudyBackgroundModifierNode(
   }
 
   override fun onDetach() {
+    blurLayer?.let { requireGraphicsContext().releaseGraphicsLayer(it) }
+    blurLayer = null
+    cachedBlurEffect = null
+    cachedBlurRadius = -1f
+    clipPathCache = null
     blurJob?.cancel()
     blurJob = null
     blurredBitmap = null

--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
@@ -156,6 +156,7 @@ private class SkyModifierNode(var sky: Sky) :
 
   override fun ContentDrawScope.draw() {
     val context = requireGraphicsContext()
+    val newlyCreated = graphicsLayer == null
     val layer = graphicsLayer ?: context.createGraphicsLayer().also {
       graphicsLayer = it
     }
@@ -174,10 +175,24 @@ private class SkyModifierNode(var sky: Sky) :
       sky.isCapturing = false
     }
 
-    // Publish the captured background for children before the on-screen pass below, so a
-    // descendant overlay reads the up-to-date layer when it draws this frame.
-    sky.backgroundLayer = layer
-    sky.incrementContentVersion()
+    // `layer` is reused across draws, so publish it to the snapshot state ONCE (when first
+    // created). Re-assigning the same instance every draw would write snapshot state that the
+    // descendant overlay reads in its own draw, invalidating it and triggering an endless redraw
+    // loop that keeps the window producing frames even while idle.
+    if (newlyCreated) {
+      sky.backgroundLayer = layer
+    }
+
+    // Re-recording `layer` above re-captures the current backdrop, so bump the content version
+    // that the legacy (API < 31) bitmap path keys its cache on. Throttle it: an unconditional
+    // per-draw bump writes snapshot state read during the overlay's draw, which re-invalidates
+    // the overlay and self-perpetuates the redraw loop, so the app never goes idle. Rate-limiting
+    // lets the tree settle to zero frames once the backdrop stops changing.
+    val now = System.currentTimeMillis()
+    if (now - lastVersionIncrementTime >= VERSION_INCREMENT_INTERVAL_MS) {
+      lastVersionIncrementTime = now
+      sky.incrementContentVersion()
+    }
 
     // Draw the subtree to the window. `isCapturing` is now false, so the overlay paints its
     // blurred backdrop (sampling `layer`, which contains no reference back to the overlay) and

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/CloudyBackground.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/CloudyBackground.kt
@@ -18,6 +18,8 @@ package com.skydoves.cloudy
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
 
 /**
  * Captures the content of this composable to a [GraphicsLayer] for background blur.
@@ -120,6 +122,10 @@ public expect fun Modifier.sky(sky: Sky): Modifier
  *                       When `true`, CPU blur is applied (may impact performance).
  *                       This setting only affects Android API 30 and below.
  *                       Defaults to [CloudyDefaults.CPP_BLUR_ENABLED].
+ * @param shape The shape the blurred backdrop is clipped to. Use a rounded shape to match a
+ *              rounded glass surface so the blur follows its corners instead of leaving a hard
+ *              rectangular inner box. Defaults to [RectangleShape] (a plain rectangular clip),
+ *              which preserves the previous behavior for existing callers.
  * @param onStateChanged Callback invoked when the blur state changes.
  * @return A [Modifier] with the background blur effect applied.
  *
@@ -136,5 +142,6 @@ public expect fun Modifier.cloudy(
   tint: Color = Color.Transparent,
   enabled: Boolean = true,
   cpuBlurEnabled: Boolean = CloudyDefaults.CPP_BLUR_ENABLED,
+  shape: Shape = RectangleShape,
   onStateChanged: (CloudyState) -> Unit = {},
 ): Modifier

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/Sky.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/Sky.kt
@@ -175,6 +175,7 @@ public class Sky internal constructor() {
    * the tail elapses. Pass the animation's duration so the blur tracks it to completion.
    */
   public fun invalidate(durationMillis: Long) {
+    require(durationMillis >= 0) { "durationMillis must be non-negative, but was $durationMillis" }
     incrementContentVersion()
     frameDriver.requestRefresh(durationMillis)
   }

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/Sky.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/Sky.kt
@@ -70,52 +70,69 @@ public class Sky internal constructor() {
    * Set by [Modifier.sky] and read by [Modifier.cloudy].
    *
    * This is `null` initially and when the sky modifier is detached.
+   *
+   * Published as a plain (non-snapshot) reference: an overlay re-reads the current layer every
+   * time it draws (the recorder always records into the SAME instance per recorder), and the
+   * per-frame refresh is driven by [SkyFrameDriver], not by a snapshot read. Writing this as
+   * snapshot state during the recorder's draw is what created the original idle redraw loop —
+   * the descendant overlay read the state, got invalidated, and forced another frame forever.
    */
-  internal var backgroundLayer: GraphicsLayer? by mutableStateOf(null)
+  internal var backgroundLayer: GraphicsLayer? = null
 
   /**
-   * Bounds of the sky container in local coordinates.
-   * Used to calculate relative positioning for child composables
-   * that apply background blur.
+   * Bounds of the sky container in local coordinates. Updated from [Modifier.sky]'s
+   * `onGloballyPositioned`. Plain field: read during the overlay's draw, which the frame driver
+   * already re-runs each frame, so no snapshot observation is needed.
    */
-  internal var sourceBounds: Rect by mutableStateOf(Rect.Zero)
+  internal var sourceBounds: Rect = Rect.Zero
 
   /**
-   * `true` while [Modifier.sky] is recording the blur source into [backgroundLayer].
+   * `true` while this sky's [Modifier.sky] recorder is recording the blur source.
    *
-   * A backdrop [Modifier.cloudy] overlay is, by design, a descendant of the [Modifier.sky]
-   * container, so the sky's capture pass re-enters the overlay's own draw. If the overlay drew
-   * its backdrop (which samples [backgroundLayer]) during that capture, the recorded display
-   * list of [backgroundLayer] would contain a reference back to itself — a cyclic `RenderNode`
-   * graph that makes the platform render thread recurse until the stack overflows
-   * (see https://github.com/skydoves/Cloudy/issues/112).
+   * A backdrop [Modifier.cloudy] overlay is a descendant of the recorder, so the capture pass
+   * re-enters the overlay's draw. The overlay reads this and draws NOTHING during capture: if it
+   * drew its blur (which samples [backgroundLayer]) into the layer being recorded, that layer would
+   * sample a layer that samples it — a cyclic `RenderNode` graph that overflows the render thread
+   * stack (https://github.com/skydoves/Cloudy/issues/112).
    *
-   * The overlay reads this flag and draws nothing while it is being captured, so it is absent
-   * from the blur source. [Modifier.sky] then draws its subtree to the window in a second pass
-   * with this flag `false`, during which the overlay paints its blurred backdrop (sampling the
-   * now-overlay-free [backgroundLayer]) and its foreground straight to the window canvas. The
-   * blur layer is therefore never recorded into [backgroundLayer], so no cycle can form.
-   *
-   * This is a plain (non-snapshot) field intentionally: capture and the nested overlay draw run
-   * synchronously on the same draw pass, so no recomposition or cross-thread visibility is needed.
+   * Scoped to this instance, so an overlay of a different sky is never suppressed. Supports exactly
+   * ONE recorder per sky (the single backdrop container per screen). Plain (non-snapshot): capture
+   * and the nested draws run synchronously on one draw pass, so no snapshot observation is needed.
    */
   internal var isCapturing: Boolean = false
 
+  /** Runs [block] with this sky marked as capturing. */
+  internal inline fun <T> capturing(block: () -> T): T {
+    isCapturing = true
+    try {
+      return block()
+    } finally {
+      isCapturing = false
+    }
+  }
+
   /**
-   * Content version counter that increments every time the background
-   * content is re-captured. Used by child modifiers to detect when
-   * cached blur results should be invalidated.
+   * Per-frame refresh driver that keeps the blur tracking the backdrop while content moves.
    *
-   * This counter enables proper cache invalidation during scrolling
-   * on devices that use bitmap-based blur (API < 31).
+   * A `Modifier.sky` recorder on a non-scrolling container is not draw-invalidated by a list
+   * scrolling underneath it, so its [backgroundLayer] would freeze while the list moves. The driver
+   * re-invalidates the recorder + overlays while scrolling, then parks so the app idles at zero
+   * frames when untouched. @see SkyFrameDriver.
+   */
+  internal val frameDriver: SkyFrameDriver = SkyFrameDriver()
+
+  /**
+   * Content version counter that increments every time [invalidate] (or the legacy capture path)
+   * signals a background change. Used by the API < 31 bitmap blur to key its cache.
+   *
+   * NOT bumped per-draw anymore: an unconditional per-draw bump wrote snapshot state read during
+   * the overlay's draw, re-invalidating it and self-perpetuating the idle redraw loop. The frame
+   * driver now drives per-frame refresh, and this counter only marks discrete, explicit changes.
    */
   internal var contentVersion: Long by mutableStateOf(0L)
     private set
 
-  /**
-   * Increments the content version, signaling that the background
-   * content has changed. Called by [Modifier.sky] after capturing.
-   */
+  /** Increments the content version, signaling a discrete background-content change. */
   internal fun incrementContentVersion() {
     contentVersion++
   }
@@ -126,7 +143,7 @@ public class Sky internal constructor() {
    * Call this method when the background content changes and needs
    * to be re-captured for blur rendering. This increments [contentVersion],
    * which triggers dependent [Modifier.cloudy] modifiers to invalidate
-   * their cached blur results.
+   * their cached blur results, and requests a refresh frame from the driver.
    *
    * ## Example
    *
@@ -148,6 +165,18 @@ public class Sky internal constructor() {
    */
   public fun invalidate() {
     incrementContentVersion()
+    frameDriver.requestRefresh()
+  }
+
+  /**
+   * Invalidates the background content for an ANIMATED change lasting [durationMillis], keeping the
+   * blur refreshing for that whole duration. A plain [invalidate] only arms a short settle tail, so
+   * a longer animation (e.g. a cross-fade between two backdrops) would freeze the blur partway once
+   * the tail elapses. Pass the animation's duration so the blur tracks it to completion.
+   */
+  public fun invalidate(durationMillis: Long) {
+    incrementContentVersion()
+    frameDriver.requestRefresh(durationMillis)
   }
 }
 

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/SkyFrameDriver.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/SkyFrameDriver.kt
@@ -120,7 +120,8 @@ internal class SkyFrameDriver {
     if (pumpJob?.isActive == true) return
     if (overlays.isEmpty()) return
     val scope = recorderScope ?: return
-    pumpJob = scope.launch {
+    lateinit var job: Job
+    job = scope.launch {
       try {
         var keepGoing = true
         while (isActive && keepGoing) {
@@ -142,8 +143,11 @@ internal class SkyFrameDriver {
           }
         }
       } finally {
-        pumpJob = null
+        // Clear only if we are still the current pump: a cancelled job's finally runs asynchronously,
+        // after a newer pump may already have been launched and stored, so a blind null would drop it.
+        if (pumpJob === job) pumpJob = null
       }
     }
+    pumpJob = job
   }
 }

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/SkyFrameDriver.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/SkyFrameDriver.kt
@@ -1,0 +1,149 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.cloudy
+
+import androidx.compose.runtime.withFrameNanos
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/**
+ * Keeps a [Sky]'s captured backdrop and its [Modifier.cloudy] overlays refreshing while content
+ * behind the glass moves (scroll, animation), then parks so the app idles at zero frames.
+ *
+ * A `Modifier.sky` recorder re-records the backdrop only when its own `draw()` runs, and an overlay
+ * re-blurs only when its draw runs. A scroll or a cross-fade of the recorded subtree repaints the
+ * subtree but does NOT re-invoke the recorder's or overlays' `draw()`, so the captured backdrop and
+ * the composited blur would freeze while sharp content moves behind the glass. The recorder forwards
+ * scroll/fling deltas (via a nested-scroll connection) to [onScrollActivity], and the app forwards
+ * discrete content changes to [requestRefresh]; both arm a short refresh window during which the
+ * driver re-invalidates the recorder (re-capture) and the overlays (re-blur) each frame.
+ *
+ * The window is measured in TIME, not frame count, so it covers a fixed-duration animation
+ * identically at 60Hz and 120Hz (a frame count would halve the wall-clock tail on a 120Hz display).
+ *
+ * Idle stays at zero frames: the window is re-armed ONLY by real activity ([onScrollActivity] /
+ * [requestRefresh]), never by the loop's own invalidations, so it always elapses and the loop exits.
+ * [withFrameNanos] does post a Choreographer frame to resume the loop, but once the window has
+ * elapsed the loop stops calling it, so nothing keeps the window producing frames.
+ */
+internal class SkyFrameDriver {
+
+  private val overlays = mutableListOf<() -> Unit>()
+
+  private var recorderScope: CoroutineScope? = null
+  private var recorderInvalidate: (() -> Unit)? = null
+  private var pumpJob: Job? = null
+
+  // Wall-clock (frame-time) nanos until which the loop should keep refreshing. Re-armed by activity.
+  private var refreshUntilNanos: Long = 0L
+
+  private companion object {
+    // Tail kept refreshing after the last activity, so the settled post-fling/post-animation frame
+    // is captured. Small, so the app idles within ~tens of ms of the motion stopping.
+    const val SETTLE_TAIL_MS = 80L
+  }
+
+  /** Registers the `Modifier.sky` recorder: [scope] hosts the loop, [invalidate] forces a capture. */
+  fun attachRecorder(scope: CoroutineScope, invalidate: () -> Unit) {
+    recorderScope = scope
+    recorderInvalidate = invalidate
+  }
+
+  fun detachRecorder(scope: CoroutineScope) {
+    if (recorderScope === scope) {
+      pumpJob?.cancel()
+      pumpJob = null
+      recorderScope = null
+      recorderInvalidate = null
+      refreshUntilNanos = 0L
+    }
+  }
+
+  /** Registers an overlay's re-blur invalidator. */
+  fun addOverlay(invalidate: () -> Unit) {
+    if (overlays.none { it === invalidate }) overlays += invalidate
+  }
+
+  fun removeOverlay(invalidate: () -> Unit) {
+    overlays.removeAll { it === invalidate }
+    if (overlays.isEmpty()) {
+      pumpJob?.cancel()
+      pumpJob = null
+      refreshUntilNanos = 0L
+    }
+  }
+
+  /**
+   * Reports scroll/fling activity behind the glass (forwarded from the recorder's nested-scroll
+   * connection). Re-arms the settle tail and starts the loop if it had parked.
+   */
+  fun onScrollActivity() {
+    extendWindow(SETTLE_TAIL_MS)
+  }
+
+  /**
+   * Requests a refresh window of at least [durationMs] (default the settle tail). The app passes the
+   * duration of a discrete content change — e.g. a cross-fade between tabs — so the blur tracks the
+   * whole animation instead of freezing partway once a short tail elapses ([Sky.invalidate]).
+   */
+  fun requestRefresh(durationMs: Long = SETTLE_TAIL_MS) {
+    extendWindow(durationMs)
+  }
+
+  // Extends the refresh window to at least [durationMs] and (re)starts the loop. The deadline is set
+  // off the loop's own frame time (folded in on the next frame), so it is always a real frame clock.
+  private fun extendWindow(durationMs: Long) {
+    pendingExtensionMs = maxOf(pendingExtensionMs, durationMs)
+    ensurePump()
+  }
+
+  // Set by extendWindow, folded into refreshUntilNanos by the loop on its next frame (the only place
+  // frame-time "now" is known). Cleared once applied.
+  private var pendingExtensionMs: Long = 0L
+
+  private fun ensurePump() {
+    if (pumpJob?.isActive == true) return
+    if (overlays.isEmpty()) return
+    val scope = recorderScope ?: return
+    pumpJob = scope.launch {
+      try {
+        var keepGoing = true
+        while (isActive && keepGoing) {
+          // withFrameNanos parks until the next window frame and hands back its frame time. It is the
+          // only clock the loop trusts: deadline math and the exit test both use this `now`.
+          keepGoing = withFrameNanos { now ->
+            if (pendingExtensionMs > 0L) {
+              refreshUntilNanos = maxOf(refreshUntilNanos, now + pendingExtensionMs * 1_000_000L)
+              pendingExtensionMs = 0L
+            }
+            val active = now < refreshUntilNanos
+            if (active) {
+              // Re-capture the moved backdrop, then re-blur the overlays against it, this frame.
+              recorderInvalidate?.invoke()
+              for (i in overlays.indices) overlays[i]()
+            }
+            // Stay in the loop while still inside the window; the work above schedules the next frame.
+            active
+          }
+        }
+      } finally {
+        pumpJob = null
+      }
+    }
+  }
+}

--- a/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/CloudyBackground.skiko.kt
+++ b/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/CloudyBackground.skiko.kt
@@ -35,8 +35,12 @@ import androidx.compose.ui.graphics.drawscope.clipPath
 import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScrollModifierNode
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.node.DelegatingNode
 import androidx.compose.ui.node.DrawModifierNode
 import androidx.compose.ui.node.GlobalPositionAwareModifierNode
 import androidx.compose.ui.node.LayoutAwareModifierNode
@@ -45,11 +49,9 @@ import androidx.compose.ui.node.invalidateDraw
 import androidx.compose.ui.node.requireGraphicsContext
 import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.toSize
 import com.skydoves.cloudy.internals.SkySnapshot
-import kotlin.time.TimeMark
-import kotlin.time.TimeSource
-import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Skiko implementation of [Modifier.sky].
@@ -125,20 +127,42 @@ private data class SkyModifierElement(val sky: Sky) : ModifierNodeElement<SkyMod
 }
 
 private class SkyModifierNode(var sky: Sky) :
-  Modifier.Node(),
+  DelegatingNode(),
   DrawModifierNode,
   GlobalPositionAwareModifierNode {
 
   private var graphicsLayer: GraphicsLayer? = null
   private var positionInRoot: Offset = Offset.Zero
 
-  // Throttle version increments to reduce blur processing frequency. Uses a monotonic time mark
-  // (multiplatform) rather than a wall clock so it works across iOS/macOS/Desktop/WASM.
-  private var lastVersionIncrement: TimeMark? = null
+  // Stable invalidator the frame driver pumps each scroll frame to re-capture the moved backdrop.
+  private val recapture: () -> Unit = { if (isAttached) invalidateDraw() }
 
-  companion object {
-    // Only increment version every 100ms to prevent excessive blur updates
-    private val VERSION_INCREMENT_INTERVAL = 100.milliseconds
+  // Forward descendant scroll/fling deltas to the frame driver: this is the precise "the backdrop is
+  // moving now" signal the draw phase lacks (a scrollable's scroll does not re-invoke this recorder's
+  // draw). The driver re-captures + re-blurs while scrolling, then parks so the app idles.
+  private val scrollConnection = object : NestedScrollConnection {
+    override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+      sky.frameDriver.onScrollActivity()
+      return Offset.Zero
+    }
+
+    override suspend fun onPreFling(available: Velocity): Velocity {
+      sky.frameDriver.onScrollActivity()
+      return Velocity.Zero
+    }
+
+    override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
+      sky.frameDriver.onScrollActivity()
+      return Velocity.Zero
+    }
+  }
+
+  init {
+    delegate(nestedScrollModifierNode(scrollConnection, dispatcher = null))
+  }
+
+  override fun onAttach() {
+    sky.frameDriver.attachRecorder(coroutineScope, recapture)
   }
 
   override fun onGloballyPositioned(coordinates: LayoutCoordinates) {
@@ -151,43 +175,27 @@ private class SkyModifierNode(var sky: Sky) :
 
   override fun ContentDrawScope.draw() {
     val context = requireGraphicsContext()
-    val newlyCreated = graphicsLayer == null
     val layer = graphicsLayer ?: context.createGraphicsLayer().also {
       graphicsLayer = it
     }
 
-    // Record the background into `layer`, the source a descendant `cloudy` overlay samples
-    // and blurs. `isCapturing` is set so the overlay draws nothing during this pass: it must be
-    // ABSENT from the blur source. Otherwise the overlay would draw its blur layer into `layer`,
-    // and that blur layer in turn samples `layer` — a cyclic RenderNode/picture graph that
-    // overflows the render thread stack (https://github.com/skydoves/Cloudy/issues/112).
-    sky.isCapturing = true
-    try {
+    // Record the background into `layer`, the source a `cloudy` overlay of this sky samples and
+    // blurs. `sky.capturing` marks the sky as recording so its overlays draw nothing during this
+    // pass: an overlay must be ABSENT from the blur source. Otherwise the overlay would draw its
+    // blur layer into the layer being recorded, and that blur layer in turn samples a backdrop
+    // layer — a cyclic picture graph that overflows the render thread stack
+    // (https://github.com/skydoves/Cloudy/issues/112).
+    sky.capturing {
       layer.record {
         this@draw.drawContent()
       }
-    } finally {
-      sky.isCapturing = false
     }
 
-    // `layer` is reused across draws, so publish it to the snapshot state ONCE (when first
-    // created). Re-assigning the same instance every draw would write snapshot state that the
-    // descendant overlay reads in its own draw, invalidating it and triggering an endless redraw
-    // loop that keeps the window producing frames even while idle.
-    if (newlyCreated) {
-      sky.backgroundLayer = layer
-    }
-
-    // Re-recording `layer` above re-captures the current backdrop, so bump the content version.
-    // Throttle it: an unconditional per-draw bump writes snapshot state read during the overlay's
-    // draw, which re-invalidates the overlay and self-perpetuates the redraw loop, so the app
-    // never goes idle. Rate-limiting lets the tree settle to zero frames once the backdrop stops
-    // changing.
-    val lastMark = lastVersionIncrement
-    if (lastMark == null || lastMark.elapsedNow() >= VERSION_INCREMENT_INTERVAL) {
-      lastVersionIncrement = TimeSource.Monotonic.markNow()
-      sky.incrementContentVersion()
-    }
+    // Publish the just-captured backdrop. A PLAIN (non-snapshot) field, so re-assigning the same
+    // instance each draw is free and never re-invalidates the overlay (that snapshot-write loop was
+    // the original idle redraw bug). The overlay re-reads it each draw; the frame driver re-runs the
+    // overlay after a fresh capture.
+    sky.backgroundLayer = layer
 
     // Draw the subtree to the window. `isCapturing` is now false, so the overlay paints its
     // blurred backdrop (sampling `layer`, which contains no reference back to the overlay) and
@@ -197,6 +205,7 @@ private class SkyModifierNode(var sky: Sky) :
   }
 
   override fun onDetach() {
+    sky.frameDriver.detachRecorder(coroutineScope)
     graphicsLayer?.let { requireGraphicsContext().releaseGraphicsLayer(it) }
     graphicsLayer = null
     sky.backgroundLayer = null
@@ -254,6 +263,10 @@ private class CloudyBackgroundModifierNode(
   private var positionInRoot: Offset = Offset.Zero
   private var size: IntSize = IntSize.Zero
 
+  // Stable re-blur invalidator the frame driver runs after each capture. A field (not a fresh lambda
+  // per call) so the driver can identity-match it on add/remove.
+  private val reblur: () -> Unit = { if (isAttached) invalidateDraw() }
+
   // Cached blur layer + BlurEffect. Reused across draws; the effect is rebuilt only when the blur
   // radius changes (it is size-independent), so a steady-state frame allocates nothing.
   private var blurLayer: GraphicsLayer? = null
@@ -277,6 +290,11 @@ private class CloudyBackgroundModifierNode(
       this.tint != tint ||
       this.shape != shape
 
+    if (this.sky != sky && isAttached) {
+      this.sky.frameDriver.removeOverlay(reblur)
+      sky.frameDriver.addOverlay(reblur)
+    }
+
     this.sky = sky
     this.radius = radius
     this.progressive = progressive
@@ -289,6 +307,10 @@ private class CloudyBackgroundModifierNode(
     }
   }
 
+  override fun onAttach() {
+    sky.frameDriver.addOverlay(reblur)
+  }
+
   override fun onGloballyPositioned(coordinates: LayoutCoordinates) {
     positionInRoot = coordinates.positionInRoot()
   }
@@ -298,12 +320,11 @@ private class CloudyBackgroundModifierNode(
   }
 
   override fun ContentDrawScope.draw() {
-    // When `sky` is an ancestor of this overlay, the sky's capture pass re-enters this draw
-    // while recording the blur source into `backgroundLayer`. This overlay must be ABSENT from
-    // that source: if it drew here, its blur layer (which samples `backgroundLayer`) would be
-    // recorded into `backgroundLayer`, forming a cyclic RenderNode/picture graph that crashes
-    // the render thread (https://github.com/skydoves/Cloudy/issues/112). Draw nothing during
-    // capture; the overlay paints itself in the sky's on-screen pass, when `isCapturing` is false.
+    // Draw nothing while this sky is recording: the overlay must be absent from the blur source,
+    // else its blur layer (which samples the backdrop) is recorded into the backdrop — a cyclic
+    // picture graph that crashes the render thread (issues/112). A `cloudy` surface is
+    // background-only; its foreground lives outside the recorder, so nothing is lost here. See
+    // [Sky.isCapturing].
     if (sky.isCapturing) {
       return
     }
@@ -431,6 +452,7 @@ private class CloudyBackgroundModifierNode(
   }
 
   override fun onDetach() {
+    sky.frameDriver.removeOverlay(reblur)
     blurLayer?.let { requireGraphicsContext().releaseGraphicsLayer(it) }
     blurLayer = null
     cachedBlurEffect = null

--- a/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/CloudyBackground.skiko.kt
+++ b/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/CloudyBackground.skiko.kt
@@ -41,6 +41,9 @@ import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.toSize
 import com.skydoves.cloudy.internals.SkySnapshot
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Skiko implementation of [Modifier.sky].
@@ -121,6 +124,15 @@ private class SkyModifierNode(var sky: Sky) :
   private var graphicsLayer: GraphicsLayer? = null
   private var positionInRoot: Offset = Offset.Zero
 
+  // Throttle version increments to reduce blur processing frequency. Uses a monotonic time mark
+  // (multiplatform) rather than a wall clock so it works across iOS/macOS/Desktop/WASM.
+  private var lastVersionIncrement: TimeMark? = null
+
+  companion object {
+    // Only increment version every 100ms to prevent excessive blur updates
+    private val VERSION_INCREMENT_INTERVAL = 100.milliseconds
+  }
+
   override fun onGloballyPositioned(coordinates: LayoutCoordinates) {
     positionInRoot = coordinates.positionInRoot()
     sky.sourceBounds = Rect(
@@ -131,6 +143,7 @@ private class SkyModifierNode(var sky: Sky) :
 
   override fun ContentDrawScope.draw() {
     val context = requireGraphicsContext()
+    val newlyCreated = graphicsLayer == null
     val layer = graphicsLayer ?: context.createGraphicsLayer().also {
       graphicsLayer = it
     }
@@ -149,10 +162,24 @@ private class SkyModifierNode(var sky: Sky) :
       sky.isCapturing = false
     }
 
-    // Publish the captured background for children before the on-screen pass below, so a
-    // descendant overlay reads the up-to-date layer when it draws this frame.
-    sky.backgroundLayer = layer
-    sky.incrementContentVersion()
+    // `layer` is reused across draws, so publish it to the snapshot state ONCE (when first
+    // created). Re-assigning the same instance every draw would write snapshot state that the
+    // descendant overlay reads in its own draw, invalidating it and triggering an endless redraw
+    // loop that keeps the window producing frames even while idle.
+    if (newlyCreated) {
+      sky.backgroundLayer = layer
+    }
+
+    // Re-recording `layer` above re-captures the current backdrop, so bump the content version.
+    // Throttle it: an unconditional per-draw bump writes snapshot state read during the overlay's
+    // draw, which re-invalidates the overlay and self-perpetuates the redraw loop, so the app
+    // never goes idle. Rate-limiting lets the tree settle to zero frames once the backdrop stops
+    // changing.
+    val lastMark = lastVersionIncrement
+    if (lastMark == null || lastMark.elapsedNow() >= VERSION_INCREMENT_INTERVAL) {
+      lastVersionIncrement = TimeSource.Monotonic.markNow()
+      sky.incrementContentVersion()
+    }
 
     // Draw the subtree to the window. `isCapturing` is now false, so the overlay paints its
     // blurred backdrop (sampling `layer`, which contains no reference back to the overlay) and

--- a/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/CloudyBackground.skiko.kt
+++ b/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/CloudyBackground.skiko.kt
@@ -24,8 +24,14 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.BlurEffect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.TileMode
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.clipPath
 import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
@@ -73,6 +79,7 @@ public actual fun Modifier.cloudy(
   tint: Color,
   enabled: Boolean,
   @Suppress("UNUSED_PARAMETER") cpuBlurEnabled: Boolean,
+  shape: Shape,
   onStateChanged: (CloudyState) -> Unit,
 ): Modifier {
   require(radius >= 0) { "Blur radius must be non-negative, but was $radius" }
@@ -94,6 +101,7 @@ public actual fun Modifier.cloudy(
       radius = radius,
       progressive = progressive,
       tint = tint,
+      shape = shape,
       onStateChanged = onStateChanged,
     ),
   )
@@ -204,6 +212,7 @@ private data class CloudyBackgroundModifierElement(
   val radius: Int,
   val progressive: CloudyProgressive,
   val tint: Color,
+  val shape: Shape,
   val onStateChanged: (CloudyState) -> Unit,
 ) : ModifierNodeElement<CloudyBackgroundModifierNode>() {
 
@@ -213,6 +222,7 @@ private data class CloudyBackgroundModifierElement(
     properties["radius"] = radius
     properties["progressive"] = progressive
     properties["tint"] = tint
+    properties["shape"] = shape
   }
 
   override fun create(): CloudyBackgroundModifierNode = CloudyBackgroundModifierNode(
@@ -220,11 +230,12 @@ private data class CloudyBackgroundModifierElement(
     radius = radius,
     progressive = progressive,
     tint = tint,
+    shape = shape,
     onStateChanged = onStateChanged,
   )
 
   override fun update(node: CloudyBackgroundModifierNode) {
-    node.update(sky, radius, progressive, tint, onStateChanged)
+    node.update(sky, radius, progressive, tint, shape, onStateChanged)
   }
 }
 
@@ -233,6 +244,7 @@ private class CloudyBackgroundModifierNode(
   private var radius: Int,
   private var progressive: CloudyProgressive,
   private var tint: Color,
+  private var shape: Shape,
   private var onStateChanged: (CloudyState) -> Unit,
 ) : Modifier.Node(),
   DrawModifierNode,
@@ -242,22 +254,34 @@ private class CloudyBackgroundModifierNode(
   private var positionInRoot: Offset = Offset.Zero
   private var size: IntSize = IntSize.Zero
 
+  // Cached blur layer + BlurEffect. Reused across draws; the effect is rebuilt only when the blur
+  // radius changes (it is size-independent), so a steady-state frame allocates nothing.
+  private var blurLayer: GraphicsLayer? = null
+  private var cachedBlurEffect: BlurEffect? = null
+  private var cachedBlurRadius: Float = -1f
+
+  // Reusable Path for the shape clip, rebuilt only when the outline changes.
+  private var clipPathCache: Path? = null
+
   fun update(
     sky: Sky,
     radius: Int,
     progressive: CloudyProgressive,
     tint: Color,
+    shape: Shape,
     onStateChanged: (CloudyState) -> Unit,
   ) {
     val needsRedraw = this.sky != sky ||
       this.radius != radius ||
       this.progressive != progressive ||
-      this.tint != tint
+      this.tint != tint ||
+      this.shape != shape
 
     this.sky = sky
     this.radius = radius
     this.progressive = progressive
     this.tint = tint
+    this.shape = shape
     this.onStateChanged = onStateChanged
 
     if (needsRedraw && isAttached) {
@@ -341,39 +365,76 @@ private class CloudyBackgroundModifierNode(
     // before handing it to Skia, so pass the requested radius through directly.
     val blurRadius = snapshot.radius.toFloat()
 
+    // Reuse the blur layer and BlurEffect across draws; rebuild the effect only when the radius
+    // changes. Allocating a GraphicsLayer + BlurEffect every frame churns memory and GPU state.
     val context = requireGraphicsContext()
-    val blurLayer = context.createGraphicsLayer()
+    val blurLayer = this@CloudyBackgroundModifierNode.blurLayer
+      ?: context.createGraphicsLayer().also { this@CloudyBackgroundModifierNode.blurLayer = it }
 
-    try {
-      // Record the clipped background region
-      blurLayer.record {
-        // Translate to sample correct region from background
-        drawContext.canvas.save()
-        drawContext.canvas.translate(-snapshot.offsetX, -snapshot.offsetY)
-        drawLayer(layer)
-        drawContext.canvas.restore()
-      }
-
-      // Apply blur effect using Skia
-      blurLayer.renderEffect = BlurEffect(
+    val blurEffect = if (cachedBlurEffect == null || cachedBlurRadius != blurRadius) {
+      BlurEffect(
         radiusX = blurRadius,
         radiusY = blurRadius,
         edgeTreatment = TileMode.Clamp,
-      )
-
-      // Clip to current bounds and draw the blurred layer
-      clipRect {
-        drawLayer(blurLayer)
-
-        // Apply tint
-        if (snapshot.tintColor != Color.Transparent) {
-          drawRect(color = snapshot.tintColor, blendMode = BlendMode.SrcOver)
-        }
+      ).also {
+        cachedBlurEffect = it
+        cachedBlurRadius = blurRadius
       }
-
-      onStateChanged(CloudyState.Success.Applied)
-    } finally {
-      context.releaseGraphicsLayer(blurLayer)
+    } else {
+      cachedBlurEffect
     }
+
+    // Record the clipped background region
+    blurLayer.record {
+      // Translate to sample correct region from background
+      drawContext.canvas.save()
+      drawContext.canvas.translate(-snapshot.offsetX, -snapshot.offsetY)
+      drawLayer(layer)
+      drawContext.canvas.restore()
+    }
+
+    if (blurLayer.renderEffect != blurEffect) {
+      blurLayer.renderEffect = blurEffect
+    }
+
+    // Clip to the surface shape (rounded corners included) and draw the blurred layer, so the
+    // blurred fill follows the rounded edge instead of leaving a hard rectangular inner box.
+    clipToShape {
+      drawLayer(blurLayer)
+
+      // Apply tint
+      if (snapshot.tintColor != Color.Transparent) {
+        drawRect(color = snapshot.tintColor, blendMode = BlendMode.SrcOver)
+      }
+    }
+
+    onStateChanged(CloudyState.Success.Applied)
+  }
+
+  /**
+   * Clips [block] to [shape]'s outline so the blurred fill follows rounded corners instead of a
+   * hard rectangle. For [RectangleShape] this is a plain rectangular clip (the existing behavior),
+   * so default callers are unaffected.
+   */
+  private fun ContentDrawScope.clipToShape(block: DrawScope.() -> Unit) {
+    // `size` here is the draw scope's size (the composite area), already a Size in pixels.
+    when (val outline = shape.createOutline(size, layoutDirection, this)) {
+      is Outline.Rectangle -> clipRect { block() }
+      is Outline.Rounded -> {
+        val path = (clipPathCache ?: Path().also { clipPathCache = it })
+        path.rewind()
+        path.addRoundRect(outline.roundRect)
+        clipPath(path) { block() }
+      }
+      is Outline.Generic -> clipPath(outline.path) { block() }
+    }
+  }
+
+  override fun onDetach() {
+    blurLayer?.let { requireGraphicsContext().releaseGraphicsLayer(it) }
+    blurLayer = null
+    cachedBlurEffect = null
+    cachedBlurRadius = -1f
+    clipPathCache = null
   }
 }

--- a/docs/src/wasmJsMain/kotlin/docs/screen/ApiSkyScreen.kt
+++ b/docs/src/wasmJsMain/kotlin/docs/screen/ApiSkyScreen.kt
@@ -141,6 +141,7 @@ fun ApiSkyScreen() {
           tint: Color = Color.Transparent,
           enabled: Boolean = true,
           cpuBlurEnabled: Boolean = CloudyDefaults.CPP_BLUR_ENABLED,
+          shape: Shape = RectangleShape,
           onStateChanged: (CloudyState) -> Unit = {},
         ): Modifier
       """,
@@ -244,6 +245,39 @@ fun ApiSkyScreen() {
       """,
     )
 
+    Spacer(modifier = Modifier.height(32.dp))
+
+    // Sky.invalidate(durationMillis)
+    Text(
+      text = "Sky.invalidate(durationMillis)",
+      style = DocsTheme.typography.h2,
+      color = DocsTheme.colors.onBackground,
+    )
+
+    Spacer(modifier = Modifier.height(12.dp))
+
+    Text(
+      text = "Use this overload when the backdrop changes over an animation, e.g. a cross-fade " +
+        "between two backgrounds or a tab transition. A plain invalidate() arms only a short " +
+        "settle tail, so a longer animation would freeze the blur partway. Pass the animation " +
+        "duration so the blur tracks it to completion.",
+      style = DocsTheme.typography.body,
+      color = DocsTheme.colors.onSurfaceVariant,
+    )
+
+    Spacer(modifier = Modifier.height(12.dp))
+
+    CodeBlock(
+      code = """
+        val sky = rememberSky()
+
+        // Re-capture the backdrop across a 240ms cross-fade between tabs.
+        LaunchedEffect(selectedTab) {
+          sky.invalidate(durationMillis = 240L)
+        }
+      """,
+    )
+
     Spacer(modifier = Modifier.height(48.dp))
   }
 }
@@ -295,6 +329,7 @@ private fun BackgroundBlurParameterTable() {
     ParamRow("tint", "Transparent", "Tint color over blurred background")
     ParamRow("enabled", "true", "Enable/disable the blur effect")
     ParamRow("cpuBlurEnabled", "false", "Enable CPU blur on Android 30-")
+    ParamRow("shape", "RectangleShape", "Shape the blurred backdrop is clipped to")
     ParamRow("onStateChanged", "{}", "State change callback")
   }
 }


### PR DESCRIPTION
### 🎯 Goal

Stabilize backdrop blur (`Modifier.sky` + `Modifier.cloudy(sky)`) for the common layout where the recorder sits on a non-scrolling container and a `LazyColumn` scrolls inside it, behind a fixed glass bar. Three bugs are addressed:

- An idle redraw loop: the recorder wrote `backgroundLayer`/`contentVersion` as snapshot state on every draw, which a descendant overlay observed and re-invalidated, so the window never went idle.
- A native RenderThread `SIGSEGV` (cyclic RenderNode) when the glass overlay is drawn into the layer it samples — this is the crash in #112.
- The blur freezing while content scrolls behind the glass, because a `LazyColumn` scroll does not re-invoke the recorder's or overlay's `draw()`.

Fixes #112.

### 🛠 Implementation details

**1. Stop the idle redraw loop.** `backgroundLayer` and `sourceBounds` become plain (non-snapshot) fields. The recorder no longer bumps `contentVersion` on every draw; per-frame refresh is driven explicitly (below) and `contentVersion` now marks only discrete changes (it still keys the API < 31 bitmap cache).

**2. Keep the overlay out of the blur source.** During capture the sky is marked recording and the `cloudy` overlay draws nothing, so it is absent from the recorded layer and no `skyLayer → blurLayer → skyLayer` cycle forms. A `cloudy` surface is a background-only material: its foreground lives outside the `Modifier.sky` recorder, so nothing is lost by skipping the overlay's draw during capture.

**3. Drive refresh while content moves, park at idle.** A new internal `SkyFrameDriver` re-invalidates the recorder (re-capture) and the overlays (re-blur) once per frame while the backdrop is moving, then stops once it settles, so the app reaches zero frames at idle. The recorder delegates a `NestedScrollConnection` that consumes nothing (returns `Offset.Zero` / `Velocity.Zero`) and only forwards scroll/fling deltas as the "backdrop is moving" signal. The refresh window is measured in time, not frame count, so it covers a fixed-duration animation identically at 60Hz and 120Hz.

**4. Clip the blur to a shape.** `Modifier.cloudy` takes a new `shape: Shape = RectangleShape` parameter. The default keeps the existing rectangular clip, so current callers are unaffected; a rounded shape clips the blurred fill to the surface corners instead of leaving a hard rectangular box inside a rounded glass bar.

The blur layer and `RenderEffect`/`BlurEffect` are cached and reused across frames (rebuilt only when the radius changes), so a steady-state frame allocates nothing. Android and the skiko (desktop/iOS) backends are kept in sync.

Public API additions (`apiDump` updated): the new `shape` parameter on `cloudy`, and a `Sky.invalidate(durationMillis: Long)` overload that holds the refresh window open for an animated change (e.g. a tab cross-fade). Adding the `shape` parameter changes the `cloudy` signature, so the previous binary signature is replaced.

`./gradlew spotlessApply` and `./gradlew apiDump` were run; results are committed.

### ✍️ Explain examples

The `cloudy` default is unchanged, so existing usage keeps working. To clip the blur to a rounded glass bar:

```kotlin
val barShape = RoundedCornerShape(36.dp)

Row(
  modifier = Modifier
    .clip(barShape)
    .cloudy(sky = sky, radius = 24, shape = barShape)
    .background(Color.White.copy(alpha = 0.15f)),
) { /* tabs */ }
```

For an animated backdrop change (e.g. cross-fading tab content behind the glass), pass the animation duration so the blur tracks the whole transition instead of freezing once a short settle tail elapses:

```kotlin
LaunchedEffect(selectedTab) {
  sky.invalidate(durationMillis = 240) // matches the cross-fade duration
}
```

The `Issue #112 — BottomNav` demo screen exercises the scrolling-behind-glass layout: it auto-scrolls a 60-item list under a blurred bottom bar. Before this change it crashes on the RenderThread; after it, the bar blurs the moving list and the app idles at zero frames once scrolling stops.

### Video


https://github.com/user-attachments/assets/c22cb656-4415-471e-a30a-521d39344447


https://github.com/user-attachments/assets/faf67c77-cb1e-4b20-994b-bb8afe340087




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added `shape` support to `Modifier.cloudy`, so blur backgrounds and scrims follow rounded and custom outlines.
  * Improved scrolling/interaction refresh so blurred backdrops stay responsive during active movement.
* **Bug Fixes**
  * Fixed clipping so blur and related visuals render strictly within the provided shape.
  * Reduced unnecessary redraws and stabilized refresh to avoid idle redraw loops.
* **Documentation**
  * Updated API docs for `Modifier.cloudy(shape=...)` and added guidance/examples for `Sky.invalidate(durationMillis)`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->