### PR TITLE
fix(cloudy): clamp legacy backdrop crop within source bounds

### DIFF
--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
@@ -722,6 +722,13 @@ private class CloudyBackgroundModifierNode(
             RenderScriptToolkit.ProgressiveDirection.NONE
         }
 
+        // Clamp so cropX+outputWidth (and Y) stay within the source; otherwise an edge child or a
+        // subpixel overshoot fails backgroundBlur's require() and strands the blur in Error.
+        val cropX = capturedSnapshot.offsetX.toInt()
+          .coerceIn(0, (softwareBitmap.width - outputWidth).coerceAtLeast(0))
+        val cropY = capturedSnapshot.offsetY.toInt()
+          .coerceIn(0, (softwareBitmap.height - outputHeight).coerceAtLeast(0))
+
         // Run native background blur pipeline (crop -> scale down -> blur -> mask -> scale up).
         // This is the blur staleness axis: how long it takes the blur to catch up to a scrolled
         // background. It runs off the main thread, so it never shows up in FrameTiming/jankstats;
@@ -731,8 +738,8 @@ private class CloudyBackgroundModifierNode(
             RenderScriptToolkit.backgroundBlur(
               srcBitmap = softwareBitmap,
               dstBitmap = outputBitmap,
-              cropX = capturedSnapshot.offsetX.toInt().coerceAtLeast(0),
-              cropY = capturedSnapshot.offsetY.toInt().coerceAtLeast(0),
+              cropX = cropX,
+              cropY = cropY,
               radius = capturedSnapshot.radius.coerceIn(1, 25),
               scale = 0.25f,
               progressiveDirection = progressiveDir,


### PR DESCRIPTION
## Problem

The legacy (API < 31, `cpuBlurEnabled`) backdrop blur clamped the crop origin with a lower bound only:

```kotlin
cropX = capturedSnapshot.offsetX.toInt().coerceAtLeast(0)
```

`outputBitmap` is sized to the full child (`outputWidth`/`outputHeight`), and native `RenderScriptToolkit.backgroundBlur` requires `cropX + dst.width <= src.width` (and the same for height, `RenderScriptToolkit.kt:227,230`). When the child sits at the sky's right/bottom edge — or a subpixel rounding overshoots by 1px — `cropX + outputWidth > srcWidth`, the `require` throws, the coroutine catches it into `CloudyState.Error`, and since every retry recomputes the same crop the blur is stranded in Error permanently.

## Fix

Clamp the origin with an upper bound too, so the crop always fits the source:

```kotlin
val cropX = capturedSnapshot.offsetX.toInt()
  .coerceIn(0, (softwareBitmap.width - outputWidth).coerceAtLeast(0))
val cropY = capturedSnapshot.offsetY.toInt()
  .coerceIn(0, (softwareBitmap.height - outputHeight).coerceAtLeast(0))
```

The lower bound is unchanged, so in-bounds children behave exactly as before. `coerceAtLeast(0)` on the upper bound guards the degenerate case where the output is larger than the source.

## Verification

`:cloudy:compileAndroidMain` builds clean.
