### PR TITLE
fix(native): guard against null bitmap pixels in JNI blur entry points

### DIFF
--- a/cloudy-native/src/main/cpp/JniEntryPoints.cpp
+++ b/cloudy-native/src/main/cpp/JniEntryPoints.cpp
@@ -48,6 +48,10 @@ public:
     }
 
     ~ByteArrayGuard() {
+        // Get*ArrayElements can fail; passing its null result to a Release call is UB (CheckJNI aborts).
+        if (data == nullptr) {
+            return;
+        }
 #ifdef USE_CRITICAL
         env->ReleasePrimitiveArrayCritical(array, data, 0);
 #else
@@ -56,6 +60,9 @@ public:
     }
 
     uint8_t *get() { return reinterpret_cast<uint8_t *>(data); }
+
+    // Get*ArrayElements returns null on failure; the kernel would deref it.
+    bool isValid() const { return data != nullptr; }
 };
 
 class IntArrayGuard {
@@ -152,9 +159,12 @@ public:
     }
 
     uint8_t *get() const {
+        // assert() is a no-op under NDEBUG (release), so callers must gate on isValid().
         assert(valid);
         return reinterpret_cast<uint8_t *>(bytes);
     }
+
+    bool isValid() const { return valid; }
 
     int width() const { return info.width; }
 
@@ -219,6 +229,10 @@ Java_com_skydoves_cloudy_internals_render_RenderScriptToolkit_nativeBlur(
     RestrictionParameter restrict{env, restriction};
     ByteArrayGuard input{env, input_array};
     ByteArrayGuard output{env, output_array};
+    if (!input.isValid() || !output.isValid()) {
+        ALOGE("nativeBlur: failed to access input/output byte array");
+        return;
+    }
 
     toolkit->blur(input.get(), output.get(), size_x, size_y, vectorSize, radius, restrict.get());
 }
@@ -231,6 +245,10 @@ Java_com_skydoves_cloudy_internals_render_RenderScriptToolkit_nativeBlurBitmap(
     RestrictionParameter restrict{env, restriction};
     BitmapGuard input{env, input_bitmap};
     BitmapGuard output{env, output_bitmap};
+    if (!input.isValid() || !output.isValid()) {
+        ALOGE("nativeBlurBitmap: invalid input/output bitmap");
+        return;
+    }
 
     toolkit->blur(input.get(), output.get(), input.width(), input.height(), input.vectorSize(),
                   radius, restrict.get());
@@ -246,6 +264,13 @@ Java_com_skydoves_cloudy_internals_render_RenderScriptToolkit_nativeBackgroundBl
     RenderScriptToolkit *toolkit = reinterpret_cast<RenderScriptToolkit *>(native_handle);
     BitmapGuard src{env, src_bitmap};
     BitmapGuard dst{env, dst_bitmap};
+
+    // Must precede vectorSize(): on an invalid guard bytesPerPixel is
+    // uninitialized, so reading vectorSize() first would be UB.
+    if (!src.isValid() || !dst.isValid()) {
+        ALOGE("nativeBackgroundBlur: invalid src/dst bitmap");
+        return JNI_FALSE;
+    }
 
     if (src.vectorSize() != 4 || dst.vectorSize() != 4) {
         ALOGE("backgroundBlur requires ARGB_8888 bitmaps");


### PR DESCRIPTION
## Summary

Adds a defensive null-pointer guard to the RenderScript-toolkit JNI blur entry points (`cloudy-native`).

`BitmapGuard` marks itself `valid = false` when a bitmap fails format/stride validation or `AndroidBitmap_lockPixels` fails, but `get()` only calls `assert(valid)` — a no-op under `NDEBUG` (release). The JNI functions never checked `valid`, so an invalid guard would hand a null pixel pointer to the blur kernel and crash with SIGSEGV.

Today's callers are all internal (`RenderScriptToolkit` is `internal`) and always pass `ARGB_8888` bitmaps, so this isn't reachable through the public API right now. The guard is defense-in-depth: it keeps a future refactor that changes an output config, or an added entry point, from turning a validation failure into a native crash.

## Changes

`JniEntryPoints.cpp`:
- Add `valid()`/`isValid()` accessors to `ByteArrayGuard`/`BitmapGuard`.
- Early-return from `nativeBlur`, `nativeBlurBitmap`, and `nativeBackgroundBlur` when a guard is invalid. In `nativeBackgroundBlur` the check precedes `vectorSize()`, which reads uninitialized state on an invalid guard.

## Test

<img width="449" height="786" alt="스크린샷 2026-07-08 오후 4 07 53" src="https://github.com/user-attachments/assets/72662575-8985-4fe7-8349-6f181e49abc2" />

<img width="1440" height="2560" alt="Screenshot_1783494516" src="https://github.com/user-attachments/assets/59b48bd0-d54d-4b29-9671-4e40496ad9e3" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when processing images by handling cases where array or bitmap data cannot be acquired.
  * Added checks to prevent crashes or undefined behavior if bitmap access fails during blur operations.
  * Updated image blur handling to stop early and log failures when required input or output data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->