### PR TITLE
fix(native): enable SSSE3 blur kernels on x86 and x86_64

### DIFF
--- a/cloudy-native/src/main/cpp/CMakeLists.txt
+++ b/cloudy-native/src/main/cpp/CMakeLists.txt
@@ -51,7 +51,17 @@ if(CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64)
             Blur_advsimd.S
             )
 endif()
-# TODO add also for x86
+
+# SSSE3 is part of the Android x86 and x86_64 ABI baseline, so -mssse3 is safe on
+# every device for these ABIs. Function entry is still runtime-gated by
+# cpuSupportsSimd() (see Utils.cpp / TaskProcessor.cpp) as a second guard.
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL i686 OR CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64)
+    add_definitions(-DARCH_X86_HAVE_SSSE3)
+    add_compile_options(-mssse3)
+    set(X86_SOURCES
+            x86.cpp
+            )
+endif()
 
 # Creates and names a library, sets it as either STATIC
 # or SHARED, and provides the relative paths to its source code.
@@ -69,7 +79,8 @@ add_library(# Sets the name of the library.
             RenderScriptToolkit.cpp
         TaskProcessor.cpp
             Utils.cpp
-            ${ASM_SOURCES})
+            ${ASM_SOURCES}
+            ${X86_SOURCES})
 
 # Searches for a specified prebuilt library and stores the path as a
 # variable. Because CMake includes system libraries in the search path by


### PR DESCRIPTION
## Problem

The SSSE3 blur kernels in `x86.cpp` (`rsdIntrinsicBlurVFU4_K`, `HFU4_K`, `HFU1_K`) never ran on x86/x86_64:

- `CMakeLists.txt` added the SIMD define only for `armv7-a` and `aarch64`; the x86 case was left as `# TODO add also for x86`, so `ARCH_X86_HAVE_SSSE3` was never defined.
- `x86.cpp` was not in the `add_library` source list, so it was never compiled.

The dispatch in `Blur.cpp` was already correct — every SSSE3 call site is behind both `#if defined(ARCH_X86_HAVE_SSSE3)` and a runtime `if (mUsesSimd)` check (seeded from `cpuSupportsSimd()` in `TaskProcessor.cpp` / `Utils.cpp`, which probes `ANDROID_CPU_X86_FEATURE_SSSE3`). Only the build wiring was missing, so x86/x86_64 fell through to the scalar path.

## Fix

Wire up the two missing pieces in `CMakeLists.txt` only:

```cmake
if(CMAKE_SYSTEM_PROCESSOR STREQUAL i686 OR CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64)
    add_definitions(-DARCH_X86_HAVE_SSSE3)
    add_compile_options(-mssse3)
    set(X86_SOURCES x86.cpp)
endif()
```

and append `${X86_SOURCES}` to the library sources.

**`-mssse3` is safe on every Android x86/x86_64 device.** Per the [NDK ABI docs](https://developer.android.com/ndk/guides/abis), SSSE3 is part of the x86 (32-bit) baseline and the x86_64 baseline (which also includes SSE4.1/4.2). The existing `cpuSupportsSimd()` runtime check still gates function entry as a second guard, so a non-conforming CPU would fall back to scalar rather than hit an illegal instruction.

`x86.cpp`, `Blur.cpp`, and `BackgroundBlur.cpp` are untouched.

## Verification

`:cloudy-native:externalNativeBuildDebug` builds clean on all four ABIs, with `x86.cpp` compiling for both x86 and x86_64.

- `llvm-nm`: the three kernels are present as defined text symbols in the x86 and x86_64 `.so`, absent from arm64 (which uses its own assembly).
- `llvm-objdump`: real SSSE3 instructions (`pshufb`, `palignr`) are emitted inside the kernels, confirming vectorization rather than scalar fallback.

Runtime output correctness on an x86_64 emulator was not exercised here; the runtime gate should now select the SSSE3 kernels there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced support for x86 Android builds, enabling optimized processing on compatible devices.

* **Bug Fixes**
  * Improved build configuration so x86 and x86_64 variants include the correct platform-specific implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->