### PR TITLE
feat: add Modifier.mirage(sky) to grade the Sky backdrop

### DIFF
--- a/app/src/commonMain/kotlin/demo/Main.kt
+++ b/app/src/commonMain/kotlin/demo/Main.kt
@@ -34,6 +34,7 @@ import demo.screen.Issue112BottomNavScreen
 import demo.screen.LiquidGlassDemoScreen
 import demo.screen.MenuHomeScreen
 import demo.screen.MirageScreen
+import demo.screen.MirageSkyScreen
 import demo.screen.ProgressiveBlurDemoScreen
 import demo.screen.RadiusDetailScreen
 import demo.screen.RadiusItemsScreen
@@ -69,6 +70,7 @@ fun CloudyDemoApp() {
               onTransformLightClick = { backStack.add(Route.TransformLight) },
               onBlurLightClick = { backStack.add(Route.BlurLight) },
               onMirageClick = { backStack.add(Route.Mirage) },
+              onMirageSkyClick = { backStack.add(Route.MirageSky) },
             )
           }
 
@@ -142,6 +144,12 @@ fun CloudyDemoApp() {
 
           is Route.Mirage -> NavEntry(route) {
             MirageScreen(
+              onBackClick = { backStack.removeLastOrNull() },
+            )
+          }
+
+          is Route.MirageSky -> NavEntry(route) {
+            MirageSkyScreen(
               onBackClick = { backStack.removeLastOrNull() },
             )
           }

--- a/app/src/commonMain/kotlin/demo/Route.kt
+++ b/app/src/commonMain/kotlin/demo/Route.kt
@@ -107,4 +107,11 @@ sealed interface Route {
    */
   @Serializable
   data object Mirage : Route
+
+  /**
+   * The backdrop mirage test screen — a card grades the `Sky` backdrop behind it via
+   * `Modifier.mirage(sky = …) { filter(…) }`, the mirage counterpart of `Modifier.cloudy(sky)`.
+   */
+  @Serializable
+  data object MirageSky : Route
 }

--- a/app/src/commonMain/kotlin/demo/screen/MenuHomeScreen.kt
+++ b/app/src/commonMain/kotlin/demo/screen/MenuHomeScreen.kt
@@ -60,6 +60,7 @@ fun MenuHomeScreen(
   onTransformLightClick: () -> Unit,
   onBlurLightClick: () -> Unit,
   onMirageClick: () -> Unit,
+  onMirageSkyClick: () -> Unit,
 ) {
   val posters = remember { MockUtil.getMockPosters() }
 
@@ -156,6 +157,14 @@ fun MenuHomeScreen(
             description = "Apply an open optic plan in one modifier block — specular vs chromatic",
             poster = posters[5],
             onClick = onMirageClick,
+          )
+        }
+        item {
+          MenuCard(
+            title = "Mirage Backdrop",
+            description = "Grade the sky backdrop behind a card — a duotone material over a list",
+            poster = posters[6],
+            onClick = onMirageSkyClick,
           )
         }
       }

