### PR TITLE
refactor(cloudy): extract drawCachedWithOverlays helper

### DIFF
--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
@@ -586,6 +586,25 @@ private class CloudyBackgroundModifierNode(
     }
   }
 
+  /** Draws the cached blur bitmap clipped to the shape, then the tint and specular highlight overlays. */
+  private fun ContentDrawScope.drawCachedWithOverlays(
+    cached: PlatformBitmap,
+    snapshot: SkySnapshot,
+  ) {
+    clipToShape {
+      drawImage(
+        image = cached.bitmap.asImageBitmap(),
+        dstSize = IntSize(size.width.toInt(), size.height.toInt()),
+      )
+      if (snapshot.tintColor != Color.Transparent) {
+        drawRect(color = snapshot.tintColor, blendMode = BlendMode.SrcOver)
+      }
+
+      // Experimental specular highlight (no-op when light == null).
+      if (light != null) drawHighlight()
+    }
+  }
+
   private fun ContentDrawScope.drawWithBitmap(layer: GraphicsLayer, snapshot: SkySnapshot) {
     val currentVersion = sky.contentVersion
     val cached = blurredBitmap
@@ -595,36 +614,14 @@ private class CloudyBackgroundModifierNode(
 
     // Draw cached blur if valid
     if (cacheValid) {
-      clipToShape {
-        drawImage(
-          image = cached.bitmap.asImageBitmap(),
-          dstSize = androidx.compose.ui.unit.IntSize(size.width.toInt(), size.height.toInt()),
-        )
-        if (snapshot.tintColor != Color.Transparent) {
-          drawRect(color = snapshot.tintColor, blendMode = BlendMode.SrcOver)
-        }
-
-        // Experimental specular highlight (no-op when light == null).
-        if (light != null) drawHighlight()
-      }
+      drawCachedWithOverlays(cached, snapshot)
       onStateChanged(CloudyState.Success.Captured(cached))
       return
     }
 
     // Show cached blur while processing new one
     if (cached != null && !cached.bitmap.isRecycled) {
-      clipToShape {
-        drawImage(
-          image = cached.bitmap.asImageBitmap(),
-          dstSize = androidx.compose.ui.unit.IntSize(size.width.toInt(), size.height.toInt()),
-        )
-        if (snapshot.tintColor != Color.Transparent) {
-          drawRect(color = snapshot.tintColor, blendMode = BlendMode.SrcOver)
-        }
-
-        // Experimental specular highlight (no-op when light == null).
-        if (light != null) drawHighlight()
-      }
+      drawCachedWithOverlays(cached, snapshot)
     }
     // No cache: draw nothing (transparent) - blur will appear when ready
 


### PR DESCRIPTION
## Problem

`drawWithBitmap` had the cached-blur draw block duplicated verbatim: once for the valid-cache path and once for the "draw stale cache while reprocessing" path — clip → `drawImage` → tint `drawRect` → specular highlight.

## Fix

Extract it into a private helper:

```kotlin
private fun ContentDrawScope.drawCachedWithOverlays(cached: PlatformBitmap, snapshot: SkySnapshot)
```

Both sites now call it (the valid path keeps its trailing `onStateChanged(...Captured)` + `return`). Pure refactor — the draw sequence, dst size, blend mode, and light gate are identical, so pixels are unchanged. Net −24 / +18.

## Verification

`:cloudy:compileAndroidMain` builds clean; the Roborazzi screenshot tests show no pixel diff (the 6 unrelated `classMethod` failures are a pre-existing Robolectric environment issue, reproduced on the base commit).
