### PR TITLE
fix(cloudy): close per-draw skiko mirage shader/texture peers instead of leaking to the finalizer

### DIFF
--- a/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/internal/MirageBackendProgram.skiko.kt
+++ b/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/internal/MirageBackendProgram.skiko.kt
@@ -29,16 +29,64 @@ import org.jetbrains.skia.Image
 import org.jetbrains.skia.ImageFilter
 import org.jetbrains.skia.RuntimeEffect
 import org.jetbrains.skia.RuntimeShaderBuilder
+import org.jetbrains.skia.Shader as SkShader
 
 /**
  * Skiko backend program — wraps a [RuntimeShaderBuilder] (its uniforms are the live per-draw state).
  * The source [RuntimeEffect] is retained too: it is the compiled artifact the builder was made from,
  * and keeping a reference keeps the compiled effect reachable for the builder's lifetime.
+ *
+ * It also holds the per-draw skia peers that [asShaderBrush]/`texture` must rebuild (skia bakes
+ * uniforms/children into a `Shader` at build time). Each is closed when replaced so their native
+ * resource is freed eagerly instead of piling up until GC runs the finalizer — matching the Android
+ * backend, which reuses one persistent `RuntimeShader` and allocates nothing per draw. This program
+ * is itself long-lived (one per kernel source, held by the unbounded [MirageProgramCache]), so the
+ * final peer stays until process exit; only the per-frame churn is eliminated.
  */
 internal actual class MirageBackendProgram(
   val builder: RuntimeShaderBuilder,
   @Suppress("unused") private val effect: RuntimeEffect,
-)
+) {
+
+  /**
+   * Overlay shader from the previous [asShaderBrush] call. It is closed one call late, not at the end
+   * of the call that made it: the compose `Paint` refs the native shader (sk_sp) synchronously during
+   * the draw that consumes this brush, so by the time the *next* draw rebuilds, the prior draw has
+   * flushed and releasing its peer cannot use-after-free.
+   */
+  private var overlayShader: SkShader? = null
+
+  /** Last texture child + the (bitmap identity, tileMode) it was built for, to skip rebuilds. */
+  private var textureImage: Image? = null
+  private var textureShader: SkShader? = null
+  private var textureKey: TextureKey? = null
+
+  fun swapOverlayShader(next: SkShader): SkShader {
+    overlayShader?.close()
+    overlayShader = next
+    return next
+  }
+
+  /** Returns the child shader for [img]/[tileMode], reusing the last one when the key is unchanged. */
+  fun textureChild(img: ImageBitmap, tileMode: TileMode): SkShader {
+    val bitmap = img.asSkiaBitmap()
+    // Key on generationId, not just identity: the same ImageBitmap mutated in place bumps the
+    // generationId, so a stale Image/shader is not reused.
+    val key = TextureKey(img, bitmap.generationId, tileMode)
+    textureShader?.let { if (key == textureKey) return it }
+    val tile = tileMode.toSkiaFilterTileMode()
+    val image = Image.makeFromBitmap(bitmap)
+    val shader = image.makeShader(tile, tile, null)
+    textureShader?.close()
+    textureImage?.close()
+    textureShader = shader
+    textureImage = image
+    textureKey = key
+    return shader
+  }
+}
+
+private data class TextureKey(val image: ImageBitmap, val generationId: Int, val tileMode: TileMode)
 
 /**
  * Compiles [compiled] into a skiko [RuntimeEffect] + [RuntimeShaderBuilder]. Skia is always present,
@@ -50,7 +98,7 @@ internal actual fun createBackendProgram(compiled: CompiledProgram): MirageBacke
   return MirageBackendProgram(RuntimeShaderBuilder(effect), effect)
 }
 
-internal actual fun MirageBackendProgram.uniformSink(): UniformSink = SkikoUniformSink(builder)
+internal actual fun MirageBackendProgram.uniformSink(): UniformSink = SkikoUniformSink(this)
 
 /**
  * makeRuntimeShader with input = null feeds the layer's own content as the `content` child, matching
@@ -66,12 +114,15 @@ internal actual fun MirageBackendProgram.asContentRenderEffect(): RenderEffect =
 
 /**
  * Skia bakes uniforms into the Shader at makeShader() time, so this rebuilds from the builder's
- * current uniforms each call - the node calls it after writing the per-draw values.
+ * current uniforms each call - the node calls it after writing the per-draw values. [asComposeShader]
+ * only wraps the same skia peer (no ref/copy), so the program owns and closes it (one call late).
  */
 internal actual fun MirageBackendProgram.asShaderBrush(): ShaderBrush =