--- a/app/src/commonMain/kotlin/demo/screen/MirageSkyScreen.kt
+++ b/app/src/commonMain/kotlin/demo/screen/MirageSkyScreen.kt
@@ -1,0 +1,322 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(com.skydoves.cloudy.ExperimentalMirage::class)
+
+package demo.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.skydoves.cloudy.MirageOptics
+import com.skydoves.cloudy.MirageScope
+import com.skydoves.cloudy.mirage
+import com.skydoves.cloudy.rememberSky
+import com.skydoves.cloudy.sky
+import demo.component.CollapsingAppBarScaffold
+import demo.component.MaxWidthContainer
+import demo.theme.Dimens
+
+/**
+ * Demonstrates `Modifier.mirage(sky = ...)`: a card grades the `Sky` backdrop behind it instead of its
+ * own content — the backdrop counterpart of `Modifier.cloudy(sky = ...)`'s blur. The container carries
+ * `Modifier.sky`, a high-contrast list scrolls behind the card, and the card samples that region and
+ * runs the picked optic over it.
+ *
+ * The headline look is [MirageOptics.Duotone], a colorize "material" rendered from the backdrop; the
+ * chips also switch to the content-sampling looks ([MirageOptics.Chromatic] / [MirageOptics.Specular])
+ * to show the same overload carries any filter optic. The Enabled toggle bypasses the plan so the raw
+ * backdrop region shows through, making the grade easy to compare.
+ *
+ * Backdrop capture needs a real GPU (Android 13+ for the runtime shader), so this renders on a device
+ * or emulator, not the Robolectric host.
+ *
+ * @param onBackClick Callback when the back button is pressed.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun MirageSkyScreen(onBackClick: () -> Unit) {
+  val sky = rememberSky()
+  val listState = rememberLazyListState()
+
+  var pick: BackdropPick by remember { mutableStateOf(BackdropPick.Duotone) }
+  var effectEnabled by remember { mutableStateOf(true) }
+  var duotone: DuotonePreset by remember { mutableStateOf(DuotonePreset.Indigo) }
+  var amount by remember { mutableStateOf(1f) }
+
+  val toneShadow = duotone.shadow
+  val toneHighlight = duotone.highlight
+  val toneAmount = amount
+
+  CollapsingAppBarScaffold(
+    title = "Mirage (sky backdrop)",
+    onBackClick = onBackClick,
+  ) { paddingValues, _ ->
+    MaxWidthContainer(modifier = Modifier.padding(paddingValues)) {
+      Column(modifier = Modifier.fillMaxSize().padding(Dimens.contentPadding)) {
+        // Stage: the sky backdrop (a scrolling, high-contrast list) with the graded card floating over
+        // it. Fixed height so it never overlaps the controls below — the card's region is always clear.
+        Box(modifier = Modifier.fillMaxWidth().weight(1f)) {
+          LazyColumn(
+            state = listState,
+            modifier = Modifier.fillMaxSize().sky(sky),
+            verticalArrangement = Arrangement.spacedBy(Dimens.itemSpacing),
+          ) {
+            items(BACKDROP_ITEM_COUNT, key = { it }) { index -> BackdropRow(index) }
+          }
+
+          // The card samples the backdrop region directly behind it and runs the picked optic over it.
+          // A visible border marks the graded region against the raw backdrop around it; the label names
+          // the recipe. Transparent fill so only the graded backdrop shows through.
+          Box(
+            modifier = Modifier
+              .align(Alignment.Center)
+              .fillMaxWidth()
+              .height(180.dp)
+              .clip(RoundedCornerShape(Dimens.cardCornerRadius))
+              .mirage(sky = sky, enabled = effectEnabled) {
+                with(pick) { declare(toneShadow, toneHighlight, toneAmount) }
+              }
+              .border(
+                width = 2.dp,
+                color = Color.White,
+                shape = RoundedCornerShape(Dimens.cardCornerRadius),
+              ),
+            contentAlignment = Alignment.TopStart,
+          ) {
+            Text(
+              text = if (effectEnabled) "mirage(sky) { filter(${pick.label}) }" else "effect off",
+              modifier = Modifier.padding(12.dp),
+              color = Color.White,
+              fontSize = 13.sp,
+              fontWeight = FontWeight.Bold,
+            )
+          }
+        }
+
+        Spacer(modifier = Modifier.height(Dimens.contentPadding))
+
+        ControlsCard(
+          modifier = Modifier,
+          pick = pick,
+          onPick = { pick = it },
+          effectEnabled = effectEnabled,
+          onEffectEnabledChange = { effectEnabled = it },
+          duotone = duotone,
+          onDuotoneChange = { duotone = it },
+          amount = amount,
+          onAmountChange = { amount = it },
+        )
+      }
+    }
+  }
+}
+
+private const val BACKDROP_ITEM_COUNT = 40
+
+/**
+ * A backdrop look the card can apply. Each keeps a typed optic so its `declare` sets that optic's own
+ * uniforms with no cast, mirroring the self-content [MirageScreen]'s pick model.
+ */
+private sealed interface BackdropPick {
+  val label: String
+
+  /** Declares this pick's filter stage into the plan; only [Duotone] reads the tone/amount controls. */
+  fun MirageScope.declare(shadow: Color, highlight: Color, amount: Float)
+
+  /** The headline colorize material: maps backdrop luminance onto a shadow -> highlight duotone. */
+  data object Duotone : BackdropPick {
+    override val label = "Duotone"
+    override fun MirageScope.declare(shadow: Color, highlight: Color, amount: Float) {
+      filter(MirageOptics.Duotone) {
+        shadow(shadow)
+        highlight(highlight)
+        amount(amount)
+      }
+    }
+  }
+
+  /** A content-sampling thin-film look, proving the overload carries any filter optic over a backdrop. */
+  data object Chromatic : BackdropPick {
+    override val label = "Chromatic"
+    override fun MirageScope.declare(shadow: Color, highlight: Color, amount: Float) {
+      filter(MirageOptics.Chromatic)
+    }
+  }
+
+  /** The liquid-glass specular glint, also content-sampling, over the backdrop. */
+  data object Specular : BackdropPick {
+    override val label = "Specular"
+    override fun MirageScope.declare(shadow: Color, highlight: Color, amount: Float) {
+      filter(MirageOptics.Specular)
+    }
+  }
+}
+
+private val BACKDROP_PICKS =
+  listOf(BackdropPick.Duotone, BackdropPick.Chromatic, BackdropPick.Specular)
+
+/** Duotone grade presets — the shadow/highlight endpoints the luminance ramp maps between. */
+private enum class DuotonePreset(val label: String, val shadow: Color, val highlight: Color) {
+  Indigo("Indigo / Cream", Color(0xFF1B1B3A), Color(0xFFFFE8C7)),
+  Teal("Teal / Sand", Color(0xFF06373B), Color(0xFFF2E2B6)),
+  Plum("Plum / Blush", Color(0xFF2E1030), Color(0xFFF7D6E0)),
+}
+
+@Composable
+private fun ControlsCard(
+  modifier: Modifier,
+  pick: BackdropPick,
+  onPick: (BackdropPick) -> Unit,
+  effectEnabled: Boolean,
+  onEffectEnabledChange: (Boolean) -> Unit,
+  duotone: DuotonePreset,
+  onDuotoneChange: (DuotonePreset) -> Unit,
+  amount: Float,
+  onAmountChange: (Float) -> Unit,
+) {
+  Card(
+    modifier = modifier.fillMaxWidth(),
+    elevation = CardDefaults.cardElevation(defaultElevation = Dimens.cardElevation),
+    shape = RoundedCornerShape(Dimens.cardCornerRadius),
+    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+  ) {
+    Column(modifier = Modifier.padding(Dimens.contentPadding)) {
+      Text(
+        text = "Modifier.mirage(sky) { filter(${pick.label}) } grades the list behind the card.",
+        fontSize = 13.sp,
+        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+        textAlign = TextAlign.Center,
+        modifier = Modifier.fillMaxWidth(),
+      )
+      Spacer(modifier = Modifier.height(12.dp))
+
+      SectionLabel("Optic")
+      FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        BACKDROP_PICKS.forEach { entry ->
+          FilterChip(
+            selected = pick == entry,
+            onClick = { onPick(entry) },
+            label = { Text(entry.label) },
+          )
+        }
+      }
+
+      if (pick == BackdropPick.Duotone) {
+        Spacer(modifier = Modifier.height(12.dp))
+        SectionLabel("Tone")
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+          DuotonePreset.entries.forEach { preset ->
+            FilterChip(
+              selected = duotone == preset,
+              onClick = { onDuotoneChange(preset) },
+              label = { Text(preset.label) },
+            )
+          }
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+        SectionLabel("Amount")
+        Slider(value = amount, onValueChange = onAmountChange, valueRange = 0f..1f)
+      }
+
+      Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Text(
+          text = "Effect enabled",
+          modifier = Modifier.weight(1f),
+          fontSize = 15.sp,
+          color = MaterialTheme.colorScheme.onSurface,
+        )
+        Switch(checked = effectEnabled, onCheckedChange = onEffectEnabledChange)
+      }
+    }
+  }
+}
+
+@Composable
+private fun SectionLabel(text: String) {
+  Text(
+    text = text,
+    fontSize = 13.sp,
+    fontWeight = FontWeight.Bold,
+    color = MaterialTheme.colorScheme.onSurface,
+  )
+}
+
+@Composable
+private fun BackdropRow(index: Int) {
+  // Alternating high-contrast bands give the grade an obvious luminance range to remap.
+  val colors = remember {
+    listOf(
+      Color(0xFF1565C0),
+      Color(0xFFC62828),
+      Color(0xFF2E7D32),
+      Color(0xFF6A1B9A),
+      Color(0xFFEF6C00),
+    )
+  }
+  Box(
+    modifier = Modifier
+      .fillMaxWidth()
+      .height(64.dp)
+      .clip(RoundedCornerShape(12.dp))
+      .background(colors[index % colors.size]),
+    contentAlignment = Alignment.CenterStart,
+  ) {
+    Text(
+      text = "Item #$index",
+      modifier = Modifier.padding(start = 16.dp),
+      color = Color.White,
+      fontSize = 16.sp,
+      fontWeight = FontWeight.SemiBold,
+    )
+  }
+}

--- a/cloudy/src/androidHostTest/kotlin/com/skydoves/cloudy/MirageFilterChainTest.kt
+++ b/cloudy/src/androidHostTest/kotlin/com/skydoves/cloudy/MirageFilterChainTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalMirage::class)
+
+package com.skydoves.cloudy
+
+import androidx.compose.ui.graphics.GraphicsContext
+import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import com.skydoves.cloudy.internal.MirageFilterChain
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Host-side unit tests for [MirageFilterChain]'s source-injection contract — the seam that makes the
+ * chain reusable between the self-content [com.skydoves.cloudy.internal.MirageNode] and the backdrop
+ * [com.skydoves.cloudy.internal.MirageBackdropNode].
+ *
+ * The empty-applicable path is the cleanly testable slice: it draws the caller's `recordSource`
+ * straight to the screen and never touches a real GPU layer, so it runs on the Robolectric host with a
+ * `ContentDrawScope` that delegates to a bare [CanvasDrawScope] (no canvas is needed — the path invokes
+ * only the injected `recordSource` lambda, not any draw primitive). The populated-chain draw records
+ * into real [GraphicsLayer]s and is covered by the platform screenshot/instrumented specs.
+ */
+@RunWith(RobolectricTestRunner::class)
+internal class MirageFilterChainTest {
+
+  @Test
+  fun `empty applicable runs recordSource and never binds`() {
+    val chain = MirageFilterChain()
+    var recorded = false
+    var bound = false
+
+    with(chain) {
+      fakeContentDrawScope().draw(
+        context = throwingGraphicsContext(),
+        applicable = emptyList(),
+        bind = { _, _ -> bound = true },
+        recordSource = { recorded = true },
+      )
+    }
+
+    assertTrue("empty applicable must draw the source directly", recorded)
+    assertFalse("empty applicable must not bind any stage program", bound)
+  }
+
+  @Test
+  fun `empty applicable draws the source without allocating a layer`() {
+    // The empty path must not reach the graphics context (no pooled layer to create), so a context
+    // that throws on any use proves the fallback is allocation-free — the API < 33 "raw region" case.
+    val chain = MirageFilterChain()
+
+    with(chain) {
+      fakeContentDrawScope().draw(
+        context = throwingGraphicsContext(),
+        applicable = emptyList(),
+        bind = { _, _ -> error("bind must not run for an empty plan") },
+        recordSource = { /* no-op source */ },
+      )
+    }
+    // Reaching here (no throw from the context stub) is the assertion.
+  }
+
+  @Test
+  fun `release on an untouched chain is a no-op`() {
+    // A chain that never drew has no pooled layers, so release must not call into the context.
+    MirageFilterChain().release(throwingGraphicsContext())
+  }
+
+  /**
+   * A [ContentDrawScope] for the empty-applicable path: delegates the [androidx.compose.ui.graphics.
+   * drawscope.DrawScope] surface to a bare [CanvasDrawScope] and stubs [drawContent]. The tested path
+   * invokes only the injected `recordSource` lambda, so no delegated draw primitive is exercised.
+   */
+  private fun fakeContentDrawScope(): ContentDrawScope =
+    object : ContentDrawScope, DrawScope by CanvasDrawScope() {
+      override fun drawContent() = Unit
+    }
+
+  /** A [GraphicsContext] that fails if the empty path ever tries to create or release a layer. */
+  private fun throwingGraphicsContext(): GraphicsContext = object : GraphicsContext {
+    override fun createGraphicsLayer(): GraphicsLayer =
+      error("empty-applicable draw must not create a graphics layer")
+
+    override fun releaseGraphicsLayer(layer: GraphicsLayer) =
+      error("empty-applicable draw must not release a graphics layer")
+  }
+}

