### PR TITLE
docs: restructure README into effect-parity sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@
 </p><br>
 
 <p align="center">
-Kotlin Multiplatform blur and liquid glass effect library for Compose, with GPU-accelerated rendering and CPU fallback for older devices. See <a href="https://skydoves.github.io/Cloudy/">documentation</a> for more details.
+Kotlin Multiplatform surface effects library for Compose — blur, liquid glass, and shader-driven looks — with GPU-accelerated rendering and CPU fallback for older devices. See <a href="https://skydoves.github.io/Cloudy/">documentation</a> for more details.
 </p><br>
 
-> <p align="center">The `blur` modifier supports only Android 12 and higher, and `RenderScript` APIs are deprecated starting in Android 12.
-> Cloudy is the backport of the blur effect for Jetpack Compose with cross-platform support.</p>
+> <p align="center">Cloudy started as a backport of the blur effect for Jetpack Compose with cross-platform support, and has grown to cover liquid glass and open shader effects as well.
+> The `Modifier.cloudy(radius = …)` blur path supports only Android 12 and higher without the deprecated `RenderScript` APIs; see <a href="#platform-support-self-blur">Platform Support</a> for the CPU fallback on older devices.</p>
 
 <p align="center">
 <img src="preview/gif0.gif" width="268"/>

--- a/README.md
+++ b/README.md
@@ -26,18 +26,29 @@ Kotlin Multiplatform blur and liquid glass effect library for Compose, with GPU-
 <img src="preview/img2.png" width="268"/>
 </p>
 
-### Supported Platforms (Blur Effect)
+Cloudy ships four independent effects you can mix and match on any composable — pick the ones you need:
 
