### PR TITLE
fix(native): own backgroundBlur scratch buffers on the toolkit instead of leaking per-thread

### DIFF
--- a/cloudy-native/src/main/cpp/BackgroundBlur.cpp
+++ b/cloudy-native/src/main/cpp/BackgroundBlur.cpp
@@ -18,8 +18,10 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <mutex>
 #include <vector>
 
+#include "BackgroundBlurBuffers.h"
 #include "RenderScriptToolkit.h"
 #include "TaskProcessor.h"
 #include "Utils.h"
@@ -69,28 +71,6 @@ public:
 
 // Global LUT instance (constructed once)
 static const GammaLUT gGammaLUT;
-
-/**
- * Internal buffer manager for background blur operations.
- * Reuses buffers across calls to minimize allocations.
- */
-class BackgroundBlurBuffers {
-public:
-    std::vector<uint8_t> scaledInput;
-    std::vector<uint8_t> blurOutput;
-
-    void ensureCapacity(size_t scaledSize, size_t blurSize) {
-        if (scaledInput.size() < scaledSize) {
-            scaledInput.resize(scaledSize);
-        }
-        if (blurOutput.size() < blurSize) {
-            blurOutput.resize(blurSize);
-        }
-    }
-};
-
-// Global buffer instance for reuse
-static thread_local BackgroundBlurBuffers gBuffers;
 
 /**
  * Crops and scales down a region from the source image.
@@ -338,14 +318,20 @@ bool RenderScriptToolkit::backgroundBlur(
     const size_t scaledHeight = std::max(static_cast<size_t>(cropHeight * scale), size_t(1));
     const size_t scaledSize = scaledWidth * scaledHeight * 4;
 
+    // Serialize access to the shared scratch buffers: backgroundBlur can run on multiple
+    // Dispatchers.Default workers at once and its crop/scale steps are not covered by the tiled
+    // blur kernel's task mutex, so the buffers would otherwise race.
+    BackgroundBlurBuffers& buffers = *backgroundBlurBuffers;
+    std::lock_guard<std::mutex> bufferLock(buffers.mutex);
+
     // Ensure buffers have sufficient capacity
-    gBuffers.ensureCapacity(scaledSize, scaledSize);
+    buffers.ensureCapacity(scaledSize, scaledSize);
 
     // Step 1: Crop and scale down
     cropAndScaleDown(
         src, srcWidth, srcHeight,
         cropX, cropY, cropWidth, cropHeight,
-        gBuffers.scaledInput.data(), scaledWidth, scaledHeight
+        buffers.scaledInput.data(), scaledWidth, scaledHeight
     );
 
     // Step 2: Apply blur
@@ -354,8 +340,8 @@ bool RenderScriptToolkit::backgroundBlur(
     scaledRadius = std::min(scaledRadius, 25);
 
     blur(
-        gBuffers.scaledInput.data(),
-        gBuffers.blurOutput.data(),
+        buffers.scaledInput.data(),
+        buffers.blurOutput.data(),
         scaledWidth, scaledHeight,
         4,  // RGBA
         scaledRadius,
@@ -365,7 +351,7 @@ bool RenderScriptToolkit::backgroundBlur(
     // Step 3: Scale up to output FIRST
     // This prevents alpha gradient interpolation artifacts
     scaleUp(
-        gBuffers.blurOutput.data(), scaledWidth, scaledHeight,
+        buffers.blurOutput.data(), scaledWidth, scaledHeight,
         dst, cropWidth, cropHeight
     );
 

--- a/cloudy-native/src/main/cpp/BackgroundBlurBuffers.h
+++ b/cloudy-native/src/main/cpp/BackgroundBlurBuffers.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ANDROID_RENDERSCRIPT_TOOLKIT_BACKGROUNDBLURBUFFERS_H
+#define ANDROID_RENDERSCRIPT_TOOLKIT_BACKGROUNDBLURBUFFERS_H
+
+#include <cstdint>
+#include <mutex>
+#include <vector>
+
+namespace renderscript {
+
+/**
+ * Scratch buffers reused across backgroundBlur calls to minimize allocations.
+ *
+ * Owned by the RenderScriptToolkit instance (see RenderScriptToolkit.h) so the memory is
+ * released when the toolkit is destroyed rather than living for the whole process. The mutex
+ * guards the whole crop -> blur -> scale-up pipeline: backgroundBlur may run on multiple
+ * Dispatchers.Default workers at once and its crop/scale steps run outside TaskProcessor's task
+ * mutex, so these shared buffers would otherwise race.
+ */
+struct BackgroundBlurBuffers {
+    std::mutex mutex;
+    std::vector<uint8_t> scaledInput;
+    std::vector<uint8_t> blurOutput;
+
+    void ensureCapacity(size_t scaledSize, size_t blurSize) {
+        if (scaledInput.size() < scaledSize) {
+            scaledInput.resize(scaledSize);
+        }
+        if (blurOutput.size() < blurSize) {
+            blurOutput.resize(blurSize);
+        }
+    }
+};
+
+}  // namespace renderscript
+
+#endif  // ANDROID_RENDERSCRIPT_TOOLKIT_BACKGROUNDBLURBUFFERS_H

