### PR TITLE
refactor(cloudy): drop redundant wall-clock throttle from legacy backdrop blur

### DIFF
--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
@@ -306,14 +306,8 @@ private class CloudyBackgroundModifierNode(
   private var blurJob: Job? = null
   private var pendingContentVersion: Long = -1L
 
-  // Throttling state to prevent blur job cancellation cascade
-  private var lastBlurStartTime: Long = 0L
+  // Latest version queued while a blur is in flight (single-slot, last-write-wins).
   private var queuedVersion: Long = -1L
-
-  companion object {
-    // Minimum time between blur starts (ms) - prevents rapid cancellation
-    private const val MIN_BLUR_INTERVAL_MS = 50L
-  }
 
   fun update(
     sky: Sky,
@@ -349,9 +343,8 @@ private class CloudyBackgroundModifierNode(
 
     if (needsRedraw) {
       // DON'T cancel blurJob - let it complete to avoid flickering
-      // Reset throttle state and version tracking
+      // Reset queue and version tracking
       queuedVersion = -1L
-      lastBlurStartTime = 0L
       cachedContentVersion = -1L
       pendingContentVersion = -1L
       // DON'T clear blurredBitmap - keep showing stale blur to prevent flickering
@@ -625,18 +618,11 @@ private class CloudyBackgroundModifierNode(
     }
     // No cache: draw nothing (transparent) - blur will appear when ready
 
-    // Completion-based throttling: DON'T cancel running jobs
-    // Instead, queue the request and let the current job complete
+    // Coalescing is completion-based: never cancel a running blur, queue the latest version and let
+    // the current job re-run once on completion (see below). No wall-clock throttle is needed on top —
+    // sky.frameDriver already pumps this overlay's invalidation at most once per frame via
+    // withFrameNanos, and a native blur outlasts a frame, so this gate is what bounds blur starts.
     if (isProcessing) {
-      // Job in progress - queue this version for later processing
-      queuedVersion = currentVersion
-      return
-    }
-
-    // Throttle blur requests to prevent rapid job restarts
-    val now = System.currentTimeMillis()
-    if (now - lastBlurStartTime < MIN_BLUR_INTERVAL_MS) {
-      // Too soon since last blur - queue for later
       queuedVersion = currentVersion
       return
     }
@@ -647,7 +633,6 @@ private class CloudyBackgroundModifierNode(
     }
 
     // Start async blur processing
-    lastBlurStartTime = now
     isProcessing = true
     pendingContentVersion = currentVersion
     onStateChanged(CloudyState.Loading)
@@ -807,6 +792,5 @@ private class CloudyBackgroundModifierNode(
     cachedContentVersion = -1L
     pendingContentVersion = -1L
     queuedVersion = -1L
-    lastBlurStartTime = 0L
   }
 }


### PR DESCRIPTION
## Problem

The legacy backdrop blur threw a wall-clock throttle (`MIN_BLUR_INTERVAL_MS = 50`) on top of `System.currentTimeMillis()` in front of the blur request. This is redundant and slightly fragile:

- the backdrop's `reblur` overlay is pumped by `SkyFrameDriver` via `withFrameNanos` — exactly one `invalidateDraw()` per frame — so the path is already frame-aligned;
- the completion gate (`isProcessing` / `queuedVersion`) already coalesces a scroll burst down to one blur at a time, and a native blur takes far longer than 50ms, so the wall-clock branch was almost always shadowed by that gate;
- `System.currentTimeMillis()` is non-monotonic (NTP / clock jumps).

The unrelated self-content path uses its own `withFrameNanos` debounce because it has *no* frame pump — that debounce is not needed here.

## Fix

Drop the wall-clock throttle and the now-unused `lastBlurStartTime` field / `MIN_BLUR_INTERVAL_MS`; rely on the frame driver (alignment) plus the completion gate (coalescing), which is the same in-flight-gate philosophy as the self-content path. The native blur call, capture, and queue re-drive are unchanged.

The dispatcher is intentionally left as-is: the `launch(Dispatchers.Main)` block does `layer.toImageBitmap()`, which needs the main thread, and the native blur is already moved off it via `withContext(Dispatchers.Default)`.

## Verification

`:cloudy:compileAndroidMain` builds clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blur rendering updates by ensuring the latest visual changes are processed after an active blur operation completes.
  * Reduced unnecessary delays and prevented missed redraws during rapid content changes.
  * Improved cleanup when the blurred component is removed from the screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->