-  ShaderBrush(builder.makeShader().asComposeShader())
+  ShaderBrush(swapOverlayShader(builder.makeShader()).asComposeShader())
 
-private class SkikoUniformSink(private val builder: RuntimeShaderBuilder) : UniformSink {
+private class SkikoUniformSink(private val program: MirageBackendProgram) : UniformSink {
+
+  private val builder: RuntimeShaderBuilder get() = program.builder
 
   override fun float(name: String, v: Float): Unit = builder.uniform(name, v)
 
@@ -102,14 +153,13 @@ private class SkikoUniformSink(private val builder: RuntimeShaderBuilder) : Unif
   }
 
   /**
-   * Bind an image as a child shader. The compose->skia bitmap bridge is public (asSkiaBitmap); the
-   * Compose->skia TileMode map is not exported from compose-ui, so it is inlined below.
+   * Bind an image as a child shader, reusing the last-built child when the same bitmap/tiling is
+   * re-bound instead of decoding a fresh `Image`+`Shader` every draw. The compose->skia bitmap bridge
+   * is public (asSkiaBitmap); the Compose->skia TileMode map is not exported from compose-ui.
    */
   override fun texture(name: String, img: ImageBitmap?, tileMode: TileMode) {
     if (img == null) return
-    val tile = tileMode.toSkiaFilterTileMode()
-    val shader = Image.makeFromBitmap(img.asSkiaBitmap()).makeShader(tile, tile, null)
-    builder.child(name, shader)
+    builder.child(name, program.textureChild(img, tileMode))
   }
 }
 


### PR DESCRIPTION
## Problem

On skiko, the Mirage backend allocated native skia peers every draw and left them for the finalizer:

- `asShaderBrush()` called `builder.makeShader()` on every overlay draw — a fresh native `Shader` each time. The bundled `MirageOptics.Foil` preset reads `mirageTime`, so an `Auto` clock re-draws it at 60–120fps, piling up shaders until GC.
- `texture()` built a new `Image` + `Shader` on every bind (latent — only custom optics declare a texture uniform).

The Android backend reuses one persistent `RuntimeShader` and allocates nothing per draw; this restores that on skiko.

## Fix

Hold the per-draw peers on `MirageBackendProgram` and close each when it's replaced.

**Shader ownership was verified against skiko 0.9.37.3 / Compose 1.11.1 sources before closing anything:** `asComposeShader()` is a pure wrapper (`Shader(internalSkiaShader = this)`, no ref/copy), and at draw time `SkPaint::setShader` takes its own native `sk_sp` ref. So closing the Kotlin peer never frees a shader the paint still holds.

- **Shader**: `swapOverlayShader` closes the *previous* frame's shader just before building the next. Closing one call late (not at the end of the call that built it) means the consuming draw has already flushed and taken its native ref, so there's no use-after-free. The returned shader carries the same baked uniforms, so pixels are unchanged.
- **Texture**: memoized on `(ImageBitmap identity, Skia generationId, TileMode)` — the same image/tiling reuses the child instead of re-decoding; a changed key (including an in-place pixel mutation, which bumps `generationId`) closes the old `Image`+`Shader` first.

`MirageProgramCache` is unbounded (one program per kernel source, process-lifetime), so the final peer stays until exit — only the per-frame churn is removed. `asContentRenderEffect` (the per-draw `ImageFilter`) is out of scope.

## Verification

`:cloudy:compileKotlinDesktop`, `:cloudy:compileKotlinMacosArm64`, `:cloudy:spotlessCheck`, and `:cloudy:desktopTest` all pass (no double-free crash).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved rendering efficiency by reusing native shader and texture resources instead of recreating them every draw.
  * Added overlay shader swapping so new overlay shaders remain active while the previous one is retired after the next draw.
  * Introduced a cached “child texture” shader reuse path for the same bitmap and tile mode, reducing per-call setup and keeping rendering consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->