### PR TITLE
fix(native): guard Range2d field lookup against pending JNI exceptions

### DIFF
--- a/cloudy-native/src/main/cpp/JniEntryPoints.cpp
+++ b/cloudy-native/src/main/cpp/JniEntryPoints.cpp
@@ -199,6 +199,9 @@ public:
          */
         jclass restrictionClass = env->FindClass("com/skydoves/cloudy/internals/render/Range2d");
         if (restrictionClass == nullptr) {
+            // FindClass left a ClassNotFoundException/NoClassDefFoundError pending; it must be
+            // cleared before any further JNI call on this thread or that call is undefined.
+            env->ExceptionClear();
             ALOGE("RenderScriptToolit. Internal error. Could not find the Kotlin Range2d class.");
             isNull = true;
             return;
@@ -207,10 +210,20 @@ public:
         jfieldID startYId = env->GetFieldID(restrictionClass, "startY", "I");
         jfieldID endXId = env->GetFieldID(restrictionClass, "endX", "I");
         jfieldID endYId = env->GetFieldID(restrictionClass, "endY", "I");
+        // A single missing field (e.g. after R8 renaming) leaves a NoSuchFieldError pending and a
+        // null id; calling GetIntField with either is UB. Degrade to "no restriction" instead.
+        if (startXId == nullptr || startYId == nullptr || endXId == nullptr || endYId == nullptr) {
+            env->ExceptionClear();
+            env->DeleteLocalRef(restrictionClass);
+            ALOGE("RenderScriptToolit. Internal error. Could not find a Range2d field.");
+            isNull = true;
+            return;
+        }
         restriction.startX = env->GetIntField(jRestriction, startXId);
         restriction.startY = env->GetIntField(jRestriction, startYId);
         restriction.endX = env->GetIntField(jRestriction, endXId);
         restriction.endY = env->GetIntField(jRestriction, endYId);
+        env->DeleteLocalRef(restrictionClass);
     }
 
     Restriction *get() { return isNull ? nullptr : &restriction; }


### PR DESCRIPTION
## Problem

`RestrictionParameter`'s constructor in `JniEntryPoints.cpp` reflects into the Kotlin `Range2d` class but does not handle JNI reflection failures:

- `FindClass` has a null check but does not clear the `ClassNotFoundException`/`NoClassDefFoundError` it leaves pending. Once an exception is pending, any subsequent JNI call on the thread (e.g. the `GetByteArrayElements` in `nativeBlur` right after) is undefined.
- `GetFieldID` is called four times with no null check. A missing field (for example after R8 renames `Range2d`'s fields) returns a null `jfieldID` and leaves a `NoSuchFieldError` pending; the following `GetIntField` calls then run with a null id and a pending exception.

This path is currently dormant — every call site passes `restriction = null`, so the constructor returns early at line 176 — but it becomes a crash the moment a restriction is supplied.

## Fix

```cpp
if (restrictionClass == nullptr) {
    env->ExceptionClear();          // clear the pending FindClass exception
    ALOGE(...);
    isNull = true;
    return;
}

// ...four GetFieldID calls...

if (startXId == nullptr || startYId == nullptr || endXId == nullptr || endYId == nullptr) {
    env->ExceptionClear();
    env->DeleteLocalRef(restrictionClass);
    ALOGE(...);
    isNull = true;                  // degrade to "no restriction"
    return;
}
// ...GetIntField only runs when all ids are valid...
env->DeleteLocalRef(restrictionClass);
```

**Degrade instead of throw.** `get()` already returns `nullptr` (meaning "no restriction" → blur the whole image) when `isNull` is set, and every call site treats the restriction as optional. Setting `isNull = true` on lookup failure matches that existing contract, so a field mismatch produces a slightly imprecise blur region rather than killing the blur pipeline. The pending JNI exception is cleared on both failure paths so the thread is not left poisoned. The local `jclass` reference is released explicitly on the normal and failure paths.

## Verification

`:cloudy-native:externalNativeBuildDebug` compiles clean across `arm64-v8a`, `armeabi-v7a`, `x86`, `x86_64`. The restriction path itself is not exercised at runtime (all call sites pass null), so this is a compile-verified hardening of a dormant path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app stability when loading restriction settings from the native layer.
  * Prevents crashes or undefined behavior by safely handling missing JNI fields/class lookups.
  * Clears pending JNI exceptions and avoids unsafe calls when required field IDs aren’t found.
  * Ensures local JNI references are cleaned up correctly on both success and error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->