--- a/cloudy/src/androidHostTest/kotlin/com/skydoves/cloudy/MiragePlanModifierTest.kt
+++ b/cloudy/src/androidHostTest/kotlin/com/skydoves/cloudy/MiragePlanModifierTest.kt
@@ -20,6 +20,7 @@ package com.skydoves.cloudy
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.node.ModifierNodeElement
+import com.skydoves.cloudy.internal.MirageBackdropElement
 import com.skydoves.cloudy.internal.MirageElement
 import com.skydoves.cloudy.internal.MiragePlanBuilder
 import com.skydoves.cloudy.internal.Stage
@@ -125,8 +126,63 @@ internal class MiragePlanModifierTest {
     assertNotEquals(auto, fixed)
   }
 
+  @Test
+  fun `mirage with sky attaches a MirageBackdropElement`() {
+    val sky = Sky()
+    val modifier = Modifier.mirage(sky = sky) { filter(tintFilter) }
+    assertTrue(
+      "Modifier.mirage(sky) should attach a MirageBackdropElement",
+      modifier.firstElementOrNull() is MirageBackdropElement,
+    )
+  }
+
+  @Test
+  fun `backdrop elements with the same sky and plan and shared block are equal`() {
+    val sky = Sky()
+    val block: MirageParams.() -> Unit = { }
+    val a = backdropElementOf(Modifier.mirage(sky = sky) { filter(tintFilter, block) })
+    val b = backdropElementOf(Modifier.mirage(sky = sky) { filter(tintFilter, block) })
+    assertEquals(a, b)
+    assertEquals(a.hashCode(), b.hashCode())
+  }
+
+  @Test
+  fun `backdrop elements with different sky instances are unequal`() {
+    // Sky is part of the reconciliation key: a different backdrop must re-create the node's plumbing.
+    val block: MirageParams.() -> Unit = { }
+    val a = backdropElementOf(Modifier.mirage(sky = Sky()) { filter(tintFilter, block) })
+    val b = backdropElementOf(Modifier.mirage(sky = Sky()) { filter(tintFilter, block) })
+    assertNotEquals(a, b)
+  }
+
+  @Test
+  fun `re-creating the params block makes an otherwise-identical backdrop element unequal`() {
+    // Two distinct lambda instances (as a recomposition produces) over the same sky + optic: unequal,
+    // so Compose runs update() and the node adopts the fresh block (no frozen uniforms).
+    val sky = Sky()
+    val a = backdropElementOf(Modifier.mirage(sky = sky) { filter(tintFilter) { } })
+    val b = backdropElementOf(Modifier.mirage(sky = sky) { filter(tintFilter) { } })
+    assertNotEquals(a, b)
+  }
+
+  @Test
+  fun `a shared params block keeps its identity through the backdrop plan`() {
+    // The plan captures the exact block instance the caller passed (=== preserved), so an unchanged
+    // block reconciles equal rather than forcing a needless update.
+    val sky = Sky()
+    val block: MirageParams.() -> Unit = { }
+    val stages = MiragePlanBuilder().apply { filter(tintFilter, block) }.stages
+    assertTrue(
+      "the plan must keep the caller's exact block instance",
+      stages[0].paramsBlock === block,
+    )
+  }
+
   private fun elementOf(modifier: Modifier): MirageElement =
     modifier.firstElementOrNull() as MirageElement
