### PR TITLE
feat(cloudy): make the native backgroundBlur pipeline measurable (microbenchmark + trace)

### DIFF
--- a/cloudy/build.gradle.kts
+++ b/cloudy/build.gradle.kts
@@ -177,6 +177,7 @@ kotlin {
       implementation(libs.androidx.compose.runtime)
       implementation(libs.androidx.lifecycle.runtime.compose)
       implementation(libs.kotlinx.coroutines.android)
+      implementation(libs.androidx.tracing.ktx)
     }
 
     commonMain.dependencies {

--- a/cloudy/build.gradle.kts
+++ b/cloudy/build.gradle.kts
@@ -150,7 +150,12 @@ kotlin {
     }
 
     withDeviceTest {
-      instrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+      // androidx.benchmark's runner (a superset of AndroidJUnitRunner) is required by BenchmarkRule;
+      // BackgroundBlurBenchmark throws at runtime under the plain runner. The @Ignore'd screenshot
+      // specs in this source set still run fine under it. suppressErrors (EMULATOR/UNLOCKED/etc.) is
+      // passed per-run from the CLI via -Pandroid.testInstrumentationRunnerArguments.* so CI/device
+      // runs stay strict by default.
+      instrumentationRunner = "androidx.benchmark.junit4.AndroidBenchmarkRunner"
     }
   }
 
