### PR TITLE
fix(build): disable the empty device-test Compose resource-copy task

### DIFF
--- a/cloudy/build.gradle.kts
+++ b/cloudy/build.gradle.kts
@@ -256,17 +256,15 @@ tasks.named<Test>("desktopTest") {
 }
 
 // The Compose plugin creates this resource-copy task for the androidDeviceTest variant but never
-// sets its outputDirectory (the KMP-library device-test component has no `assets` source to wire
-// it to), so it fails config-time validation. This source set has no composeResources/, so give
-// the task a throwaway output dir to make it a valid no-op. See compose-gradle-plugin
-// AndroidResources.kt.
+// wires its @OutputDirectory (CopyResourcesToAndroidAssetsTask.outputDirectory): the KMP-library
+// device-test component has no `assets` source, so the plugin's
+// `componentSources.assets?.addGeneratedSourceDirectory(...)` short-circuits and the property stays
+// unset, failing config-time validation. This source set has no composeResources/ to copy, so the
+// task is a no-op with nothing to produce -- disable it. Skipped tasks are exempt from output
+// validation, and its only downstream (packageAndroidDeviceTestResources dependsOn) tolerates the
+// skip. See compose-gradle-plugin 1.11.1 AndroidResources.kt.
 tasks.matching { it.name == "copyAndroidDeviceTestComposeResourcesToAndroidAssets" }.configureEach {
-  // The task type is internal to the Compose plugin, so set outputDirectory reflectively.
-  val outputDir = layout.buildDirectory.dir("composeResources/androidDeviceTestAssets")
-  @Suppress("UNCHECKED_CAST")
-  val prop = javaClass.getMethod("getOutputDirectory")
-    .invoke(this) as org.gradle.api.file.DirectoryProperty
-  prop.convention(outputDir)
+  enabled = false
 }
 
 // Kotest's runner is JVM-only, so the shared commonTest sources compile for the Kotlin/Native


### PR DESCRIPTION
Follow-up to a review comment on #138: the device-test resource-copy workaround merged using reflection, which was fragile and hard to read.

## Background

The Compose plugin creates a `copyAndroidDeviceTestComposeResourcesToAndroidAssets` task for the `androidDeviceTest` variant but never wires its `@OutputDirectory`. Per the plugin source (`AndroidResources.kt:186`, compose-gradle-plugin 1.11.1), it sets the output via `componentSources.assets?.addGeneratedSourceDirectory(...)`, and the KMP-library device-test component has no `assets` source, so the `?.` short-circuits and the property stays unset — failing config-time validation ("outputDirectory Value not set") for every device-test build.

The original workaround set the property reflectively:

```kotlin
@Suppress("UNCHECKED_CAST")
val prop = javaClass.getMethod("getOutputDirectory").invoke(this) as DirectoryProperty
prop.convention(outputDir)
```

Two problems, both raised in review: the `@Suppress` is a no-op (the cast is checked, to a non-generic type), and `getMethod("getOutputDirectory")` breaks config-time for the whole device-test build if a plugin bump renames the getter.

## Why reflection at all — and why it's avoidable

`outputDirectory` lives only on `org.jetbrains.compose.resources.CopyResourcesToAndroidAssetsTask`, an `internal abstract class extends DefaultTask`. Its runtime supertypes and interfaces are all Gradle infrastructure — no public type exposes the property, so it genuinely can't be set through a typed cast. Reflection was the only way to *set* it.

But it doesn't need to be set. This source set has no `composeResources/` directory, so the task has nothing to copy — it only exists to fail validation. So instead of reaching into the task to satisfy the check, disable the empty task:

```kotlin
tasks.matching { it.name == "copyAndroidDeviceTestComposeResourcesToAndroidAssets" }.configureEach {
  enabled = false
}
```

A skipped task is exempt from output validation, and its only downstream (`packageAndroidDeviceTestResources` via `dependsOn`) tolerates the skip. This uses only the first-class `Task.enabled` API — nothing tied to the plugin's internal class or getter names — and matches the existing `wasmJs { testTask { enabled = false } }` idiom in this same file.

## Verification

`:cloudy:assembleAndroidDeviceTest` builds clean; the copy task reports `SKIPPED`, `packageAndroidDeviceTestResources` is `UP-TO-DATE`, and the config-time error is gone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android device-test builds by preventing unnecessary resource-copy tasks from triggering configuration errors.
  * No changes to app functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->