+
+  private fun backdropElementOf(modifier: Modifier): MirageBackdropElement =
+    modifier.firstElementOrNull() as MirageBackdropElement
 
   /** foldIn returns the first ModifierNodeElement in the chain (there is exactly one here). */
   private fun Modifier.firstElementOrNull(): ModifierNodeElement<*>? =

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/MirageModifier.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/MirageModifier.kt
@@ -17,6 +17,7 @@ package com.skydoves.cloudy
 
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.BlendMode
+import com.skydoves.cloudy.internal.MirageBackdropElement
 
 /**
  * Time-driving policy for the standard `mirageTime` uniform. Plan-level — the plan (not each stage)
@@ -115,3 +116,39 @@ public expect fun Modifier.mirage(
   enabled: Boolean = true,
   plan: MirageScope.() -> Unit,
 ): Modifier
+
+/**
+ * Applies a mirage effect [plan] to the [sky] **backdrop** behind the modified node, instead of to the
+ * node's own content. Use it to grade, tint, or overlay the captured background — e.g.
+ * `Modifier.mirage(sky = sky) { filter(MirageOptics.Duotone) }` renders a duotone "material" from the
+ * backdrop, the mirage counterpart of `Modifier.cloudy(sky = sky)`'s blur.
+ *
+ * The node samples the region of [sky]'s captured backdrop directly behind it (tracked via its layout
+ * position, like [Modifier.cloudy]), feeds those pixels through the plan's filter stages, and draws the
+ * result. The modified node's own content is drawn on top, so this is typically applied to an otherwise
+ * empty surface.
+ *
+ * Backdrop capture requires a `Modifier.sky(sky)` ancestor to record the background. While that
+ * backdrop scrolls, the effect refreshes automatically. Single commonMain implementation: the same
+ * node runs on Android (AGSL) and every skiko target (SKSL). Below API 33 (no `RuntimeShader`) the
+ * filters are skipped and the raw backdrop region is drawn, mirroring the radius-0 backdrop blur.
+ *
+ * This is a distinct overload from the content [mirage] above: `mirage { … }` filters the content,
+ * `mirage(sky = …) { … }` filters the backdrop. Otherwise it behaves identically — [plan] is evaluated
+ * once to fix the stages, each stage's `params` block is re-evaluated per draw (no recomposition), and
+ * programs are shared through the same process-wide cache.
+ *
+ * @param sky the backdrop state holder captured by a `Modifier.sky` ancestor; the source of the pixels
+ *   the plan grades. Identity-stable via `rememberSky`, so it participates in the node's key cheaply.
+ * @param clock time-driving policy for the standard `mirageTime` uniform. Default: [MirageClock.Auto].
+ * @param enabled when `false`, the plan is bypassed and the node's content passes through unmodified.
+ * @param plan the stage declaration block; see [MirageScope].
+ * @return a [Modifier] that applies the plan to the [sky] backdrop.
+ */
+@ExperimentalMirage
+public fun Modifier.mirage(
+  sky: Sky,
+  clock: MirageClock = MirageClock.Auto,
+  enabled: Boolean = true,
+  plan: MirageScope.() -> Unit,
+): Modifier = this.then(MirageBackdropElement(sky, clock, enabled, plan))

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/internal/MirageBackdropElement.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/internal/MirageBackdropElement.kt
@@ -1,0 +1,83 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalMirage::class)
+
+package com.skydoves.cloudy.internal
+
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.platform.InspectorInfo
+import com.skydoves.cloudy.ExperimentalMirage
+import com.skydoves.cloudy.MirageClock
+import com.skydoves.cloudy.MirageScope
+import com.skydoves.cloudy.Sky
+
+/**
+ * Element that reconciles a [MirageBackdropNode]. Equatable on [sky], [clock], [enabled], the plan's
+ * ordered stage optics + blend modes, **and** the per-stage params-block identities — the same key as
+ * [MirageElement] plus [sky]. [sky] is identity-stable across recompositions (`rememberSky` holds it in
+ * a `remember`), so including it keeps the cheap blocks-only [MirageBackdropNode.update] path. The
+ * blocks are compared by reference so a recomposition that re-creates them (e.g. an animated uniform)
+ * is unequal and [update] runs to adopt them.
+ */
+@OptIn(ExperimentalMirage::class)
+internal class MirageBackdropElement(
+  private val sky: Sky,
+  private val clock: MirageClock,
+  private val enabled: Boolean,
+  private val plan: MirageScope.() -> Unit,
+) : ModifierNodeElement<MirageBackdropNode>() {
+
+  /** Build the stage list eagerly so create()/equals share one evaluation of the plan. */
+  private val stages: List<Stage> = MiragePlanBuilder().apply(plan).stages
+
+  override fun create(): MirageBackdropNode = MirageBackdropNode(sky, clock, enabled, stages)
+
+  override fun update(node: MirageBackdropNode) {
+    node.update(sky, clock, enabled, stages)
+  }
+
+  override fun InspectorInfo.inspectableProperties() {
+    name = "mirage"
+    properties["sky"] = sky
+    properties["clock"] = clock
+    properties["enabled"] = enabled
+    properties["stages"] = stages.map { it.optic.name }
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is MirageBackdropElement) return false
+    if (sky != other.sky) return false
+    if (clock != other.clock || enabled != other.enabled) return false
+    if (!sameStructure(stages, other.stages)) return false
+    for (i in stages.indices) {
+      if (stages[i].paramsBlock !== other.stages[i].paramsBlock) return false
+    }
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = sky.hashCode()
+    result = 31 * result + clock.hashCode()
+    result = 31 * result + enabled.hashCode()
+    for (stage in stages) {
+      result = 31 * result + stage.optic.hashCode()
+      if (stage is Stage.Overlay) result = 31 * result + stage.blendMode.hashCode()
+      result = 31 * result + (stage.paramsBlock?.hashCode() ?: 0)
+    }
+    return result
+  }
+}

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/internal/MirageBackdropNode.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/internal/MirageBackdropNode.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.platform.LocalDensity
 import com.skydoves.cloudy.ExperimentalMirage
 import com.skydoves.cloudy.MirageClock
 import com.skydoves.cloudy.Sky
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
@@ -72,6 +73,10 @@ internal class MirageBackdropNode(
   private var timeSeconds: Float = 0f
   private var startNanos: Long = -1L
   private var planUsesTime: Boolean = false
+
+  // The running Auto-clock frame loop, if any. Cancelled before a re-warm launches a new one so a
+  // structural update never leaves two loops advancing timeSeconds and invalidating in parallel.
+  private var frameLoopJob: Job? = null
 
   // Stable re-blur invalidator (a field, not a fresh lambda) so the frame driver can identity-match it
   // in addOverlay/removeOverlay — a new lambda each attach would never unregister.
@@ -113,7 +118,13 @@ internal class MirageBackdropNode(
   }
 
   override fun onGloballyPositioned(coordinates: LayoutCoordinates) {
-    positionInRoot = coordinates.positionInRoot()
+    val newPosition = coordinates.positionInRoot()
+    if (newPosition != positionInRoot) {
+      // The backdrop sample offset is derived from this position, so a move must redraw or the node
+      // keeps sampling the region it used to sit over.
+      positionInRoot = newPosition
+      if (isAttached) invalidateDraw()
+    }
   }
 
   /**
@@ -130,7 +141,10 @@ internal class MirageBackdropNode(
     planUsesTime = usesTime
     startNanos = -1L
 
-    if (clock is MirageClock.Auto && usesTime) {
+    // Cancel a prior loop before starting a new one: a re-warm on structural update would otherwise
+    // stack loops that all advance timeSeconds and invalidate.
+    frameLoopJob?.cancel()
+    frameLoopJob = if (clock is MirageClock.Auto && usesTime) {
       coroutineScope.launch {
         while (isActive) {
           withFrameNanos { now ->
@@ -140,6 +154,8 @@ internal class MirageBackdropNode(
           }
         }
       }
+    } else {
+      null
     }
   }
 
@@ -239,6 +255,9 @@ internal class MirageBackdropNode(
 
   override fun onDetach() {
     sky.frameDriver.removeOverlay(reblur)
+    // coroutineScope is cancelled on detach anyway; null the handle so a re-attach starts clean.
+    frameLoopJob?.cancel()
+    frameLoopJob = null
     chain.release(requireGraphicsContext())
   }
 }

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/internal/MirageBackdropNode.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/internal/MirageBackdropNode.kt
@@ -1,0 +1,244 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalMirage::class)
+
+package com.skydoves.cloudy.internal
+
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
+import androidx.compose.ui.node.DrawModifierNode
+import androidx.compose.ui.node.GlobalPositionAwareModifierNode
+import androidx.compose.ui.node.currentValueOf
+import androidx.compose.ui.node.invalidateDraw
+import androidx.compose.ui.node.requireGraphicsContext
+import androidx.compose.ui.platform.LocalDensity
+import com.skydoves.cloudy.ExperimentalMirage
+import com.skydoves.cloudy.MirageClock
+import com.skydoves.cloudy.Sky
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/**
+ * Runs a mirage plan against a [Sky] **backdrop** instead of the node's own content: the sibling of
+ * [MirageNode] that records the offset Sky region into stage 0 (via [MirageFilterChain]) so a colorize
+ * optic grades the backdrop rather than the content. It is a separate node because a backdrop is
+ * positioned relative to the Sky and refreshed as the Sky scrolls, so it carries positioning and the
+ * frame-driver lifecycle that a pure self-content node has no reason to.
+ *
+ * A backdrop node is a descendant of the Sky recorder, so the capture pass re-enters its draw. Drawing
+ * a backdrop-sampling effect into the layer being recorded would form a cyclic `RenderNode` graph that
+ * overflows the render thread (https://github.com/skydoves/Cloudy/issues/112), so [draw] returns on its
+ * first line while [Sky.isCapturing].
+ */
+@OptIn(ExperimentalMirage::class)
+internal class MirageBackdropNode(
+  var sky: Sky,
+  var clock: MirageClock,
+  var enabled: Boolean,
+  stages: List<Stage>,
+) : Modifier.Node(),
+  DrawModifierNode,
+  GlobalPositionAwareModifierNode,
+  CompositionLocalConsumerModifierNode {
+
+  var stages: List<Stage> = stages
+    private set
+
+  private var positionInRoot: Offset = Offset.Zero
+
+  private val chain = MirageFilterChain()
+
+  // Same clock machinery as MirageNode: this small duplication is deliberate (the clock is a node
+  // concern, not a chain concern, and forcing it into the shared chain would drag lifecycle in).
+  private var timeSeconds: Float = 0f
+  private var startNanos: Long = -1L
+  private var planUsesTime: Boolean = false
+
+  // Stable re-blur invalidator (a field, not a fresh lambda) so the frame driver can identity-match it
+  // in addOverlay/removeOverlay — a new lambda each attach would never unregister.
+  private val reblur: () -> Unit = { if (isAttached) invalidateDraw() }
+
+  fun update(sky: Sky, clock: MirageClock, enabled: Boolean, stages: List<Stage>) {
+    // Re-register the scroll-refresh overlay on the new sky before adopting it, mirroring the cloudy
+    // backdrop node: a sky swap must move the frame-driver registration or the old sky keeps pumping
+    // this node while the new one never does.
+    if (this.sky != sky && isAttached) {
+      this.sky.frameDriver.removeOverlay(reblur)
+      sky.frameDriver.addOverlay(reblur)
+    }
+
+    val structuralChange = sky != this.sky || clock != this.clock || enabled != this.enabled ||
+      !sameStructure(this.stages, stages)
+
+    this.sky = sky
+    this.clock = clock
+    this.enabled = enabled
+    this.stages = stages
+
+    if (!structuralChange) {
+      // Blocks-only change: the layers still match the (unchanged) filter count, so keep them.
+      if (isAttached) invalidateDraw()
+      return
+    }
+
+    if (isAttached) {
+      chain.release(requireGraphicsContext())
+      warmAndSchedule()
+      invalidateDraw()
+    }
+  }
+
+  override fun onAttach() {
+    warmAndSchedule()
+    sky.frameDriver.addOverlay(reblur)
+  }
+
+  override fun onGloballyPositioned(coordinates: LayoutCoordinates) {
+    positionInRoot = coordinates.positionInRoot()
+  }
+
+  /**
+   * Warm the cache for every stage (so usesTime is known and the draw loop enters with programs
+   * ready), then start the frame loop when the clock is Auto and some stage is time-driven.
+   */
+  private fun warmAndSchedule() {
+    val dialect = currentDialect()
+    var usesTime = false
+    for (stage in stages) {
+      val cached = MirageProgramCache.obtain(stage.optic, dialect) ?: continue
+      if (cached.compiled.usesTime) usesTime = true
+    }
+    planUsesTime = usesTime
+    startNanos = -1L
+
+    if (clock is MirageClock.Auto && usesTime) {
+      coroutineScope.launch {
+        while (isActive) {
+          withFrameNanos { now ->
+            if (startNanos < 0L) startNanos = now
+            timeSeconds = ((now - startNanos) / 1_000_000_000f) % TIME_WRAP_SECONDS
+            invalidateDraw()
+          }
+        }
+      }
+    }
+  }
+
+  override fun ContentDrawScope.draw() {
+    // Draw nothing while this sky is recording: keeping this node out of the blur/grade source avoids
+    // the cyclic RenderNode graph that crashes the render thread (issues/112). See [Sky.isCapturing].
+    if (sky.isCapturing) {
+      return
+    }
+
+    if (!enabled) {
+      drawContent()
+      return
+    }
+
+    val backgroundLayer = sky.backgroundLayer
+    if (backgroundLayer == null) {
+      // No captured backdrop yet: nothing to sample, so just draw this node's own content.
+      drawContent()
+      return
+    }
+
+    // The shader resolution is the ContentDrawScope's canvas size, exactly as MirageNode binds it.
+    val width = size.width
+    val height = size.height
+    if (width <= 0f || height <= 0f) {
+      drawContent()
+      return
+    }
+
+    val dialect = currentDialect()
+    val density = currentValueOf(LocalDensity).density
+    val time = timeFor(clock)
+
+    // Backdrop-relative offset — this node's root position minus the sky origin, exactly as the cloudy
+    // backdrop path computes it (CloudyBackground.android.kt:397-399).
+    val skyBounds = sky.sourceBounds
+    val offsetX = positionInRoot.x - skyBounds.left
+    val offsetY = positionInRoot.y - skyBounds.top
+
+    val filters = stages.filterIsInstance<Stage.Filter>()
+    val overlays = stages.filterIsInstance<Stage.Overlay>()
+
+    val applicable = filters.mapNotNull { stage ->
+      val cached = MirageProgramCache.obtain(stage.optic, dialect) ?: return@mapNotNull null
+      stage to cached
+    }
+
+    with(chain) {
+      draw(
+        context = requireGraphicsContext(),
+        applicable = applicable,
+        bind = { stage, cached ->
+          bindUniforms(cached, stage.params, stage.paramsBlock, width, height, density, time)
+        },
+        // Stage 0 records the offset-shifted Sky region (a direct port of the cloudy backdrop record,
+        // CloudyBackground.android.kt:550-559); the chain's content-bound effect then grades THAT. When
+        // no stage is applicable (API < 33) the chain draws this same region raw.
+        recordSource = {
+          drawContext.canvas.save()
+          drawContext.canvas.translate(-offsetX, -offsetY)
+          drawLayer(backgroundLayer)
+          drawContext.canvas.restore()
+        },
+      )
+    }
+
+    drawOverlays(overlays, width, height, density, time)
+
+    drawContent()
+  }
+
+  /**
+   * Overlays: composite each generator over the graded backdrop via a ShaderBrush under the stage's
+   * blend mode — the same overlay path [MirageNode] uses, applied over the backdrop result.
+   */
+  private fun ContentDrawScope.drawOverlays(
+    overlays: List<Stage.Overlay>,
+    width: Float,
+    height: Float,
+    density: Float,
+    time: Float,
+  ) {
+    val dialect = currentDialect()
+    for (stage in overlays) {
+      val cached = MirageProgramCache.obtain(stage.optic, dialect) ?: continue
+      bindUniforms(cached, stage.params, stage.paramsBlock, width, height, density, time)
+      drawRect(brush = cached.backend.asShaderBrush(), blendMode = stage.blendMode)
+    }
+  }
+
+  private fun timeFor(clock: MirageClock): Float = when (clock) {
+    is MirageClock.Auto -> if (planUsesTime) timeSeconds else 0f
+    is MirageClock.Paused -> timeSeconds
+    is MirageClock.Fixed -> clock.seconds
+  }
+
+  override fun onDetach() {
+    sky.frameDriver.removeOverlay(reblur)
+    chain.release(requireGraphicsContext())
+  }
+}

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/internal/MirageFilterChain.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/internal/MirageFilterChain.kt
@@ -1,0 +1,119 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalMirage::class)
+
+package com.skydoves.cloudy.internal
+
+import androidx.compose.ui.graphics.GraphicsContext
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.layer.drawLayer
+import com.skydoves.cloudy.ExperimentalMirage
+
+/**
+ * Owns and runs the layer-chaining draw for a mirage filter plan, decoupled from *what* stage 0
+ * samples. A [MirageNode] records its own content into stage 0; a backdrop node records the Sky
+ * region instead — the chaining, per-stage render-effect binding, and layer pooling are identical, so
+ * they are extracted here rather than duplicated (Pure Fabrication: the algorithm is neither the
+ * self-content node nor the backdrop node, it is the shared stage-chain machinery).
+ *
+ * It holds no clock, no Sky, and no params ownership: the caller supplies the already-resolved
+ * [Stage.Filter] → [CachedProgram] pairs, the per-stage uniform [bind], and the stage-0 source. This
+ * keeps the chain lifecycle-free — its only state is the reusable layer pool, released on detach.
+ *
+ * ## Draw model (no fusion)
+ * Stage 0 records the caller's `recordSource`; each later stage records the previous stage's layer.
+ * After binding, every stage sets its layer's content-bound render effect so the program transforms
+ * exactly the recorded pixels. The last stage's layer holds the fully chained result and is drawn.
+ */
+internal class MirageFilterChain {
+
+  /**
+   * Reusable filter layers, one per applicable stage, indexed by stage order. Rebuilt lazily on first
+   * draw and released via [release]; never allocated inside the steady-state draw.
+   */
+  private var filterLayers: Array<GraphicsLayer?> = arrayOfNulls(0)
+
+  /**
+   * Draws [applicable] as a chained stack of content-bound render effects.
+   *
+   * When [applicable] is empty (no stage declared, or every stage unsupported — e.g. Android below
+   * API 33 where [MirageProgramCache.obtain] returns `null`), [recordSource] is drawn straight to the
+   * screen. This single contract is why both the self-content pass-through and the backdrop API < 33
+   * "raw region" fallback need no extra branch: the caller's `recordSource` (own content, or the
+   * offset backdrop region) is what shows.
+   *
+   * @param context the graphics context that owns the layer pool (`requireGraphicsContext()` from the
+   *   calling node — passed in because the chain is a plain collaborator, not a `Modifier.Node`).
+   * @param applicable already-resolved (`obtain != null`) filter stages in declared order.
+   * @param bind writes a stage's per-draw uniforms into its program (called before the effect is set,
+   *   so the effect captures the current uniforms). The caller keeps clock/params ownership.
+   * @param recordSource records the stage-0 input — the self content for a node, or the offset Sky
+   *   region for a backdrop node.
+   */
+  fun ContentDrawScope.draw(
+    context: GraphicsContext,
+    applicable: List<Pair<Stage.Filter, CachedProgram>>,
+    bind: (Stage.Filter, CachedProgram) -> Unit,
+    recordSource: DrawScope.() -> Unit,
+  ) {
+    if (applicable.isEmpty()) {
+      // No filter ran (none declared, or all unsupported): draw the source as-is.
+      recordSource()
+      return
+    }
+
+    if (filterLayers.size != applicable.size) {
+      // Layer count changed (a structural plan change). Release any stale layers before resizing so
+      // the pool never leaks even if the node did not reset it first.
+      release(context)
+      filterLayers = arrayOfNulls(applicable.size)
+    }
+
+    for (index in applicable.indices) {
+      val (stage, cached) = applicable[index]
+      val layer = filterLayers[index]
+        ?: context.createGraphicsLayer().also { filterLayers[index] = it }
+
+      // Record the previous stage's output (or the caller's source for the first stage) into this
+      // stage's layer, so the render effect below transforms exactly that.
+      layer.record {
+        if (index == 0) {
+          recordSource()
+        } else {
+          drawLayer(filterLayers[index - 1]!!)
+        }
+      }
+
+      bind(stage, cached)
+      layer.renderEffect = cached.backend.asContentRenderEffect()
+    }
+
+    // The last applicable filter's layer holds the fully chained result.
+    drawLayer(filterLayers[applicable.lastIndex]!!)
+  }
+
+  /** Releases the pooled layers back to [context]; call from the owning node's `onDetach`. */
+  fun release(context: GraphicsContext) {
+    if (filterLayers.isEmpty()) return
+    for (i in filterLayers.indices) {
+      filterLayers[i]?.let { context.releaseGraphicsLayer(it) }
+      filterLayers[i] = null
+    }
+    filterLayers = arrayOfNulls(0)
+  }
+}

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/internal/MirageNode.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/internal/MirageNode.kt
@@ -19,14 +19,9 @@ package com.skydoves.cloudy.internal
 
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.BlendMode
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
 import androidx.compose.ui.graphics.layer.GraphicsLayer