@@ -227,6 +232,9 @@ kotlin {
       implementation(libs.androidx.test.runner)
       implementation(libs.androidx.test.junit)
       implementation(libs.junit4)
+      // Microbenchmark for the native backgroundBlur hot path (BackgroundBlurBenchmark). Uses
+      // implementation (not androidTestImplementation) so the benchmark manifest merges in.
+      implementation(libs.androidx.benchmark.junit4)
     }
 
     iosTest.dependencies {
@@ -244,6 +252,20 @@ tasks.withType<Test>().configureEach {
 
 tasks.named<Test>("desktopTest") {
   useJUnitPlatform()
+}
+
+// The Compose plugin creates this resource-copy task for the androidDeviceTest variant but never
+// sets its outputDirectory (the KMP-library device-test component has no `assets` source to wire
+// it to), so it fails config-time validation. This source set has no composeResources/, so give
+// the task a throwaway output dir to make it a valid no-op. See compose-gradle-plugin
+// AndroidResources.kt.
+tasks.matching { it.name == "copyAndroidDeviceTestComposeResourcesToAndroidAssets" }.configureEach {
+  // The task type is internal to the Compose plugin, so set outputDirectory reflectively.
+  val outputDir = layout.buildDirectory.dir("composeResources/androidDeviceTestAssets")
+  @Suppress("UNCHECKED_CAST")
+  val prop = javaClass.getMethod("getOutputDirectory")
+    .invoke(this) as org.gradle.api.file.DirectoryProperty
+  prop.convention(outputDir)
 }
 
 // Kotest's runner is JVM-only, so the shared commonTest sources compile for the Kotlin/Native

--- a/cloudy/src/androidDeviceTest/kotlin/com/skydoves/cloudy/BackgroundBlurBenchmark.kt
+++ b/cloudy/src/androidDeviceTest/kotlin/com/skydoves/cloudy/BackgroundBlurBenchmark.kt
@@ -1,0 +1,115 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.cloudy
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import androidx.benchmark.junit4.BenchmarkRule
+import androidx.benchmark.junit4.measureRepeated
+import com.skydoves.cloudy.internals.render.RenderScriptToolkit
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+/**
+ * Microbenchmark for the native [RenderScriptToolkit.backgroundBlur] pipeline.
+ *
+ * Lives in `androidDeviceTest` because [RenderScriptToolkit] is `internal` to `androidMain`; the
+ * KMP android device-test compilation is a friend of `androidMain`, so this is the only place a
+ * benchmark can call `backgroundBlur` without widening its visibility.
+ *
+ * Emulator ABI runs on the host CPU, not the device NEON path, so absolute numbers are only valid
+ * for same-host before/after comparison, not as device-representative latency.
+ */
+@RunWith(Parameterized::class)
+internal class BackgroundBlurBenchmark(private val case: Case) {
+
+  @get:Rule
+  val benchmarkRule = BenchmarkRule()
+
+  private lateinit var src: Bitmap
+  private lateinit var dst: Bitmap
+
+  private fun setUp() {
+    src = gradientBitmap(case.srcW, case.srcH)
+    // dst must be exactly the crop size (backgroundBlur writes the full-res cropped output).
+    dst = Bitmap.createBitmap(case.cropW, case.cropH, Bitmap.Config.ARGB_8888)
+  }
+
+  @Test
+  fun backgroundBlur() {
+    setUp()
+    benchmarkRule.measureRepeated {
+      RenderScriptToolkit.backgroundBlur(
+        srcBitmap = src,
+        dstBitmap = dst,
+        cropX = case.cropX,
+        cropY = case.cropY,
+        radius = case.radius,
+        scale = case.scale,
+      )
+    }
+  }
+
+  /**
+   * One benchmark case. [srcW]/[srcH] is the full background; [cropW]/[cropH] (== dst) is the
+   * blurred region; [scale] is the internal downscale before blur.
+   */
+  data class Case(
+    val name: String,
+    val srcW: Int,
+    val srcH: Int,
+    val cropX: Int,
+    val cropY: Int,
+    val cropW: Int,
+    val cropH: Int,
+    val radius: Int,
+    val scale: Float,
+  ) {
+    override fun toString(): String = name // Parameterized uses this for the test name.
+  }
+
+  companion object {
+    /**
+     * Deterministic diagonal gradient: reproducible run-to-run, high-frequency enough that the blur
+     * kernel does real work, and rowBytes stays width*4 as the toolkit's stride check requires.
+     */
+    private fun gradientBitmap(w: Int, h: Int): Bitmap {
+      val pixels = IntArray(w * h)
+      var i = 0
+      for (y in 0 until h) {
+        for (x in 0 until w) {
+          val r = (x * 255) / w
+          val g = (y * 255) / h
+          val b = ((x + y) * 255) / (w + h)
+          pixels[i++] = Color.rgb(r, g, b)
+        }
+      }
+      return Bitmap.createBitmap(pixels, w, h, Bitmap.Config.ARGB_8888)
+    }
+
+    @JvmStatic
+    @Parameterized.Parameters(name = "{0}")
+    fun cases(): List<Case> = listOf(
+      Case("phone_1080x800_s25_r25", 1080, 2400, 0, 800, 1080, 800, 25, 0.25f),
+      Case("tablet_2000x1500_s25_r25", 2560, 1600, 280, 50, 2000, 1500, 25, 0.25f),
+      // Aggressive scale 0.10 with a large dst: shows scale-up-to-full-res dominating regardless
+      // of how small the downscaled blur input is.
+      Case("bigcard_1080x1920_s10_r25", 1080, 1920, 0, 0, 1080, 1920, 25, 0.10f),
+    )
+  }
+}

--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
@@ -64,6 +64,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.toSize
+import androidx.tracing.trace
 import com.skydoves.cloudy.internals.SkySnapshot
 import com.skydoves.cloudy.internals.render.RenderScriptToolkit
 import kotlinx.coroutines.Dispatchers
@@ -721,19 +722,24 @@ private class CloudyBackgroundModifierNode(
             RenderScriptToolkit.ProgressiveDirection.NONE
         }
 
-        // Run native background blur pipeline (crop -> scale down -> blur -> mask -> scale up)
+        // Run native background blur pipeline (crop -> scale down -> blur -> mask -> scale up).
+        // This is the blur staleness axis: how long it takes the blur to catch up to a scrolled
+        // background. It runs off the main thread, so it never shows up in FrameTiming/jankstats;
+        // trace() surfaces it to Perfetto/TraceSectionMetric instead.
         val success = withContext(Dispatchers.Default) {
-          RenderScriptToolkit.backgroundBlur(
-            srcBitmap = softwareBitmap,
-            dstBitmap = outputBitmap,
-            cropX = capturedSnapshot.offsetX.toInt().coerceAtLeast(0),
-            cropY = capturedSnapshot.offsetY.toInt().coerceAtLeast(0),
-            radius = capturedSnapshot.radius.coerceIn(1, 25),
-            scale = 0.25f,
-            progressiveDirection = progressiveDir,
-            fadeStart = capturedSnapshot.fadeStart,
-            fadeEnd = capturedSnapshot.fadeEnd,
-          )
+          trace("Cloudy.backgroundBlur") {
+            RenderScriptToolkit.backgroundBlur(
+              srcBitmap = softwareBitmap,
+              dstBitmap = outputBitmap,
+              cropX = capturedSnapshot.offsetX.toInt().coerceAtLeast(0),
+              cropY = capturedSnapshot.offsetY.toInt().coerceAtLeast(0),
+              radius = capturedSnapshot.radius.coerceIn(1, 25),
+              scale = 0.25f,
+              progressiveDirection = progressiveDir,
+              fadeStart = capturedSnapshot.fadeStart,
+              fadeEnd = capturedSnapshot.fadeEnd,
+            )
+          }
         }
 
         if (!success) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ androidxJunit = "1.3.0"
 androidxMacroBenchmark = "1.4.1"
 androidxProfileinstaller = "1.4.1"
 androidxUiAutomator = "2.4.0"
+androidxTracing = "1.3.0"
 landscapist = "2.11.0"
 composeMultiplatform = "1.11.1"
 androidxNav3 = "1.1.1"
@@ -66,6 +67,7 @@ androidx-test-runner = { group = "androidx.test", name = "runner", version.ref =
 androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "androidxTest" }
 androidx-test-junit = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "androidxJunit" }
 androidx-test-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "androidxUiAutomator" }
+androidx-tracing-ktx = { group = "androidx.tracing", name = "tracing-ktx", version.ref = "androidxTracing" }
 compose-runtime = { group = "org.jetbrains.compose.runtime", name = "runtime", version.ref = "composeMultiplatform" }
 compose-foundation = { group = "org.jetbrains.compose.foundation", name = "foundation", version.ref = "composeMultiplatform" }
 compose-ui = { group = "org.jetbrains.compose.ui", name = "ui", version.ref = "composeMultiplatform" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,6 +61,7 @@ androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = 
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidxLifecycle" }
 androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "androidxProfileinstaller" }
 androidx-benchmark-macro = { group = "androidx.benchmark", name = "benchmark-macro-junit4", version.ref = "androidxMacroBenchmark" }
