### PR TITLE
fix(cloudy): recycle legacy backdrop blur intermediate and stale bitmaps

### DIFF
--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
@@ -757,7 +757,17 @@ private class CloudyBackgroundModifierNode(
 
         Log.d(TAG, "Blur complete: ${outputBitmap.width}x${outputBitmap.height}")
 
+        // Free the consumed capture; softwareBitmap IS capturedBitmap unless a HARDWARE copy was made.
+        if (!softwareBitmap.isRecycled) softwareBitmap.recycle()
+        if (softwareBitmap !== capturedBitmap &&
+          !capturedBitmap.isRecycled
+        ) {
+          capturedBitmap.recycle()
+        }
+
         if (node.isAttached) {
+          // Recycle the superseded blur before replacing it (draw and replace both run on Main).
+          blurredBitmap?.dispose()
           blurredBitmap = PlatformBitmap(outputBitmap)
           cachedContentVersion = processingVersion
           onStateChanged(CloudyState.Success.Captured(blurredBitmap!!))
@@ -794,6 +804,7 @@ private class CloudyBackgroundModifierNode(
     cachedRadius = -1f
     blurJob?.cancel()
     blurJob = null
+    blurredBitmap?.dispose()
     blurredBitmap = null
     isProcessing = false
     cachedContentVersion = -1L


### PR DESCRIPTION
## Problem

The legacy backdrop blur never recycled its bitmaps, unlike the self-content path (`CloudyLegacyBlurStrategy.kt:412`):

- the previous `blurredBitmap` was replaced without disposing it (and `onDetach` just nulled it),
- the intermediate capture (`capturedBitmap` / its HARDWARE→ARGB copy) was left for GC.

On API < 31 scrolling re-captures every frame, so these pile up as GC pressure.

## Fix

Recycle the intermediates once the native blur has consumed them, and dispose the superseded / detached `blurredBitmap`:

```kotlin
if (!softwareBitmap.isRecycled) softwareBitmap.recycle()
if (softwareBitmap !== capturedBitmap && !capturedBitmap.isRecycled) capturedBitmap.recycle()
```

Two safety points: `softwareBitmap` **is** `capturedBitmap` unless a HARDWARE copy was made, so the second recycle is gated on identity to avoid a double free; and `blurredBitmap` is only read and replaced on the main thread, so disposing the superseded one (a new blur is ready) is never a use-after-free. `outputBitmap` is the result and is not touched.

## Verification

`:cloudy:compileAndroidMain` builds clean. (`testAndroidHostTest` has pre-existing Robolectric sandbox failures unrelated to this change, reproduced on the base commit.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory management during blur processing by releasing temporary image resources after use.
  * Ensured previously rendered blur images are properly cleared when replaced or when the component is removed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->