-import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
 import androidx.compose.ui.node.DrawModifierNode
 import androidx.compose.ui.node.ModifierNodeElement
@@ -42,32 +37,14 @@ import com.skydoves.cloudy.MirageClock
 import com.skydoves.cloudy.MirageParams
 import com.skydoves.cloudy.MirageScope
 import com.skydoves.cloudy.Optic
-import com.skydoves.cloudy.UColor
-import com.skydoves.cloudy.UFloat
-import com.skydoves.cloudy.UFloatArray
-import com.skydoves.cloudy.UInt1
-import com.skydoves.cloudy.UOffset
-import com.skydoves.cloudy.USize
-import com.skydoves.cloudy.UTexture
-import com.skydoves.cloudy.UVec3
-import com.skydoves.cloudy.UVec4
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
 /** The shading language the current platform runs (Android = AGSL, every skiko target = SKSL). */
 internal expect fun currentDialect(): Dialect
 
-/**
- * Standard uniform names the compiler emits on demand. The node binds each one only when the compiled
- * program declared it: Android's RuntimeShader throws IllegalArgumentException on a write to an
- * undeclared uniform (skiko tolerates it), so the CompiledProgram.uses* flags gate every bind.
- */
-private const val STD_RESOLUTION = "mirageResolution"
-private const val STD_TIME = "mirageTime"
-private const val STD_DENSITY = "mirageDensity"
-
 /** mirageTime wraps here so a long session never grows the argument enough to decay float32 sin(). */
