### PR TITLE
docs(cloudy): clarify per-draw ImageFilter reclamation and compile-fail contract in LiquidGlass.skiko

### DIFF
--- a/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/LiquidGlass.skiko.kt
+++ b/cloudy/src/skikoMain/kotlin/com/skydoves/cloudy/LiquidGlass.skiko.kt
@@ -142,6 +142,10 @@ private fun Modifier.liquidGlassImpl(
   }
 
   // Cache the RuntimeEffect + RuntimeShaderBuilder across recompositions.
+  // Contract: a shader that fails to compile degrades gracefully (glass silently absent) rather
+  // than crashing the host — the shipped SKSL is known-good so this never fires in practice.
+  // Note: this is the inverse of MirageBackendProgram.skiko, which lets makeForShader throw
+  // (fail-fast) since a Mirage program is user-authored and a compile error is a caller bug.
   val shaderBuilder = remember {
     try {
       val effect = RuntimeEffect.makeForShader(LiquidGlassShaderSource.SKSL)
@@ -189,6 +193,10 @@ private fun Modifier.liquidGlassImpl(
       shaderBuilder.uniform("specPoolGain", tuning.poolGain)
 
       // "content" binds to the underlying content (null input = source content).
+      // A fresh ImageFilter per draw is inherent to skiko's RenderEffect model: the layer's
+      // renderEffect setter neither reuses nor closes the prior filter, so we cannot close ours
+      // (the layer draws it after this block). skiko reclaims the orphaned native filter via its
+      // phantom-reference cleaner thread — a cost of the model, not a leak.
       val imageFilter = ImageFilter.makeRuntimeShader(
         runtimeShaderBuilder = shaderBuilder,
         shaderName = "content",


### PR DESCRIPTION
Documentation-only follow-up from a skiko audit of `LiquidGlass.skiko.kt`. Two audit items there turned out to be inherent costs, not fixable defects — this records why, so they aren't "fixed" into a regression later.

## Per-draw ImageFilter (not a leak)

`ImageFilter.makeRuntimeShader` runs every draw. Checked against skiko 0.9.37.3: `ImageFilter` is closeable, but `SkiaGraphicsLayer.renderEffect`'s setter neither reuses nor closes the prior filter, and our `graphicsLayer{}` block has no handle to the previous frame's filter (and closing the current one would break the draw that follows the block). skiko reclaims the orphaned native filter via its phantom-reference cleaner thread, so this is a cost of the RenderEffect model, not a leak. Documented in place.

## Compile-fail contract

`LiquidGlass.skiko` catches a shader compile failure and degrades gracefully (glass silently absent), which is the right contract for a visual Modifier extension — but the silent drop was undocumented. This is the inverse of `MirageBackendProgram.skiko`, which lets `makeForShader` throw (fail-fast), since a Mirage program is user-authored and a compile error is a caller bug. Both contracts are now stated in the code.

The uniform-push-per-draw item was left as-is: the SKSL declares every uniform without a `layout` default, so unset uniforms throw, and the ImageFilter rebuilds each draw anyway — gating individual `uniform()` calls buys nothing. The existing comment already covers it.

## Verification

`:cloudy:compileKotlinDesktop`, `:cloudy:spotlessCheck`, `:cloudy:desktopTest` pass. No behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added clarifying comments about shader compilation failures and the graceful fallback behavior (the glass effect is omitted instead of crashing).
  * Documented rendering lifecycle expectations for per-draw RenderEffect `ImageFilter` creation and how cleanup is handled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->