--- a/cloudy-native/src/main/cpp/RenderScriptToolkit.cpp
+++ b/cloudy-native/src/main/cpp/RenderScriptToolkit.cpp
@@ -16,6 +16,7 @@
 
 #include "RenderScriptToolkit.h"
 
+#include "BackgroundBlurBuffers.h"
 #include "TaskProcessor.h"
 
 #define LOG_TAG "renderscript.toolkit.RenderScriptToolkit"
@@ -26,11 +27,13 @@ namespace renderscript {
 // named source file. E.g. RenderScriptToolkit::blur() is found in Blur.cpp.
 
 RenderScriptToolkit::RenderScriptToolkit(int numberOfThreads)
-    : processor{new TaskProcessor(numberOfThreads)} {}
+    : processor{new TaskProcessor(numberOfThreads)},
+      backgroundBlurBuffers{new BackgroundBlurBuffers()} {}
 
 RenderScriptToolkit::~RenderScriptToolkit() {
-    // By defining the destructor here, we don't need to include TaskProcessor.h
-    // in RenderScriptToolkit.h.
+    // By defining the destructor here, we don't need to include TaskProcessor.h or
+    // BackgroundBlurBuffers.h in RenderScriptToolkit.h. Destroying the toolkit frees the
+    // backgroundBlur scratch buffers.
 }
 
 }  // namespace renderscript

--- a/cloudy-native/src/main/cpp/RenderScriptToolkit.h
+++ b/cloudy-native/src/main/cpp/RenderScriptToolkit.h
@@ -23,6 +23,7 @@
 namespace renderscript {
 
 class TaskProcessor;
+struct BackgroundBlurBuffers;
 
 /**
  * Define a range of data to process.
@@ -73,6 +74,13 @@ class RenderScriptToolkit {
      * tiles the tasks and schedule them over the pool threads.
      */
     std::unique_ptr<TaskProcessor> processor;
+
+    /** Scratch buffers for backgroundBlur, owned by the toolkit so they are released when it is
+     * destroyed (destroyNative) instead of leaking one set per worker thread for the app's life.
+     * Defined in BackgroundBlurBuffers.h; accessed under its own lock because backgroundBlur may
+     * run concurrently on Dispatchers.Default workers and, unlike the tiled blur kernel, is not
+     * serialized by TaskProcessor's task mutex. */
+    std::unique_ptr<BackgroundBlurBuffers> backgroundBlurBuffers;
 
 public:
     /**


### PR DESCRIPTION
## Problem

`backgroundBlur`'s scratch buffers were held in a `static thread_local BackgroundBlurBuffers gBuffers` in `BackgroundBlur.cpp`:

- One set of buffers was allocated per `Dispatchers.Default` worker thread that ever ran a background blur, and `ensureCapacity` only grows, never shrinks. After blurring a large region, each worker's `scaledInput` + `blurOutput` stayed resident at the largest size seen for the whole process lifetime (roughly N-workers × max-crop of RAM held indefinitely).

The `thread_local` was, in effect, the only thing making concurrent `backgroundBlur` calls safe today: `TaskProcessor`'s task mutex only covers the tiled blur kernel, while `cropAndScaleDown` / `scaleUp` write to the shared buffers with no lock, and the caller (`CloudyBackground.android.kt`) invokes `backgroundBlur` from `Dispatchers.Default` with no in-flight gate — so multiple blur targets on screen produce genuinely concurrent calls.

## Fix

Move the buffers onto the `RenderScriptToolkit` instance and guard them with their own mutex:

- New `BackgroundBlurBuffers.h` holds `scaledInput` / `blurOutput` / `ensureCapacity` plus a `std::mutex`.
- `RenderScriptToolkit` owns a `std::unique_ptr<BackgroundBlurBuffers>` (same pimpl pattern as the existing `processor`), so the memory is freed in `destroyNative` instead of leaking per thread for the app's life.
- `backgroundBlur` takes the buffer lock for the whole crop → blur → scale-up pipeline.

Lock order is always `buffers.mutex` → task mutex (acquired inside the nested `blur()` call), never the reverse, so there is no deadlock. The pixel logic (`cropAndScaleDown` / `scaleUp` / `applyProgressiveMask` / `GammaLUT`) and all signatures are unchanged — output is identical.

Trade-off: when several blur targets are on screen, the crop/scale steps now run serialized rather than per-worker-parallel. Single-target scenarios (the common case) are unaffected, and the blur kernel step was already serialized by the task mutex, so the real loss is small. A per-call buffer pool could restore that parallelism later if a measurement shows it matters, but that is not warranted now.

## Verification

`:cloudy-native:externalNativeBuildDebug` builds clean on all four ABIs (arm64-v8a, armeabi-v7a, x86, x86_64), including a forced recompile.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved background blur processing with reusable scratch buffers to better handle repeated blur requests.

* **Bug Fixes**
  * Fixed concurrent background blur buffer access to make multi-threaded blur operations safer and more reliable.

* **Performance**
  * Reduced unnecessary allocations by reusing buffer storage and growing it only when larger sizes are needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->