+androidx-benchmark-junit4 = { group = "androidx.benchmark", name = "benchmark-junit4", version.ref = "androidxMacroBenchmark" }
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTest" }
 androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "androidxTest" }
 androidx-test-junit = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "androidxJunit" }


### PR DESCRIPTION
## What this adds

Two ways to measure the native `backgroundBlur` hot path, so changes to that pipeline can be judged with a number instead of a guess: a **microbenchmark** for its isolated latency, and a **trace section** that surfaces the same work when it runs off-thread during real use.

`RenderScriptToolkit` is an `internal object` in `androidMain`, so the benchmark lives in the `cloudy` module's own `androidDeviceTest` source set — the KMP android device-test compilation is a friend of `androidMain` and can call `internal fun backgroundBlur` directly, the same way the existing `SkyBackdropScreenshotTest` does. No separate module or `@VisibleForTesting` hole is needed. The existing `:benchmark` module targets `:app-android` as a macrobenchmark and can't reach `internal`, so it isn't reused.

## Files

- `cloudy/src/androidDeviceTest/kotlin/com/skydoves/cloudy/BackgroundBlurBenchmark.kt` — `@Parameterized` + `BenchmarkRule.measureRepeated`, 3 cases. Bitmaps are built and filled with a deterministic gradient in `setUp()` (outside the measured loop); the loop calls only `backgroundBlur`. Both src and dst are ARGB_8888 (the toolkit's `validateBitmap(alphaAllowed = false)` requires it), dst sized to the crop.
- `gradle/libs.versions.toml` — adds `benchmark-junit4` at the same version as the existing macro benchmark.
- `cloudy/build.gradle.kts` — device-test runner set to `AndroidBenchmarkRunner`; `benchmark-junit4` wired as `implementation` on `androidDeviceTest` (required for manifest merge); a workaround for a Compose-plugin config-time failure on the KMP-library device-test variant (its Compose-resources copy task has no assets source, so its `outputDirectory` is pointed at the build dir as a no-op).

## Cases

The cases are chosen so the dominant cost — the full-resolution scale-up pass — is visible: dst (= crop = output) is large, and `bigcard` uses `scale = 0.10` to show that heavy downscaling does *not* make the pipeline cheap, because scale-up writes the full-resolution output regardless of scale.

## Baseline (emulator, arm64-v8a, API 27)

Measured on `emulator-5554` (`test_avd_27`), which is arm64 so the real NEON kernels run:

| case | crop (= dst) | scale | median | ns / dst-px |
|---|---|---|---|---|
| phone_1080x800_s25_r25 | 1080×800 | 0.25 | 3.83 ms | ~4.5 |
| bigcard_1080x1920_s10_r25 | 1080×1920 | 0.10 | 8.72 ms | ~4.2 |
| tablet_2000x1500_s25_r25 | 2000×1500 | 0.25 | 13.43 ms | ~4.5 |

Time scales almost linearly with dst pixel count, confirming the scale-up pass dominates.

Run with:

```
ANDROID_SERIAL=emulator-5554 ./gradlew :cloudy:connectedAndroidDeviceTest \
  -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.suppressErrors=EMULATOR,UNLOCKED,LOW-BATTERY,DEBUGGABLE,CODE-COVERAGE
```

The suppressed errors (`EMULATOR`, `UNLOCKED`, `DEBUGGABLE`) mean these are relative-comparison numbers, not absolute device figures — before/after must be measured back-to-back on the same emulator. On a real device the runner would report unsuppressed, stable numbers.

## Trace section

On API < 31, `backgroundBlur` runs on `Dispatchers.Default`, off the UI thread, so it never blocks a frame and a scroll `FrameTimingMetric` can't see it. The microbenchmark measures it in isolation; to see the same work *during* a real scroll, the call is wrapped in a trace section:

```kotlin
trace("Cloudy.backgroundBlur") {
  RenderScriptToolkit.backgroundBlur(/* … */)
}
```

`androidx.tracing.trace {}` is an inline lambda, so it passes the `Boolean` result straight through with no try/finally and no per-call allocation, and it emits nothing measurable when tracing is off. This makes the pipeline's per-blur duration visible to Perfetto and to `TraceSectionMetric`, which is how the blur-latency (staleness) improvement in #137 is measured. It adds `androidx.tracing:tracing-ktx` as an `implementation` dependency on `androidMain` — a small, standard library that consumers get transitively; it must be `implementation` (not `compileOnly`) because the inline `beginSection`/`endSection` calls have to resolve at runtime in the consumer app.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Added Android device benchmarks for background blur across multiple configurations.
  * Added tracing support to make background-blur processing measurable in Android performance tools.

* **Testing**
  * Improved instrumented test setup for benchmark execution.
  * Added coverage for different blur sizes, crop regions, radii, and scales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