-private const val TIME_WRAP_SECONDS = 3600f
+internal const val TIME_WRAP_SECONDS = 3600f
 
 /**
  * One declared stage of a mirage plan. Sealed so the draw loop branches exhaustively over the two
@@ -154,11 +131,8 @@ internal class MirageNode(var clock: MirageClock, var enabled: Boolean, stages: 
   var stages: List<Stage> = stages
     private set
 
-  /**
-   * Reusable filter layers, one per filter stage, indexed by stage order. Rebuilt lazily on first
-   * draw and released on detach; never allocated inside the steady-state draw.
-   */
-  private var filterLayers: Array<GraphicsLayer?> = arrayOfNulls(0)
+  /** Owns the filter-layer pool and the stage-chaining draw; the node keeps only clock + binding. */
+  private val chain = MirageFilterChain()
 
   /**
    * mirageTime, in seconds. Auto advances it from the frame loop; Fixed writes a constant; Paused
@@ -198,9 +172,10 @@ internal class MirageNode(var clock: MirageClock, var enabled: Boolean, stages: 
       return
     }
 
-    releaseLayers()
-    filterLayers = arrayOfNulls(0)
+    // Structural change: the filter count may differ, so drop the pooled layers. The chain re-sizes
+    // itself lazily on the next draw. (When detached there are no pooled layers to release.)
     if (isAttached) {
+      chain.release(requireGraphicsContext())
       warmAndSchedule()
       invalidateDraw()
     }
@@ -264,7 +239,8 @@ internal class MirageNode(var clock: MirageClock, var enabled: Boolean, stages: 
   /**
    * Filters: record the running content into a per-stage layer, bind that stage's program, apply it
    * as the layer's content-bound render effect, then draw the layer - feeding the next stage. A stage
-   * whose program is unavailable (API < 33) is skipped, leaving the running content untouched.
+   * whose program is unavailable (API < 33) is skipped, leaving the running content untouched. The
+   * layer chaining lives in [MirageFilterChain]; here stage 0 records this node's own content.
    */
   private fun ContentDrawScope.drawFilteredContent(
     filters: List<Stage.Filter>,
@@ -279,36 +255,16 @@ internal class MirageNode(var clock: MirageClock, var enabled: Boolean, stages: 
       stage to cached
     }
 
-    if (applicable.isEmpty()) {
-      // No filter ran (none declared, or all unsupported): draw the content as-is.
-      drawContent()
-      return
+    with(chain) {
+      draw(
+        context = requireGraphicsContext(),
+        applicable = applicable,
+        bind = { stage, cached ->
+          bindUniforms(cached, stage.params, stage.paramsBlock, width, height, density, time)
+        },
+        recordSource = { this@drawFilteredContent.drawContent() },
+      )
     }
-
-    ensureFilterLayers(applicable.size)
-    val context = requireGraphicsContext()
-
-    for ((index, entry) in applicable.withIndex()) {
-      val (stage, cached) = entry
-      val layer = filterLayers[index]
-        ?: context.createGraphicsLayer().also { filterLayers[index] = it }
-
-      // Record the previous stage's output (or the original content for the first stage) into this
-      // stage's layer, so the render effect below transforms exactly that.
-      layer.record {
-        if (index == 0) {
-          this@drawFilteredContent.drawContent()
-        } else {
-          drawLayer(filterLayers[index - 1]!!)
-        }
-      }
-
-      bindUniforms(cached, stage.params, stage.paramsBlock, width, height, density, time)
-      layer.renderEffect = cached.backend.asContentRenderEffect()
-    }
-
-    // The last applicable filter's layer holds the fully chained result.
-    drawLayer(filterLayers[applicable.lastIndex]!!)
   }
 
   /**
@@ -330,76 +286,14 @@ internal class MirageNode(var clock: MirageClock, var enabled: Boolean, stages: 
     }
   }
 
-  /**
-   * Resets each handle to its declared default, runs the caller's per-draw block, then pushes the
-   * standard uniforms + every schema slot through the sink in declaration order.
-   */
-  private fun bindUniforms(
-    cached: CachedProgram,
-    params: MirageParams,
-    paramsBlock: (MirageParams.() -> Unit)?,
-    width: Float,
-    height: Float,
-    density: Float,
-    time: Float,
-  ) {
-    // Reset to defaults so a value written on a previous draw does not leak when this draw's block
-    // leaves it unset — the schema's declared default is the single source of truth per draw.
-    resetToDefaults(params, cached.compiled.schema)
-    paramsBlock?.invoke(params)
-
-    val sink = cached.backend.uniformSink()
-
-    // Standard uniforms first, each gated on whether the compiled kernel declared it: Android's
-    // RuntimeShader throws on a write to an undeclared uniform name.
-    val compiled = cached.compiled
-    if (compiled.usesResolution) sink.float2(STD_RESOLUTION, width, height)
-    if (compiled.usesTime) sink.float(STD_TIME, time)
-    if (compiled.usesDensity) sink.float(STD_DENSITY, density)
-
-    // Schema uniforms in declaration (= bind) order: the params' live handles and the compiled
-    // schema entries share the same slot index, so entries[handle.slot] names each write.
-    val entries = cached.compiled.schema.entries
-    for (handle in params.handles) {
-      val name = entries[handle.slot].name
-      when (handle) {
-        is UFloat -> sink.float(name, handle.value)
-        is UOffset -> sink.float2(name, handle.value.x, handle.value.y)
-        is USize -> sink.float2(name, handle.value.width, handle.value.height)
-        is UInt1 -> sink.int(name, handle.value)
-        is UVec3 -> sink.floatArray(name, handle.value)
-        is UVec4 -> sink.floatArray(name, handle.value)
-        is UFloatArray -> sink.floatArray(name, handle.value)
-        is UColor -> sink.color(name, handle.value)
-        is UTexture -> sink.texture(name, handle.value, handle.tileMode)
-      }
-    }
-  }
-
-  private fun ensureFilterLayers(count: Int) {
-    if (filterLayers.size != count) {
-      releaseLayers()
-      filterLayers = arrayOfNulls(count)
-    }
-  }
-
   private fun timeFor(clock: MirageClock): Float = when (clock) {
     is MirageClock.Auto -> if (planUsesTime) timeSeconds else 0f
     is MirageClock.Paused -> timeSeconds
     is MirageClock.Fixed -> clock.seconds
   }
 
-  private fun releaseLayers() {
-    if (filterLayers.isEmpty()) return
-    val context = requireGraphicsContext()
-    for (i in filterLayers.indices) {
-      filterLayers[i]?.let { context.releaseGraphicsLayer(it) }
-      filterLayers[i] = null
-    }
-  }
-
   override fun onDetach() {
-    releaseLayers()
+    chain.release(requireGraphicsContext())
   }
 }
 
