### PR TITLE
fix(cloudy): write fixed tilt light with LaunchedEffect instead of SideEffect

### DIFF
--- a/cloudy/src/desktopMain/kotlin/com/skydoves/cloudy/GyroLight.desktop.kt
+++ b/cloudy/src/desktopMain/kotlin/com/skydoves/cloudy/GyroLight.desktop.kt
@@ -16,8 +16,8 @@
 package com.skydoves.cloudy
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.geometry.Offset
 
 /** Desktop (JVM) has no motion sensor: the light stays fixed at [base]. */
@@ -29,5 +29,5 @@ internal actual fun rememberTiltSource(
   tiltGain: Float,
   out: MutableState<Offset>,
 ) {
-  SideEffect { out.value = base }
+  LaunchedEffect(base) { out.value = base }
 }

--- a/cloudy/src/macosMain/kotlin/com/skydoves/cloudy/GyroLight.macos.kt
+++ b/cloudy/src/macosMain/kotlin/com/skydoves/cloudy/GyroLight.macos.kt
@@ -16,8 +16,8 @@
 package com.skydoves.cloudy
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.geometry.Offset
 
 /** macOS has no device-tilt sensor: the light stays fixed at [base]. */
@@ -29,5 +29,5 @@ internal actual fun rememberTiltSource(
   tiltGain: Float,
   out: MutableState<Offset>,
 ) {
-  SideEffect { out.value = base }
+  LaunchedEffect(base) { out.value = base }
 }

--- a/cloudy/src/wasmJsMain/kotlin/com/skydoves/cloudy/GyroLight.wasmJs.kt
+++ b/cloudy/src/wasmJsMain/kotlin/com/skydoves/cloudy/GyroLight.wasmJs.kt
@@ -16,8 +16,8 @@
 package com.skydoves.cloudy
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.geometry.Offset
 
 /** Web (wasmJs) does not wire device motion here: the light stays fixed at [base]. */
@@ -29,5 +29,5 @@ internal actual fun rememberTiltSource(
   tiltGain: Float,
   out: MutableState<Offset>,
 ) {
-  SideEffect { out.value = base }
+  LaunchedEffect(base) { out.value = base }
 }


### PR DESCRIPTION
## Problem

The desktop / macOS / wasmJs `rememberTiltSource` actuals (no motion sensor — the light stays fixed at `base`) wrote the value with `SideEffect { out.value = base }`, which runs on every successful recomposition.

## Fix

```kotlin
LaunchedEffect(base) { out.value = base }
```

`out` is created as `remember { mutableStateOf(base) }` in common code, so it already starts at `base`; the write only needs to repeat when `base` changes. `LaunchedEffect(base)` does exactly that (and the initial composition), instead of re-writing the same value every recomposition.

## Verification

`:cloudy:compileKotlinDesktop` and `:cloudy:spotlessCheck` pass.
