### PR TITLE
fix(native): tile the backgroundBlur scale-up pass across the thread pool

### DIFF
--- a/cloudy-native/src/main/cpp/BackgroundBlur.cpp
+++ b/cloudy-native/src/main/cpp/BackgroundBlur.cpp
@@ -132,59 +132,82 @@ static void cropAndScaleDown(
 
 /**
  * Scales up an image using gamma-correct bilinear interpolation.
+ *
+ * A Task so this pass can be tiled across the thread pool: it writes the full-resolution output
+ * (the pipeline's dominant cost) and each output pixel samples the source read-only, so tiling is
+ * safe and byte-identical to a single-threaded pass.
  */
-static void scaleUp(
-    const uint8_t* src, size_t srcWidth, size_t srcHeight,
-    uint8_t* dst, size_t dstWidth, size_t dstHeight
-) {
-    const float scaleX = static_cast<float>(srcWidth) / dstWidth;
-    const float scaleY = static_cast<float>(srcHeight) / dstHeight;
+class ScaleUpTask : public Task {
+    const uint8_t* mSrc;
+    uint8_t* mDst;
+    const size_t mSrcWidth;
+    const size_t mSrcHeight;
+    const float mScaleX;
+    const float mScaleY;
 
-    for (size_t y = 0; y < dstHeight; y++) {
-        const float srcYf = y * scaleY;
-        const size_t srcY0 = std::min(static_cast<size_t>(srcYf), srcHeight - 1);
-        const size_t srcY1 = std::min(srcY0 + 1, srcHeight - 1);
-        const float yFrac = srcYf - srcY0;
+    void processData(int /*threadIndex*/, size_t startX, size_t startY, size_t endX,
+                     size_t endY) override {
+        // Tile bounds are output-pixel coordinates; mSizeX is the output (dst) width.
+        for (size_t y = startY; y < endY; y++) {
+            const float srcYf = y * mScaleY;
+            const size_t srcY0 = std::min(static_cast<size_t>(srcYf), mSrcHeight - 1);
+            const size_t srcY1 = std::min(srcY0 + 1, mSrcHeight - 1);
+            const float yFrac = srcYf - srcY0;
 
-        for (size_t x = 0; x < dstWidth; x++) {
-            const float srcXf = x * scaleX;
-            const size_t srcX0 = std::min(static_cast<size_t>(srcXf), srcWidth - 1);
-            const size_t srcX1 = std::min(srcX0 + 1, srcWidth - 1);
-            const float xFrac = srcXf - srcX0;
+            for (size_t x = startX; x < endX; x++) {
+                const float srcXf = x * mScaleX;
+                const size_t srcX0 = std::min(static_cast<size_t>(srcXf), mSrcWidth - 1);
+                const size_t srcX1 = std::min(srcX0 + 1, mSrcWidth - 1);
+                const float xFrac = srcXf - srcX0;
 
-            // Gamma-correct bilinear interpolation for RGB channels
-            for (int c = 0; c < 3; c++) {
-                // Convert sRGB to linear
-                const float p00 = gGammaLUT.srgbToLinear[src[(srcY0 * srcWidth + srcX0) * 4 + c]];
-                const float p10 = gGammaLUT.srgbToLinear[src[(srcY0 * srcWidth + srcX1) * 4 + c]];
-                const float p01 = gGammaLUT.srgbToLinear[src[(srcY1 * srcWidth + srcX0) * 4 + c]];
-                const float p11 = gGammaLUT.srgbToLinear[src[(srcY1 * srcWidth + srcX1) * 4 + c]];
+                // Gamma-correct bilinear interpolation for RGB channels
+                for (int c = 0; c < 3; c++) {
+                    // Convert sRGB to linear
+                    const float p00 = gGammaLUT.srgbToLinear[mSrc[(srcY0 * mSrcWidth + srcX0) * 4 + c]];
+                    const float p10 = gGammaLUT.srgbToLinear[mSrc[(srcY0 * mSrcWidth + srcX1) * 4 + c]];
+                    const float p01 = gGammaLUT.srgbToLinear[mSrc[(srcY1 * mSrcWidth + srcX0) * 4 + c]];
+                    const float p11 = gGammaLUT.srgbToLinear[mSrc[(srcY1 * mSrcWidth + srcX1) * 4 + c]];
 
-                // Bilinear interpolation in linear space
-                const float top = p00 + (p10 - p00) * xFrac;
-                const float bottom = p01 + (p11 - p01) * xFrac;
-                const float linear = top + (bottom - top) * yFrac;
+                    // Bilinear interpolation in linear space
+                    const float top = p00 + (p10 - p00) * xFrac;
+                    const float bottom = p01 + (p11 - p01) * xFrac;
+                    const float linear = top + (bottom - top) * yFrac;
 
-                // Convert back to sRGB
-                dst[(y * dstWidth + x) * 4 + c] = gGammaLUT.toSrgb(linear);
-            }
+                    // Convert back to sRGB
+                    mDst[(y * mSizeX + x) * 4 + c] = gGammaLUT.toSrgb(linear);
+                }
 
-            // Alpha channel: linear interpolation (no gamma)
-            {
-                const float p00 = src[(srcY0 * srcWidth + srcX0) * 4 + 3];
-                const float p10 = src[(srcY0 * srcWidth + srcX1) * 4 + 3];
-                const float p01 = src[(srcY1 * srcWidth + srcX0) * 4 + 3];
-                const float p11 = src[(srcY1 * srcWidth + srcX1) * 4 + 3];
+                // Alpha channel: linear interpolation (no gamma)
+                {
+                    const float p00 = mSrc[(srcY0 * mSrcWidth + srcX0) * 4 + 3];
+                    const float p10 = mSrc[(srcY0 * mSrcWidth + srcX1) * 4 + 3];
+                    const float p01 = mSrc[(srcY1 * mSrcWidth + srcX0) * 4 + 3];
+                    const float p11 = mSrc[(srcY1 * mSrcWidth + srcX1) * 4 + 3];
 
-                const float top = p00 + (p10 - p00) * xFrac;
-                const float bottom = p01 + (p11 - p01) * xFrac;
-                const float value = top + (bottom - top) * yFrac;
+                    const float top = p00 + (p10 - p00) * xFrac;
+                    const float bottom = p01 + (p11 - p01) * xFrac;
+                    const float value = top + (bottom - top) * yFrac;
 
-                dst[(y * dstWidth + x) * 4 + 3] = static_cast<uint8_t>(std::clamp(value, 0.0f, 255.0f));
+                    mDst[(y * mSizeX + x) * 4 + 3] = static_cast<uint8_t>(std::clamp(value, 0.0f, 255.0f));
+                }
             }
         }
     }
-}
+
+   public:
+    ScaleUpTask(const uint8_t* src, size_t srcWidth, size_t srcHeight,
+                uint8_t* dst, size_t dstWidth, size_t dstHeight)
+        // prefersDataAsOneRow is false: each output pixel maps to a distinct 2D source location
+        // (srcXf=x*scaleX, srcYf=y*scaleY), so rows must not be flattened into one as blend/histogram do.
+        : Task{dstWidth, dstHeight, /*vectorSize=*/4, /*prefersDataAsOneRow=*/false,
+               /*restriction=*/nullptr},
+          mSrc{src},
+          mDst{dst},
+          mSrcWidth{srcWidth},
+          mSrcHeight{srcHeight},
+          mScaleX{static_cast<float>(srcWidth) / dstWidth},
+          mScaleY{static_cast<float>(srcHeight) / dstHeight} {}
+};
 
 /**
  * Applies a progressive alpha mask to create fade effect.
@@ -349,11 +372,14 @@ bool RenderScriptToolkit::backgroundBlur(
     );
 
     // Step 3: Scale up to output FIRST
-    // This prevents alpha gradient interpolation artifacts
-    scaleUp(
+    // This prevents alpha gradient interpolation artifacts.
+    // doTask runs under buffers.mutex (as blur() above does) and takes mTaskMutex internally, so the
+    // lock order is always buffers.mutex -> mTaskMutex and never inverts.
+    ScaleUpTask scaleUpTask(
         buffers.blurOutput.data(), scaledWidth, scaledHeight,
         dst, cropWidth, cropHeight
     );
+    processor->doTask(&scaleUpTask);
 
     // Step 4: Apply progressive mask on FINAL full-resolution output
     // This ensures crisp alpha gradients without interpolation artifacts


### PR DESCRIPTION
> Stacked on #138 (`bench/background-blur`) — this PR targets that branch so its microbenchmark is present to measure the change. Merge #138 first, then this retargets to `main`.

## Motivation

A native microbenchmark of `backgroundBlur`'s three stages (crop+scale-down → blur → scale-up) found that **`scaleUp` dominates the pipeline at 89–99% of total time**, while the multithreaded `blur` is only 1–3%. The result held across two independent host configs (x86_64+SSSE3 blur, and arm64 with a deliberately scalar blur as a lower bound).

The reason is an asymmetry the stage names hide: `cropAndScaleDown` gets cheaper as `scale` drops (fewer output pixels), but `scaleUp` writes the **full-resolution** output (`cropWidth * cropHeight`) with a gamma-LUT bilinear sample per pixel regardless of `scale`. So `blur` was never the bottleneck — the one single-threaded stage on the full-resolution output was.

## Change

Convert the `scaleUp` free function to a `ScaleUpTask` (subclass of `Task`) and dispatch it through the existing `TaskProcessor`, the same path `blur` already uses. Each output pixel samples the source read-only with no dependency on any other output pixel, so the pass tiles cleanly.

- `prefersDataAsOneRow = false`: each output `(x, y)` maps to a distinct 2D source location (`srcXf = x * scaleX`, `srcYf = y * scaleY`), so rows must not be flattened into one logical row.
- The gamma-LUT / bilinear math is unchanged; only the loop bounds are parameterized to `[startX, endX) × [startY, endY)`.
- `doTask` is called under `buffers.mutex` (as `blur()` already is) and takes `mTaskMutex` internally, so the lock order is always `buffers.mutex → mTaskMutex` and never inverts.

`cropAndScaleDown` is left single-threaded — the benchmark showed it is negligible (0.04 ms at scale 0.10), so parallelizing it would add synchronization cost for no gain.

## Verification

**Correctness (byte-identical output):** a host harness links the real `TaskProcessor` + thread pool and compares the tiled `ScaleUpTask` output against the original single-threaded `scaleUp` via `memcmp`. All 12 cases are byte-identical, including degenerate strips (1×1, 1×500, 500×1) and prime-ish sizes (1919×1081 at scale 0.137) that stress tile boundaries. No off-by-one.

**End-to-end (#138 microbenchmark, emulator arm64-v8a API 27):** before (main) and after (this branch) measured back-to-back on the same emulator with the same command.

| case | before | after | speedup |
|---|---|---|---|
| phone 1080×800 s=0.25 | 3.83 ms | 1.48 ms | 2.58× |
| bigcard 1080×1920 s=0.10 | 8.72 ms | 2.91 ms | 2.99× |
| tablet 2000×1500 s=0.25 | 13.43 ms | 4.96 ms | 2.71× |

The whole `backgroundBlur` call is 2.6–3.0× faster, and the speedup grows with dst size (`bigcard`), matching the finding that scale-up on the full-resolution output dominates. The emulator exposes fewer cores than the host harness, so the ratio is below the host measurement — a real device has more cores to spread the tiled pass across.

**Build:** `:cloudy-native:externalNativeBuildDebug` builds clean on all four ABIs.

For very small outputs, `setTiling` collapses to a single tile (target tile size ≥ 1000 B), so the caller thread runs it directly and the pool wait returns immediately — no regression on tiny inputs, and production full-resolution outputs are always large enough to parallelize.

## Where this shows up at runtime

`backgroundBlur` runs on `Dispatchers.Default`, off the UI thread, so a scroll `FrameTimingMetric` does not move — the blur never blocked a frame to begin with. The win instead shows up as **blur staleness**: on API < 31 CPU-blur, the frosted backdrop lags the moving content by one blur-pipeline duration, and that is exactly what tiling `scaleUp` shortens.

Measured by tracing the native `Cloudy.backgroundBlur` section during an identical backdrop scroll on the same API 27 emulator, before vs after:

| metric | before (single-thread) | after (tiled) | speedup |
|---|---|---|---|
| median pipeline duration | 53.4 ms | 18.9 ms | 2.82× |
| p90 | 56.9 ms | 23.4 ms | 2.44× |
| blur updates in the same scroll | 41 | 62 | +51% |

The 2.82× median matches the microbenchmark, and because each blur clears sooner, ~50% more updates land inside the `MIN_BLUR_INTERVAL_MS = 50` throttle — the backdrop tracks the scroll more closely. (Emulator ABI runs on the host CPU, so the absolute ms don't transfer to a device; the ratio and the update-count structure do.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved background blur scaling by using tiled, region-based processing for faster high-resolution renders.
  * Reduced work during resize by computing per-pixel sampling efficiently while keeping the same output behavior.
* **Visual Improvements**
  * Enhanced color accuracy during background blur scaling with gamma-correct interpolation.
  * Preserved and improved transparency quality by applying correct alpha handling during resize.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