@@ -411,7 +305,7 @@ internal class MirageNode(var clock: MirageClock, var enabled: Boolean, stages: 
  * runs the identical comparison to decide element equality.
  */
 @OptIn(ExperimentalMirage::class)
-private fun sameStructure(a: List<Stage>, b: List<Stage>): Boolean {
+internal fun sameStructure(a: List<Stage>, b: List<Stage>): Boolean {
   if (a.size != b.size) return false
   for (i in a.indices) {
     val x = a[i]
@@ -483,38 +377,5 @@ internal class MirageElement(
       result = 31 * result + (stage.paramsBlock?.hashCode() ?: 0)
     }
     return result
-  }
-}
-
-/**
- * Resets each handle on [params] back to the declared default from its schema entry, so an unset
- * uniform this draw re-uses its default rather than a stale prior-draw value.
- */
-@OptIn(ExperimentalMirage::class)
-private fun resetToDefaults(params: MirageParams, schema: UniformSchema) {
-  for (handle in params.handles) {
-    val default = schema.entries[handle.slot].default
-    when (handle) {
-      is UFloat -> handle.value = default as Float
-
-      is UOffset -> handle.value = default as Offset
-
-      is USize -> handle.value = default as Size
-
-      is UInt1 -> handle.value = default as Int
-
-      is UVec3 -> handle.value = (default as FloatArray).copyOf()
-
-      is UVec4 -> handle.value = (default as FloatArray).copyOf()
-
-      is UFloatArray -> handle.value = (default as FloatArray).copyOf()
-
-      is UColor -> handle.value = default as Color
-
-      is UTexture -> {
-        @Suppress("UNCHECKED_CAST")
-        handle.value = default as ImageBitmap?
-      }
-    }
   }
 }

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/internal/MirageNode.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/internal/MirageNode.kt
@@ -37,6 +37,7 @@ import com.skydoves.cloudy.MirageClock
 import com.skydoves.cloudy.MirageParams
 import com.skydoves.cloudy.MirageScope
 import com.skydoves.cloudy.Optic
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
@@ -150,6 +151,10 @@ internal class MirageNode(var clock: MirageClock, var enabled: Boolean, stages: 
    */
   private var planUsesTime: Boolean = false
 
+  // The running Auto-clock frame loop, if any. Cancelled before a re-warm launches a new one so a
+  // structural update never leaves two loops advancing timeSeconds and invalidating in parallel.
+  private var frameLoopJob: Job? = null
+
   fun update(clock: MirageClock, enabled: Boolean, stages: List<Stage>) {
     // A recomposition re-creates the params blocks every time (they are lambdas), so the element is
     // unequal — and thus update() runs — on every recomposition even when only the blocks changed. If
@@ -199,7 +204,10 @@ internal class MirageNode(var clock: MirageClock, var enabled: Boolean, stages: 
     planUsesTime = usesTime
     startNanos = -1L
 
-    if (clock is MirageClock.Auto && usesTime) {
+    // Cancel a prior loop before starting a new one: a re-warm on structural update would otherwise
+    // stack loops that all advance timeSeconds and invalidate.
+    frameLoopJob?.cancel()
+    frameLoopJob = if (clock is MirageClock.Auto && usesTime) {
       coroutineScope.launch {
         while (isActive) {
           withFrameNanos { now ->
@@ -209,6 +217,8 @@ internal class MirageNode(var clock: MirageClock, var enabled: Boolean, stages: 
           }
         }
       }
+    } else {
+      null
     }
   }
 
@@ -293,6 +303,9 @@ internal class MirageNode(var clock: MirageClock, var enabled: Boolean, stages: 
   }
 
   override fun onDetach() {
+    // coroutineScope is cancelled on detach anyway; null the handle so a re-attach starts clean.
+    frameLoopJob?.cancel()
+    frameLoopJob = null
     chain.release(requireGraphicsContext())
   }
 }

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/internal/MirageUniformBinding.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/internal/MirageUniformBinding.kt
@@ -1,0 +1,126 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalMirage::class)
+
+package com.skydoves.cloudy.internal
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import com.skydoves.cloudy.ExperimentalMirage
+import com.skydoves.cloudy.MirageParams
+import com.skydoves.cloudy.UColor
+import com.skydoves.cloudy.UFloat
+import com.skydoves.cloudy.UFloatArray
+import com.skydoves.cloudy.UInt1
+import com.skydoves.cloudy.UOffset
+import com.skydoves.cloudy.USize
+import com.skydoves.cloudy.UTexture
+import com.skydoves.cloudy.UVec3
+import com.skydoves.cloudy.UVec4
+
+/**
+ * Standard uniform names the compiler emits on demand. A node binds each one only when the compiled
+ * program declared it: Android's RuntimeShader throws IllegalArgumentException on a write to an
+ * undeclared uniform (skiko tolerates it), so the CompiledProgram.uses* flags gate every bind.
+ *
+ * Shared by [MirageNode] and [MirageBackdropNode] (both bind identically; only their stage-0 source
+ * differs), so they live here rather than in either node.
+ */
+internal const val STD_RESOLUTION = "mirageResolution"
+internal const val STD_TIME = "mirageTime"
+internal const val STD_DENSITY = "mirageDensity"
+
+/**
+ * Resets each handle to its declared default, runs the caller's per-draw [paramsBlock], then pushes
+ * the standard uniforms + every schema slot through the sink in declaration order. A pure function of
+ * (cached, params, block, w, h, density, time) — no clock, no lifecycle — so both mirage nodes share
+ * it as the `bind` closure they hand to [MirageFilterChain].
+ */
+internal fun bindUniforms(
+  cached: CachedProgram,
+  params: MirageParams,
+  paramsBlock: (MirageParams.() -> Unit)?,
+  width: Float,
+  height: Float,
+  density: Float,
+  time: Float,
+) {
+  // Reset to defaults so a value written on a previous draw does not leak when this draw's block
+  // leaves it unset — the schema's declared default is the single source of truth per draw.
+  resetToDefaults(params, cached.compiled.schema)
+  paramsBlock?.invoke(params)
+
+  val sink = cached.backend.uniformSink()
+
+  // Standard uniforms first, each gated on whether the compiled kernel declared it: Android's
+  // RuntimeShader throws on a write to an undeclared uniform name.
+  val compiled = cached.compiled
+  if (compiled.usesResolution) sink.float2(STD_RESOLUTION, width, height)
+  if (compiled.usesTime) sink.float(STD_TIME, time)
+  if (compiled.usesDensity) sink.float(STD_DENSITY, density)
+
+  // Schema uniforms in declaration (= bind) order: the params' live handles and the compiled schema
+  // entries share the same slot index, so entries[handle.slot] names each write.
+  val entries = cached.compiled.schema.entries
+  for (handle in params.handles) {
+    val name = entries[handle.slot].name
+    when (handle) {
+      is UFloat -> sink.float(name, handle.value)
+      is UOffset -> sink.float2(name, handle.value.x, handle.value.y)
+      is USize -> sink.float2(name, handle.value.width, handle.value.height)
+      is UInt1 -> sink.int(name, handle.value)
+      is UVec3 -> sink.floatArray(name, handle.value)
+      is UVec4 -> sink.floatArray(name, handle.value)
+      is UFloatArray -> sink.floatArray(name, handle.value)
+      is UColor -> sink.color(name, handle.value)
+      is UTexture -> sink.texture(name, handle.value, handle.tileMode)
+    }
+  }
+}
+
+/**
+ * Resets each handle on [params] back to the declared default from its schema entry, so an unset
+ * uniform this draw re-uses its default rather than a stale prior-draw value.
+ */
+internal fun resetToDefaults(params: MirageParams, schema: UniformSchema) {
+  for (handle in params.handles) {
+    val default = schema.entries[handle.slot].default
+    when (handle) {
+      is UFloat -> handle.value = default as Float
+
+      is UOffset -> handle.value = default as Offset
+
+      is USize -> handle.value = default as Size
+
+      is UInt1 -> handle.value = default as Int
+
+      is UVec3 -> handle.value = (default as FloatArray).copyOf()
+
+      is UVec4 -> handle.value = (default as FloatArray).copyOf()
+
+      is UFloatArray -> handle.value = (default as FloatArray).copyOf()
+
+      is UColor -> handle.value = default as Color
+
+      is UTexture -> {
+        @Suppress("UNCHECKED_CAST")
+        handle.value = default as ImageBitmap?
+      }
+    }
+  }
+}


### PR DESCRIPTION
### 🎯 Goal

Add `Modifier.mirage(sky = sky) { … }`, a backdrop-bound overload of the mirage plan API. Where `Modifier.mirage { … }` filters the node's own content, this overload runs the same plan against the captured `Sky` backdrop behind the node. The headline use is a colorize material, e.g. a duotone rendered from the background:

```kotlin
Modifier.mirage(sky = sky) { filter(MirageOptics.Duotone) }
```

It is the mirage counterpart of `Modifier.cloudy(sky = sky)`'s backdrop blur, reusing the same `Sky` capture plumbing.

### 🛠 Implementation details

The filter draw is the same on both paths — record into a per-stage `GraphicsLayer`, bind uniforms, set the content-bound render effect, chain the layers. The only difference is what stage 0 records: the self-content node records `drawContent()`; the backdrop node records the offset-shifted `Sky.backgroundLayer` region, exactly as `CloudyBackground` does for blur. So the backend (`MirageBackendProgram.asContentRenderEffect`) is unchanged: on Android `createRuntimeShaderEffect(shader, "content")` and on skiko `makeRuntimeShader(input = null)` both bind the shader's `content` to the layer's recorded pixels, so recording the backdrop is enough to grade it.

- **`MirageFilterChain`** extracts the stage-chaining draw and the filter-layer pool out of `MirageNode`, so the self-content node and the backdrop node share it instead of duplicating the loop. Its stage-0 source is injected as a `recordSource` lambda. When no stage is applicable (below API 33, where `RuntimeShader` is unavailable) it draws `recordSource` directly, which gives the backdrop path a raw-region fallback that matches the radius-0 backdrop blur, with no extra branch.
- **`MirageBackdropNode`** is a separate node rather than a flag on `MirageNode`. A backdrop is positioned relative to the `Sky` and refreshes while the `Sky` scrolls, so it implements `GlobalPositionAwareModifierNode` and registers with the frame driver — lifecycle a pure self-content node has no reason to carry. Keeping the two nodes separate holds `MirageNode` to its single responsibility and confines the `Sky` coupling to the backdrop node. The node redraws when its root position changes, so the backdrop sample follows the node as it moves.
- **Frame-loop lifecycle.** The `Auto` clock's `withFrameNanos` loop is tracked and cancelled before a re-warm starts a new one, so a structural update never leaves two loops running. This also corrects the same pre-existing behavior in `MirageNode`, which the backdrop node's clock handling mirrors.
- **Issue #112 guard.** The backdrop node is a descendant of the `Sky` recorder, so the capture pass re-enters its draw. Drawing a backdrop-sampling effect into the layer being recorded would form a cyclic `RenderNode` graph that overflows the render thread. The first line of `draw()` returns while `Sky.isCapturing`, the same guard the cloudy backdrop overlay uses.
- **KMP.** The overload and node are a single `commonMain` implementation; the node APIs it needs (`GlobalPositionAwareModifierNode`, `LayoutCoordinates.positionInRoot()`, `GraphicsLayer.record`) are all common, so Android (AGSL) and every skiko target (SKSL) run the same code.

The public surface is one experimental overload. `apiDump` is unchanged (the overload and the new internals are `@ExperimentalMirage`, which the ABI dump excludes).

### ✍️ Explain examples

Duotone material rendered from the backdrop:

```kotlin
val sky = rememberSky()

Box(modifier = Modifier.sky(sky)) {
  // Background content behind the card.
  AsyncImage(model = "background.jpg", modifier = Modifier.fillMaxSize())

  // The card grades the backdrop behind it into a duotone.
  Box(
    modifier = Modifier
      .size(200.dp)
      .clip(RoundedCornerShape(24.dp))
      .mirage(sky = sky) { filter(MirageOptics.Duotone) },
  )
}
```

Override the grade per draw through the `params` block, the same way the content overload does:

```kotlin
Modifier.mirage(sky = sky) {
  filter(MirageOptics.Duotone) {
    shadow = Color(0xFF102A43)
    highlight = Color(0xFFF0E6D2)
    amount = 0.8f
  }
}
```

### Tests

https://github.com/user-attachments/assets/065e18e7-85a3-4032-9e68-cf346b5a5139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for applying mirage effects to a captured backdrop `Sky` (in addition to the node’s own content) via a new `mirage(sky = ...)` modifier overload.
* **Bug Fixes**
  * Avoided unnecessary graphics resource allocation/release when no mirage stages apply, and ensured releasing an unused chain is a no-op.
  * Improved mirage modifier equality so updates/reconciliation respect the `sky` instance and the provided params-block identity.
* **Tests**
  * Added host-side and smoke tests covering backdrop mirage behavior, resource cleanup, and modifier equality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