-| Platform | Implementation | Performance | State Type |
-|----------|----------------|-------------|------------|
-| Android 31+ | RenderEffect (GPU) | GPU-accelerated | `Success.Applied` |
-| Android 30- | Native C++ (CPU) | NEON/SIMD optimized | `Success.Captured` |
-| iOS | Skia BlurEffect (Metal GPU) | GPU-accelerated | `Success.Applied` |
-| macOS | Skia BlurEffect (Metal GPU) | GPU-accelerated | `Success.Applied` |
-| Desktop (JVM) | Skia BlurEffect (GPU) | GPU-accelerated | `Success.Applied` |
-| WASM (Browser) | Skia BlurEffect (WebGL) | GPU-accelerated | `Success.Applied` |
+| Effect | Modifier | What it does |
+|--------|----------|---------------|
+| [Self blur](#self-blur) | `Modifier.cloudy(radius = …)` | Blurs a composable's **own** content |
+| [Backdrop blur](#backdrop-blur) | `Modifier.cloudy(sky = …)` | Blurs the content **behind** a composable (glassmorphism) |
+| [Liquid Glass](#liquid-glass) | `Modifier.liquidGlass(…)` | A realistic glass lens with refraction and chromatic dispersion |
+| [Mirage](#mirage) | `Modifier.mirage { }` | An open shader-effect plan — thin-film / specular presets, or your own |
 
-> See [Liquid Glass Effect](#liquid-glass-effect) for liquid glass platform support.
+**Table of contents**
+
+- [Download](#download)
+- **Part I — Effects**
+  - [Self blur](#self-blur)
+  - [Backdrop blur](#backdrop-blur)
+  - [Liquid Glass](#liquid-glass)
+  - [Mirage](#mirage)
+- **Part II — Going further**
+  - [Motion-driven light sources](#motion-driven-light-sources)
+  - [Authoring your own Mirage optic](#authoring-your-own-mirage-optic)
+  - [Blur effect with network images](#blur-effect-with-network-images)
+- [Acknowledgements](#acknowledgements)
+- [License](#license)
 
 ## Download
 
@@ -79,9 +90,13 @@ sourceSets {
 }
 ```
 
-## Usage
+# Part I — Effects
 
-Cloudy offers two blur modes: `Modifier.cloudy(radius = …)` blurs a composable's **own** content (covered below), while [Background Blur](#background-blur-backdrop-blur) blurs the content *behind* a composable for glassmorphism surfaces.
+## Self blur
+
+Cloudy offers two blur modes: `Modifier.cloudy(radius = …)` blurs a composable's **own** content (covered here), while [Backdrop blur](#backdrop-blur) blurs the content *behind* a composable for glassmorphism surfaces.
+
+### Basic Usage
 
 You can implement blur effect with `Modifier.cloudy()` composable function as seen below:
 
@@ -123,7 +138,7 @@ Column(
 }
 ```
 
-## Observing Blurring Status
+### Observing Blurring Status
 
 You can monitor the status of the blurring effect by using the `onStateChanged` parameter, which provides `CloudyState`. This allows you to observe and respond to changes in the blurring effect's state effectively.
 
@@ -160,7 +175,7 @@ GlideImage(
 )
 ```
 
-### CloudyState Types
+`CloudyState` has the following types:
 
 | State | Description | Bitmap Available |
 |-------|-------------|------------------|
@@ -171,7 +186,7 @@ GlideImage(
 | `Error` | Blur operation failed | No |
 | `Nothing` | Initial state | No |
 
-## Maintaining Blurring Effect on Responsive Composable
+### Maintaining Blurring Effect on Responsive Composable
 
 The `Modifier.cloudy` captures the bitmap of the composable node under the hood.
 
@@ -200,7 +215,20 @@ private fun HomePoster(poster: Poster) {
           ..
 ```
 
-## Background Blur (Backdrop Blur)
+### Platform Support (Self Blur)
+
+| Platform | Implementation | Performance | State Type |
+|----------|----------------|-------------|------------|
+| Android 31+ | RenderEffect (GPU) | GPU-accelerated | `Success.Applied` |
+| Android 30- | Native C++ (CPU) | NEON/SIMD optimized | `Success.Captured` |
+| iOS | Skia BlurEffect (Metal GPU) | GPU-accelerated | `Success.Applied` |
+| macOS | Skia BlurEffect (Metal GPU) | GPU-accelerated | `Success.Applied` |
+| Desktop (JVM) | Skia BlurEffect (GPU) | GPU-accelerated | `Success.Applied` |
+| WASM (Browser) | Skia BlurEffect (WebGL) | GPU-accelerated | `Success.Applied` |
+
+> See [Backdrop blur](#platform-behavior-background-blur) and [Liquid Glass](#platform-support-liquid-glass) for their own platform support tables.
+
+## Backdrop blur
 
 Background blur — also called **backdrop blur** — blurs the content that sits *behind* a composable, producing a glassmorphism / frosted-glass surface such as a translucent app bar, bottom navigation, or card. Unlike `Modifier.cloudy(radius = …)`, which blurs a composable's **own** content, the backdrop API samples a shared snapshot of the background and renders it blurred *underneath* your overlay.
 
@@ -332,28 +360,13 @@ LaunchedEffect(selectedTab) {
 
 > On Android 30 and below, CPU blur is disabled by default and a semi-transparent scrim (`CloudyState.Success.Scrim`) is shown instead, following a performance-first approach. Set `cpuBlurEnabled = true` to force CPU blur on those devices.
 
-## Blur Effect with Network Images
-
-You can easily implement blur effect with [Landscapist](https://github.com/skydoves/landscapist), which is a Jetpack Compose image loading library that fetches and displays network images with Glide, Coil, and Fresco. For more information, see the [Transformation](https://github.com/skydoves/landscapist#transformation) section.
-
-## Liquid Glass Effect
+## Liquid Glass
 
 ![image](screenshots/liquidglass.gif)
 
 Cloudy provides a `Modifier.liquidGlass()` that creates a realistic glass lens effect with SDF-based crisp edges, normal-based refraction, and chromatic dispersion.
 
 **Note:** For blur effects, use `Modifier.cloudy()` separately. The two modifiers are designed to work independently, giving you full control over each effect.
-
-### Platform Support (Liquid Glass)
-
-| Platform | Implementation | Features |
-|----------|----------------|----------|
-| Android 33+ | RuntimeShader (AGSL) | Full effect |
-| Android 32- | Fallback | Tint + edge + shape (no lens refraction) |
-| iOS | Skia RuntimeEffect | Full effect |
-| macOS | Skia RuntimeEffect | Full effect |
-| Desktop (JVM) | Skia RuntimeEffect | Full effect |
-| WASM | Skia RuntimeEffect | Full effect |
 
 ### Basic Usage
 
@@ -430,65 +443,26 @@ You can customize the liquid glass effect with various parameters:
 | `contrast` | 1.0f | Light/dark contrast (1.0 = normal) | Approximation |
 | `tint` | Transparent | Optional color tint overlay | Yes |
 | `edge` | 0.2f | Edge lighting width (0 = none) | Yes (as stroke) |
-| `light` | Fixed | Specular light source (see Motion-driven specular) | No (requires API 33+) |
+| `light` | Fixed | Specular light source (see [Motion-driven light sources](#motion-driven-light-sources)) | No (requires API 33+) |
 | `glow` | `LiquidGlassDefaults.Glow` | Perceptual glint tuning: brightness (`intensity`) and focus (`sharpness`). Use `LiquidGlassDefaults.NoGlow` to remove the glint | No (requires API 33+) |
 | `enabled` | true | Enable/disable the effect | Yes |
 
 > **Note:** On Android 32 and below, the lens refraction effect is not available since it requires `RuntimeShader` (API 33+). The fallback draws a visible lens shape with tint, edge lighting, and color adjustments. For blur effects, use `Modifier.cloudy()` separately.
 
-### Motion-driven specular (experimental)
+### Platform Support (Liquid Glass)
 
-By default the rim highlight uses a fixed light direction that reproduces the *direction* of the old fixed light. The specular itself is a new multi-term model (a moving focal pool, body sheen, a Blinn rim, and a back-rim, screen-blended), so the highlight looks different from pre-release versions — an intended upgrade, not a bit-for-bit match. Opt in to **gyro-driven specular** to make the highlight sweep across the glass as the device tilts (à la iOS 26 "lights move in space"):
+| Platform | Implementation | Features |
+|----------|----------------|----------|
+| Android 33+ | RuntimeShader (AGSL) | Full effect |
+| Android 32- | Fallback | Tint + edge + shape (no lens refraction) |
+| iOS | Skia RuntimeEffect | Full effect |
+| macOS | Skia RuntimeEffect | Full effect |
+| Desktop (JVM) | Skia RuntimeEffect | Full effect |
+| WASM | Skia RuntimeEffect | Full effect |
 
-```kotlin
-@OptIn(ExperimentalLiquidGlassMotion::class)
-@Composable
-fun GlassCard() {
-  // Hoist once and share across items in a list — one call registers one sensor.
-  val light = rememberGyroLightSource(enabled = true)
+> Liquid Glass also supports an optional, opt-in motion-driven light source — see [Motion-driven light sources](#motion-driven-light-sources) in Part II.
 
-  Box(
-    modifier = Modifier.liquidGlass(
-      lensCenter = lensCenter,
-      light = light,
-    ),
-  ) { /* ... */ }
-}
-```
-
-- **Opt-in & accessible:** the default is a fixed light *direction*; motion is opt-in. Enabling gyro only changes where the light *direction* comes from — the specular model itself is the same whether the light is fixed or motion-driven. When **Reduce Motion** is enabled (Android animator scale `0`, iOS `isReduceMotionEnabled`), the light is frozen and no sensors are registered — observed live.
-- **Platform support:** Android **API 33+** (the fallback path has no shader → no-op), iOS, and any device with a motion sensor. Desktop/Web and sensorless devices keep a static light.
-- **Lists:** call `rememberGyroLightSource()` **once** above the list and pass the result to each item, so a single sensor listener is shared.
-
-> **iOS:** the consuming app's `Info.plist` **must** declare `NSMotionUsageDescription`, or recent iOS terminates the app on the first device-motion read. iOS v1 uses a portrait-oriented projection; landscape is not yet remapped.
-
-#### Transform-driven light (no sensor)
-
-`rememberTransformLightSource` is the sibling of `rememberGyroLightSource`. Instead of the device gyro, it drives the highlight from a composable's **own** `rotationX` / `rotationY` — the same values you apply through `Modifier.graphicsLayer`. It needs no sensor, no platform code, and works on every target including Desktop and Web:
-
-```kotlin
-@OptIn(ExperimentalLiquidGlassMotion::class)
-@Composable
-fun TiltCard() {
-  var rx by remember { mutableFloatStateOf(0f) }
-  var ry by remember { mutableFloatStateOf(0f) }
-  val light = rememberTransformLightSource(rotationX = { rx }, rotationY = { ry })
-
-  Box(
-    modifier = Modifier
-      .graphicsLayer { rotationX = rx; rotationY = ry; cameraDistance = 12f * density }
-      .liquidGlass(lensCenter = lensCenter, light = light),
-  ) { /* ... */ }
-}
-```
-
-The rotations are read as lambdas (deferred reads) so per-frame updates invalidate the draw without recomposing the modifier, matching the gyro source's behavior.
-
-#### Glint tuning
-
-The `glow` parameter tunes the specular glint with two perceptual knobs: `intensity` (brightness) and `sharpness` (focus). Build one with the `LiquidGlassGlow(intensity = …, sharpness = …)` factory, or use `LiquidGlassDefaults.NoGlow` to switch the glint off. The full set of shader tunables — `glowRimMix` and `glowWidthPx`, alongside `glowIntensity` / `glowSharpness` — lives on the experimental `Modifier.liquidGlassTuned` overload, intended for live experimentation rather than the committed API surface.
-
-## Mirage (open shader effect)
+## Mirage
 
 `Modifier.mirage { }` applies an **open shader-effect plan** to any composable: one modifier runs a plan of typed `Optic`s — either the bundled looks or optics you author yourself — against the content it wraps. It ships a family of thin-film / specular presets, and because an optic is just a kernel plus a typed uniform schema, consumers can add new effects without any library change.
 
@@ -499,14 +473,6 @@ Mirage is behind an experimental opt-in and is excluded from the stable ABI whil
 @Composable
 fun Poster() { /* ... */ }
 ```
-
-### Platform Support (Mirage)
-
-| Platform | Implementation | Behavior |
-|----------|----------------|----------|
-| Android 33+ | RuntimeShader (AGSL) | Full effect |
-| Android 32- | — | Each stage is skipped; content passes through unchanged |
-| iOS / macOS / Desktop (JVM) / WASM | Skia RuntimeEffect (SKSL) | Full effect |
 
 ### Basic Usage
 
@@ -566,7 +532,77 @@ Modifier.mirage {
 }
 ```
 
-### Authoring your own optic
+### Platform Support (Mirage)
+
+| Platform | Implementation | Behavior |
+|----------|----------------|----------|
+| Android 33+ | RuntimeShader (AGSL) | Full effect |
+| Android 32- | — | Each stage is skipped; content passes through unchanged |
+| iOS / macOS / Desktop (JVM) / WASM | Skia RuntimeEffect (SKSL) | Full effect |
+
+> Want to write your own preset instead of using the bundled ones? See [Authoring your own Mirage optic](#authoring-your-own-mirage-optic) in Part II.
+
+# Part II — Going further
+
+The topics below extend an effect from Part I — an opt-in motion source for Liquid Glass, writing a custom Mirage optic, and using Cloudy with a network image loader. Read these once the basics above are working.
+
+## Motion-driven light sources
+
+*Extends: [Liquid Glass](#liquid-glass)*
+
+By default the rim highlight uses a fixed light direction that reproduces the *direction* of the old fixed light. The specular itself is a new multi-term model (a moving focal pool, body sheen, a Blinn rim, and a back-rim, screen-blended), so the highlight looks different from pre-release versions — an intended upgrade, not a bit-for-bit match. Opt in to **gyro-driven specular** to make the highlight sweep across the glass as the device tilts (à la iOS 26 "lights move in space"):
+
+```kotlin
+@OptIn(ExperimentalLiquidGlassMotion::class)
+@Composable
+fun GlassCard() {
+  // Hoist once and share across items in a list — one call registers one sensor.
+  val light = rememberGyroLightSource(enabled = true)
+
+  Box(
+    modifier = Modifier.liquidGlass(
+      lensCenter = lensCenter,
+      light = light,
+    ),
+  ) { /* ... */ }
+}
+```
+
+- **Opt-in & accessible:** the default is a fixed light *direction*; motion is opt-in. Enabling gyro only changes where the light *direction* comes from — the specular model itself is the same whether the light is fixed or motion-driven. When **Reduce Motion** is enabled (Android animator scale `0`, iOS `isReduceMotionEnabled`), the light is frozen and no sensors are registered — observed live.
+- **Platform support:** Android **API 33+** (the fallback path has no shader → no-op), iOS, and any device with a motion sensor. Desktop/Web and sensorless devices keep a static light.
+- **Lists:** call `rememberGyroLightSource()` **once** above the list and pass the result to each item, so a single sensor listener is shared.
+
+> **iOS:** the consuming app's `Info.plist` **must** declare `NSMotionUsageDescription`, or recent iOS terminates the app on the first device-motion read. iOS v1 uses a portrait-oriented projection; landscape is not yet remapped.
+
+### Transform-driven light (no sensor)
+
+`rememberTransformLightSource` is the sibling of `rememberGyroLightSource`. Instead of the device gyro, it drives the highlight from a composable's **own** `rotationX` / `rotationY` — the same values you apply through `Modifier.graphicsLayer`. It needs no sensor, no platform code, and works on every target including Desktop and Web:
+
+```kotlin
+@OptIn(ExperimentalLiquidGlassMotion::class)
+@Composable
+fun TiltCard() {
+  var rx by remember { mutableFloatStateOf(0f) }
+  var ry by remember { mutableFloatStateOf(0f) }
+  val light = rememberTransformLightSource(rotationX = { rx }, rotationY = { ry })
+
+  Box(
+    modifier = Modifier
+      .graphicsLayer { rotationX = rx; rotationY = ry; cameraDistance = 12f * density }
+      .liquidGlass(lensCenter = lensCenter, light = light),
+  ) { /* ... */ }
+}
+```
+
+The rotations are read as lambdas (deferred reads) so per-frame updates invalidate the draw without recomposing the modifier, matching the gyro source's behavior.
+
+### Glint tuning
+
+The `glow` parameter tunes the specular glint with two perceptual knobs: `intensity` (brightness) and `sharpness` (focus). Build one with the `LiquidGlassGlow(intensity = …, sharpness = …)` factory, or use `LiquidGlassDefaults.NoGlow` to switch the glint off. The full set of shader tunables — `glowRimMix` and `glowWidthPx`, alongside `glowIntensity` / `glowSharpness` — lives on the experimental `Modifier.liquidGlassTuned` overload, intended for live experimentation rather than the committed API surface.
+
+## Authoring your own Mirage optic
+
+*Extends: [Mirage](#mirage)*
 
 An optic is a kernel plus a `MirageParams` subclass whose property names are the shader uniform identifiers. A `composite` optic authors a full `half4 main(float2 xy)` and samples the content through the compiler-provided `content` shader:
 
@@ -597,6 +633,14 @@ Apply it exactly like a preset: `Modifier.mirage { filter(Vignette) { strength(0
 
 The other factories are `Optic.colorize` (a point-wise `half4 kernel(float2 p, half4 src)` that never reaches `content` directly), `Optic.generate` (a content-free overlay), and `Optic.raw` (an escape hatch that emits your source verbatim). The compiler declares the standard uniforms (`mirageResolution` / `mirageTime` / `mirageDensity`) only when the kernel references them, and rejects kernels that use derivative builtins, preprocessor directives, or the raw fragment-coord builtin (none of which compile as a runtime shader).
 
+## Blur effect with network images
+
+*Extends: [Self blur](#self-blur)*
+
+You can easily implement blur effect with [Landscapist](https://github.com/skydoves/landscapist), which is a Jetpack Compose image loading library that fetches and displays network images with Glide, Coil, and Fresco. For more information, see the [Transformation](https://github.com/skydoves/landscapist#transformation) section.
+
+---
+
 ## Find this repository useful? :heart:
 Support it by joining __[stargazers](https://github.com/skydoves/cloudy/stargazers)__ for this repository. :star: <br>
 Also, __[follow me](https://github.com/skydoves)__ on GitHub for my next creations! 🤩
@@ -605,7 +649,7 @@ Also, __[follow me](https://github.com/skydoves)__ on GitHub for my next creatio
 
 The liquid glass shader implementation was inspired by [FletchMcKee/liquid](https://github.com/FletchMcKee/liquid).
 
-# License
+## License
 ```xml
 Designed and developed by 2022 skydoves (Jaewoong Eum)
 

--- a/docs/src/wasmJsMain/kotlin/docs/navigation/DocsRoute.kt
+++ b/docs/src/wasmJsMain/kotlin/docs/navigation/DocsRoute.kt
@@ -21,9 +21,9 @@ sealed class DocsRoute(val path: String, val title: String) {
   data object Installation : DocsRoute("/guide/installation", "Installation")
   data object PlatformSupport : DocsRoute("/guide/platforms", "Platform Support")
   data object ApiCloudy : DocsRoute("/api/cloudy", "Modifier.cloudy()")
-  data object ApiSky : DocsRoute("/api/sky", "Background Blur")
-  data object ApiProgressive : DocsRoute("/api/progressive", "CloudyProgressive")
   data object ApiState : DocsRoute("/api/state", "CloudyState")
+  data object ApiSky : DocsRoute("/api/sky", "Backdrop Blur")
+  data object ApiProgressive : DocsRoute("/api/progressive", "CloudyProgressive")
   data object ApiLiquidGlass : DocsRoute("/api/liquid-glass", "Liquid Glass")
   data object ApiMotionLight : DocsRoute("/api/motion-light", "Motion Light")
   data object ApiMirage : DocsRoute("/api/mirage", "Mirage")
@@ -31,12 +31,14 @@ sealed class DocsRoute(val path: String, val title: String) {
 
   companion object {
     val guideRoutes = listOf(GettingStarted, Installation, PlatformSupport)
+
+    // Grouped to mirror README's Part I: Self blur -> Backdrop blur -> Liquid Glass -> Mirage.
     val apiRoutes =
       listOf(
         ApiCloudy,
+        ApiState,
         ApiSky,
         ApiProgressive,
-        ApiState,
         ApiLiquidGlass,
         ApiMotionLight,
         ApiMirage,

--- a/docs/src/wasmJsMain/kotlin/docs/screen/ApiCloudyScreen.kt
+++ b/docs/src/wasmJsMain/kotlin/docs/screen/ApiCloudyScreen.kt
@@ -290,8 +290,7 @@ private fun PlatformBehaviorTable() {
       )
     }
 
-    PlatformRow("Android 33+", "AGSL RuntimeShader", "CloudyState.Success.Applied")
-    PlatformRow("Android 31-32", "RenderEffect (GPU)", "CloudyState.Success.Applied")
+    PlatformRow("Android 31+", "RenderEffect (GPU)", "CloudyState.Success.Applied")
     PlatformRow("Android 23-30", "Native C++ (CPU)", "CloudyState.Success.Captured")
     PlatformRow("iOS", "Skia BlurEffect", "CloudyState.Success.Applied")
     PlatformRow("macOS", "Skia BlurEffect", "CloudyState.Success.Applied")

--- a/docs/src/wasmJsMain/kotlin/docs/screen/ApiSkyScreen.kt
+++ b/docs/src/wasmJsMain/kotlin/docs/screen/ApiSkyScreen.kt
@@ -46,7 +46,7 @@ fun ApiSkyScreen() {
       .padding(32.dp),
   ) {
     Text(
-      text = "Background Blur (Glassmorphism)",
+      text = "Backdrop Blur (Glassmorphism)",
       style = DocsTheme.typography.h1,
       color = DocsTheme.colors.onBackground,
     )

--- a/docs/src/wasmJsMain/kotlin/docs/screen/GettingStartedScreen.kt
+++ b/docs/src/wasmJsMain/kotlin/docs/screen/GettingStartedScreen.kt
@@ -46,8 +46,10 @@ fun GettingStartedScreen() {
     Spacer(modifier = Modifier.height(16.dp))
 
     Text(
-      text = "Cloudy is a Jetpack Compose blur library for Kotlin Multiplatform. " +
-        "It provides a simple Modifier.cloudy() API to apply blur effects to any composable.",
+      text = "Cloudy is a Compose Multiplatform surface effects library. It ships four " +
+        "modifiers you can mix and match: Modifier.cloudy() for blur (your own content, " +
+        "or the content behind you), Modifier.liquidGlass() for a refractive glass lens, " +
+        "and Modifier.mirage { } for an open shader-effect plan.",
       style = DocsTheme.typography.body,
       color = DocsTheme.colors.onSurfaceVariant,
     )
@@ -176,6 +178,99 @@ fun GettingStartedScreen() {
           }
         )
       """,
+    )
+
+    Spacer(modifier = Modifier.height(32.dp))
+
+    // Liquid Glass
+    Text(
+      text = "Liquid Glass",
+      style = DocsTheme.typography.h2,
+      color = DocsTheme.colors.onBackground,
+    )
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    Text(
+      text = "Add a realistic glass lens with refraction and chromatic dispersion. " +
+        "It is independent of Modifier.cloudy() — combine both for a blurred backdrop " +
+        "seen through a glass lens:",
+      style = DocsTheme.typography.body,
+      color = DocsTheme.colors.onSurfaceVariant,
+    )
+
+    Spacer(modifier = Modifier.height(12.dp))
+
+    CodeBlock(
+      code = """
+        var lensCenter by remember { mutableStateOf(Offset(100f, 100f)) }
+
+        Box(
+          modifier = Modifier
+            .cloudy(radius = 15) // Optional: combine with Cloudy blur
+            .liquidGlass(lensCenter = lensCenter)
+        ) {
+          Image(painter = painterResource("photo.png"), contentDescription = null)
+        }
+      """,
+    )
+
+    Spacer(modifier = Modifier.height(12.dp))
+
+    Text(
+      text = "See the Modifier.liquidGlass() reference for the full parameter set and " +
+        "motion-driven light sources.",
+      style = DocsTheme.typography.bodySmall,
+      color = DocsTheme.colors.onSurfaceVariant,
+    )
+
+    Spacer(modifier = Modifier.height(32.dp))
+
+    // Mirage
+    Text(
+      text = "Mirage",
+      style = DocsTheme.typography.h2,
+      color = DocsTheme.colors.onBackground,
+    )
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    Text(
+      text = "Apply an open shader-effect plan through Modifier.mirage { }. It ships thin-film " +
+        "and specular presets, and consumers can author their own optics with no library " +
+        "change. Mirage is experimental — opt in with @OptIn(ExperimentalMirage::class):",
+      style = DocsTheme.typography.body,
+      color = DocsTheme.colors.onSurfaceVariant,
+    )
+
+    Spacer(modifier = Modifier.height(12.dp))
+
+    CodeBlock(
+      code = """
+        @OptIn(ExperimentalMirage::class)
+        @Composable
+        fun Poster() {
+          Box(
+            modifier = Modifier.mirage {
+              filter(MirageOptics.Chromatic) {
+                lensCenter(Offset(260f, 260f))
+                lensSize(Size(520f, 520f))
+              }
+            },
+          ) {
+            Image(painter = painterResource("photo.png"), contentDescription = null)
+          }
+        }
+      """,
+    )
+
+    Spacer(modifier = Modifier.height(12.dp))
+
+    Text(
+      text = "See the Mirage reference for the full preset gallery and how to author " +
+        "your own optic.",
+      style = DocsTheme.typography.bodySmall,
+      color = DocsTheme.colors.onSurfaceVariant,
     )
 
     Spacer(modifier = Modifier.height(48.dp))

--- a/docs/src/wasmJsMain/kotlin/docs/screen/HomeScreen.kt
+++ b/docs/src/wasmJsMain/kotlin/docs/screen/HomeScreen.kt
@@ -32,10 +32,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Android
+import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.BlurOn
 import androidx.compose.material.icons.filled.Code
-import androidx.compose.material.icons.filled.Gradient
+import androidx.compose.material.icons.filled.Lens
 import androidx.compose.material.icons.filled.PhoneIphone
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Rocket
@@ -106,7 +106,8 @@ private fun HeroSection(onNavigate: (DocsRoute) -> Unit) {
     Spacer(modifier = Modifier.height(8.dp))
 
     Text(
-      text = "Cross-platform blur effects for Compose Multiplatform",
+      text = "Cross-platform surface effects for Compose Multiplatform — blur, liquid " +
+        "glass, and shader-driven looks",
       style = DocsTheme.typography.body,
       color = DocsTheme.colors.onSurfaceVariant,
       textAlign = TextAlign.Center,
@@ -172,21 +173,23 @@ private fun FeaturesSection() {
 
       FeatureCard(
         icon = Icons.Default.BlurOn,
-        title = "Smooth & Seamless",
-        description = "Silky smooth blur animations with minimal overhead, " +
-          "seamlessly integrating into your Compose UI",
+        title = "Blur",
+        description = "Blur a composable's own content, or the content behind it " +
+          "for frosted-glass surfaces — with progressive fade and gyro-driven light",
       )
 
       FeatureCard(
-        icon = Icons.Default.Gradient,
-        title = "Progressive Blur",
-        description = "Create gradient blur effects with TopToBottom, BottomToTop, and Edges modes",
+        icon = Icons.Default.Lens,
+        title = "Liquid Glass",
+        description = "A realistic glass lens with SDF edges, normal-based refraction, " +
+          "and chromatic dispersion",
       )
 
       FeatureCard(
-        icon = Icons.Default.Android,
-        title = "Legacy Support",
-        description = "CPU-based blur for Android API 23-30 using native C++ SIMD optimizations",
+        icon = Icons.Default.AutoAwesome,
+        title = "Mirage",
+        description = "An open shader-effect plan — thin-film and specular presets, " +
+          "or author your own optic with no library change",
       )
 
       FeatureCard(
@@ -266,7 +269,7 @@ private fun QuickLinksSection(onNavigate: (DocsRoute) -> Unit) {
 
       QuickLinkCard(
         title = "Playground",
-        description = "Try blur effects live",
+        description = "Try every effect live",
         onClick = { onNavigate(DocsRoute.Playground) },
       )
     }

--- a/docs/src/wasmJsMain/kotlin/docs/screen/PlatformSupportScreen.kt
+++ b/docs/src/wasmJsMain/kotlin/docs/screen/PlatformSupportScreen.kt
@@ -56,8 +56,8 @@ fun PlatformSupportScreen() {
     Spacer(modifier = Modifier.height(16.dp))
 
     Text(
-      text = "Cloudy supports all Kotlin Multiplatform targets " +
-        "with platform-optimized implementations.",
+      text = "Cloudy's blur, Liquid Glass, and Mirage effects all support every Kotlin " +
+        "Multiplatform target, with platform-optimized implementations.",
       style = DocsTheme.typography.body,
       color = DocsTheme.colors.onSurfaceVariant,
     )
@@ -90,9 +90,12 @@ fun PlatformSupportScreen() {
       text = """
         Android uses different implementations based on API level:
 
-        • API 33+: AGSL RuntimeShader for progressive blur with custom shaders
-        • API 31-32: RenderEffect.createBlurEffect() for GPU-accelerated uniform blur
+        • API 31+: RenderEffect.createBlurEffect() for GPU-accelerated blur
         • API 23-30: Native C++ with NEON/SIMD optimizations for CPU-based blur
+
+        Progressive (gradient) blur, Liquid Glass's lens refraction, and Mirage all need one
+        API level higher — 33+ — since they run on AGSL RuntimeShader rather than
+        RenderEffect. See the Progressive Blur Support table below.
       """.trimIndent(),
       style = DocsTheme.typography.body,
       color = DocsTheme.colors.onSurfaceVariant,
@@ -119,6 +122,28 @@ fun PlatformSupportScreen() {
     Spacer(modifier = Modifier.height(16.dp))
 
     ProgressiveBlurTable()
+
+    Spacer(modifier = Modifier.height(32.dp))
+
+    // Liquid Glass & Mirage Support
+    Text(
+      text = "Liquid Glass & Mirage Support",
+      style = DocsTheme.typography.h2,
+      color = DocsTheme.colors.onBackground,
+    )
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    Text(
+      text = "Both effects run on a RuntimeShader, so they share the same Android floor as " +
+        "progressive blur: full effect at API 33+, with a shader-free fallback below it.",
+      style = DocsTheme.typography.body,
+      color = DocsTheme.colors.onSurfaceVariant,
+    )
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    ShaderEffectSupportTable()
 
     Spacer(modifier = Modifier.height(48.dp))
   }
@@ -147,8 +172,7 @@ private fun PlatformTable() {
     }
 
     // Rows
-    TableRow("Android 33+", "AGSL RuntimeShader")
-    TableRow("Android 31-32", "RenderEffect (GPU)")
+    TableRow("Android 31+", "RenderEffect (GPU)")
     TableRow("Android 23-30", "Native C++ (CPU)")
     TableRow("iOS", "Skia")
     TableRow("macOS", "Skia")
@@ -185,6 +209,55 @@ private fun ProgressiveBlurTable() {
     ProgressiveRow("Android 31-32", "Uniform only", "Falls back with warning")
     ProgressiveRow("Android 23-30", "Uniform only", "CPU blur limitation")
     ProgressiveRow("iOS/macOS/Desktop/WASM", "Full", "Skia shader support")
+  }
+}
+
+@Composable
+private fun ShaderEffectSupportTable() {
+  val shape = RoundedCornerShape(8.dp)
+
+  Column(
+    modifier = Modifier
+      .fillMaxWidth()
+      .clip(shape)
+      .border(1.dp, DocsTheme.colors.divider, shape),
+  ) {
+    // Header
+    Row(
+      modifier = Modifier
+        .fillMaxWidth()
+        .background(DocsTheme.colors.surfaceVariant)
+        .padding(12.dp),
+      horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+      TableCell("Platform", weight = 1f, isHeader = true)
+      TableCell("Liquid Glass", weight = 1f, isHeader = true)
+      TableCell("Mirage", weight = 1.5f, isHeader = true)
+    }
+
+    // Rows
+    ShaderEffectRow("Android 33+", "Full effect", "Full effect")
+    ShaderEffectRow(
+      "Android 23-32",
+      "Fallback (tint + edge, no refraction)",
+      "Content passes through unchanged",
+    )
+    ShaderEffectRow("iOS/macOS/Desktop/WASM", "Full effect", "Full effect")
+  }
+}
+
+@Composable
+private fun ShaderEffectRow(platform: String, liquidGlass: String, mirage: String) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .background(DocsTheme.colors.surface)
+      .padding(12.dp),
+    horizontalArrangement = Arrangement.SpaceBetween,
+  ) {
+    TableCell(platform, weight = 1f)
+    TableCell(liquidGlass, weight = 1f)
+    TableCell(mirage, weight = 1.5f)
   }
 }
 

--- a/docs/src/wasmJsMain/kotlin/docs/screen/PlaygroundScreen.kt
+++ b/docs/src/wasmJsMain/kotlin/docs/screen/PlaygroundScreen.kt
@@ -63,9 +63,12 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.skydoves.cloudy.CloudyProgressive
+import com.skydoves.cloudy.ExperimentalMirage
 import com.skydoves.cloudy.LiquidGlassDefaults
+import com.skydoves.cloudy.MirageOptics
 import com.skydoves.cloudy.cloudy
 import com.skydoves.cloudy.liquidGlass
+import com.skydoves.cloudy.mirage
 import com.skydoves.cloudy.rememberSky
 import com.skydoves.cloudy.sky
 import docs.component.CodeBlock
@@ -100,7 +103,7 @@ fun PlaygroundScreen() {
     Spacer(modifier = Modifier.height(16.dp))
 
     Text(
-      text = "Adjust parameters and see blur effects in real-time. " +
+      text = "Adjust parameters and see every surface effect in real-time. " +
         "The code snippet updates automatically.",
       style = DocsTheme.typography.body,
       color = DocsTheme.colors.onSurfaceVariant,
@@ -115,13 +118,18 @@ fun PlaygroundScreen() {
 
     Spacer(modifier = Modifier.height(48.dp))
 
+    // Background Blur Demo
+    BackgroundBlurDemo()
+
+    Spacer(modifier = Modifier.height(48.dp))
+
     // Liquid Glass Demo
     LiquidGlassDemo()
 
     Spacer(modifier = Modifier.height(48.dp))
 
-    // Background Blur Demo
-    // BackgroundBlurDemo()
+    // Mirage Demo
+    MirageDemo()
 
     Spacer(modifier = Modifier.height(48.dp))
   }
@@ -503,6 +511,205 @@ private fun LiquidGlassDemo() {
       }
 
       CodeBlock(code = liquidGlassCode)
+    }
+  }
+}
+
+private enum class MiragePresetOption(val displayName: String) {
+  Specular("Specular"),
+  Chromatic("Chromatic"),
+  OilSlick("OilSlick"),
+  SoapBubble("SoapBubble"),
+  MetallicFoil("MetallicFoil"),
+  Pearl("Pearl"),
+}
+
+@OptIn(ExperimentalMirage::class)
+@Composable
+private fun MirageDemo() {
+  var lensCenter by remember { mutableStateOf(Offset.Zero) }
+  var preset by remember { mutableStateOf(MiragePresetOption.Chromatic) }
+  var dropdownExpanded by remember { mutableStateOf(false) }
+  var enabled by remember { mutableStateOf(true) }
+
+  Card(
+    modifier = Modifier.fillMaxWidth(),
+    colors = CardDefaults.cardColors(containerColor = DocsTheme.colors.surface),
+    shape = RoundedCornerShape(16.dp),
+  ) {
+    Column(modifier = Modifier.padding(24.dp)) {
+      Text(
+        text = "Mirage (Modifier.mirage)",
+        style = DocsTheme.typography.h2,
+        color = DocsTheme.colors.onBackground,
+      )
+
+      Spacer(modifier = Modifier.height(8.dp))
+
+      Text(
+        text = "Drag on the preview to move the optic's lens. Experimental — behind " +
+          "@OptIn(ExperimentalMirage::class). Foil (an overlay) and Duotone (no lens) " +
+          "aren't lens-driven presets, so they're left out of this drag demo — see the " +
+          "Mirage reference for the full gallery.",
+        style = DocsTheme.typography.bodySmall,
+        color = DocsTheme.colors.onSurfaceVariant,
+      )
+
+      Spacer(modifier = Modifier.height(24.dp))
+
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(24.dp),
+      ) {
+        // Controls
+        Column(modifier = Modifier.weight(1f)) {
+          Text(
+            text = "Preset",
+            style = DocsTheme.typography.bodySmall,
+            color = DocsTheme.colors.onSurface,
+          )
+          Spacer(modifier = Modifier.height(4.dp))
+
+          Box {
+            OutlinedButton(onClick = { dropdownExpanded = true }) {
+              Text(preset.displayName)
+            }
+
+            DropdownMenu(
+              expanded = dropdownExpanded,
+              onDismissRequest = { dropdownExpanded = false },
+            ) {
+              MiragePresetOption.entries.forEach { option ->
+                DropdownMenuItem(
+                  text = { Text(option.displayName) },
+                  onClick = {
+                    preset = option
+                    dropdownExpanded = false
+                  },
+                )
+              }
+            }
+          }
+
+          Spacer(modifier = Modifier.height(16.dp))
+
+          // Enabled Toggle
+          Row(verticalAlignment = Alignment.CenterVertically) {
+            Checkbox(
+              checked = enabled,
+              onCheckedChange = { enabled = it },
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+              text = "Enabled",
+              style = DocsTheme.typography.bodySmall,
+              color = DocsTheme.colors.onSurface,
+            )
+          }
+        }
+
+        // Preview
+        Box(
+          modifier = Modifier
+            .size(200.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .border(1.dp, DocsTheme.colors.divider, RoundedCornerShape(12.dp))
+            .onSizeChanged { size ->
+              lensCenter = Offset(size.width / 2f, size.height / 2f)
+            }
+            .pointerInput(Unit) {
+              detectDragGestures { change, dragAmount ->
+                lensCenter += dragAmount
+                change.consume()
+              }
+            }
+            .mirage(enabled = enabled) {
+              // Each preset carries its own MirageLensParams subclass, so the filter() call
+              // (and its type-inferred params block) must be repeated per branch rather than
+              // hoisted behind a shared `val optic = when (...) { ... }`.
+              when (preset) {
+                MiragePresetOption.Specular -> filter(MirageOptics.Specular) {
+                  lensCenter(lensCenter)
+                  lensSize(Size(180f, 180f))
+                  cornerRadius(40f)
+                }
+
+                MiragePresetOption.Chromatic -> filter(MirageOptics.Chromatic) {
+                  lensCenter(lensCenter)
+                  lensSize(Size(180f, 180f))
+                  cornerRadius(40f)
+                }
+
+                MiragePresetOption.OilSlick -> filter(MirageOptics.OilSlick) {
+                  lensCenter(lensCenter)
+                  lensSize(Size(180f, 180f))
+                  cornerRadius(40f)
+                }
+
+                MiragePresetOption.SoapBubble -> filter(MirageOptics.SoapBubble) {
+                  lensCenter(lensCenter)
+                  lensSize(Size(180f, 180f))
+                  cornerRadius(40f)
+                }
+
+                MiragePresetOption.MetallicFoil -> filter(MirageOptics.MetallicFoil) {
+                  lensCenter(lensCenter)
+                  lensSize(Size(180f, 180f))
+                  cornerRadius(40f)
+                }
+
+                MiragePresetOption.Pearl -> filter(MirageOptics.Pearl) {
+                  lensCenter(lensCenter)
+                  lensSize(Size(180f, 180f))
+                  cornerRadius(40f)
+                }
+              }
+            },
+          contentAlignment = Alignment.Center,
+        ) {
+          GradientBackground()
+
+          Text(
+            text = if (enabled) "Drag to move lens" else "disabled",
+            style = DocsTheme.typography.caption,
+            color = Color.White,
+            fontWeight = FontWeight.Bold,
+          )
+        }
+      }
+
+      Spacer(modifier = Modifier.height(24.dp))
+
+      // Generated Code
+      Text(
+        text = "Generated Code",
+        style = DocsTheme.typography.bodySmall,
+        fontWeight = FontWeight.SemiBold,
+        color = DocsTheme.colors.onSurface,
+      )
+
+      Spacer(modifier = Modifier.height(8.dp))
+
+      val mirageCode = buildString {
+        append("@OptIn(ExperimentalMirage::class)\n")
+        append("Box(\n")
+        append("  modifier = Modifier.mirage {\n")
+        append("    filter(MirageOptics.${preset.displayName}) {\n")
+        append("      lensCenter(lensCenter)\n")
+        append("      lensSize(Size(180f, 180f))\n")
+        append("      cornerRadius(40f)\n")
+        append("    }\n")
+        if (!enabled) {
+          append("  }, enabled = false,\n")
+        } else {
+          append("  }\n")
+        }
+        append(") {\n")
+        append("  // Your content here\n")
+        append("}")
+      }
+
+      CodeBlock(code = mirageCode)
     }
   }
 }

--- a/docs/src/wasmJsMain/kotlin/docs/screen/PlaygroundScreen.kt
+++ b/docs/src/wasmJsMain/kotlin/docs/screen/PlaygroundScreen.kt
@@ -693,17 +693,17 @@ private fun MirageDemo() {
       val mirageCode = buildString {
         append("@OptIn(ExperimentalMirage::class)\n")
         append("Box(\n")
-        append("  modifier = Modifier.mirage {\n")
+        if (enabled) {
+          append("  modifier = Modifier.mirage {\n")
+        } else {
+          append("  modifier = Modifier.mirage(enabled = false) {\n")
+        }
         append("    filter(MirageOptics.${preset.displayName}) {\n")
         append("      lensCenter(lensCenter)\n")
         append("      lensSize(Size(180f, 180f))\n")
         append("      cornerRadius(40f)\n")
         append("    }\n")
-        if (!enabled) {
-          append("  }, enabled = false,\n")
-        } else {
-          append("  }\n")
-        }
+        append("  },\n")
         append(") {\n")
         append("  // Your content here\n")
         append("}")


### PR DESCRIPTION
### 🎯 Goal
The README grew feature-by-feature (self blur → backdrop blur → liquid glass → mirage) and ended up with four sections of nearly equal weight (109–152 lines each) but wildly different heading depth — only self blur got its own top-level sections, the other three were each flattened under one `##` with everything nested underneath. There was also no table of contents, so a reader who only wanted backdrop blur had to scroll past the self-blur usage docs first.

While reworking the structure, the "blur and liquid glass effect library" framing itself needed a look — Cloudy now ships four effects (blur, backdrop blur, liquid glass, mirage), so a blur-only tagline undersells Mirage and the general shader-effect plan. That framing gap turned out to run deeper in the docs site (skydoves.github.io/Cloudy/, built from `docs/`): Liquid Glass and Mirage were missing from the Home feature cards and Getting Started guide entirely, the Playground had no Mirage demo (and its finished `BackgroundBlurDemo()` was commented out), and several screens' Platform Support tables disagreed with each other and with the README on Android API-level breakpoints. This PR reorganizes the README and closes those gaps in the docs site.

### 🛠 Implementation details
**README**
- Added a top-of-file effect summary table and a table of contents.
- Split into **Part I — Effects** (Self blur, Backdrop blur, Liquid Glass, Mirage), each sharing the same five-slot template: Basic Usage → feature-specific steps → Customization/Parameters → Platform Support.
- Split off **Part II — Going further**: Motion-driven light sources (extends Liquid Glass), Authoring your own Mirage optic (extends Mirage), and Blur effect with network images (extends Self blur).
- Reframed the hero tagline and intro blockquote around "surface effects" rather than blur-only, since Mirage and Liquid Glass are peer effects, not blur variants.
- Verified code fence count is unchanged (44) and all in-doc anchor links resolve under GitHub's heading→anchor rules.

**Docs site (`docs/`, a Kotlin/Wasm Compose app)**
- Reordered `DocsRoute.apiRoutes` and renamed the Backdrop Blur screen/route to mirror the README's effect ordering and naming.
- Home's hero tagline and feature cards, and Getting Started's intro and Basic Usage flow, now cover all four effects instead of blur alone.
- Verified the Android API-level breakpoints against the actual `SDK_INT` branches in `cloudy/src/androidMain` (`Cloudy.android.kt`, `LiquidGlass.android.kt`, `MirageBackendProgram.android.kt`, etc.) and fixed two screens (`ApiCloudyScreen`, `PlatformSupportScreen`) that split self blur into a spurious "33+/31-32/23-30" three-way table — the code only branches on API 31 for that path. Added a Liquid Glass & Mirage support table (both gate on API 33, the real RuntimeShader floor).
- Playground: re-enabled the already-implemented `BackgroundBlurDemo()` (previously commented out) and added an interactive Mirage demo (preset picker + draggable lens) alongside the existing blur and Liquid Glass demos.
- `./gradlew :docs:compileKotlinWasmJs` and `:docs:spotlessCheck` both pass.

This PR doesn't touch the `cloudy` library module's public API, so `apiDump` doesn't apply.

### ✍️ Explain examples
The Mirage playground demo applies a `MirageOptics` preset (Specular or one of the five thin-film looks) to a draggable lens the same way the existing Liquid Glass demo does, with the generated `Modifier.mirage { filter(...) { ... } }` snippet shown live below it. Foil (an overlay-only preset) and Duotone (no lens) are left out of this particular demo since they don't share the lens-drag interaction — that's called out in the on-screen copy, with a pointer to the full Mirage reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refreshed the README to clearly present the full four-effect suite (blur, backdrop blur, liquid glass, mirage) with reorganized structure, improved navigation, and updated section content (including liquid glass controls and Mirage flow).
  * Updated API and screen labels (e.g., “Backdrop Blur”) plus reordered docs route presentation for consistency.
  * Improved platform support messaging and Android API coverage tables for blur, liquid glass, and mirage.
  * Revised “Getting Started,” Home, Platform Support, and Playground copy, including a new interactive Mirage demo with presets and lens controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->