### PR TITLE
fix(cloudy): auto-frame the mirage lens instead of pinning it at the origin

### DIFF
--- a/app/src/commonMain/kotlin/demo/screen/MirageSkyScreen.kt
+++ b/app/src/commonMain/kotlin/demo/screen/MirageSkyScreen.kt
@@ -91,10 +91,14 @@ fun MirageSkyScreen(onBackClick: () -> Unit) {
   var effectEnabled by remember { mutableStateOf(true) }
   var duotone: DuotonePreset by remember { mutableStateOf(DuotonePreset.Indigo) }
   var amount by remember { mutableStateOf(1f) }
+  var chromatic by remember { mutableStateOf(ChromaticControls()) }
+  var specular by remember { mutableStateOf(SpecularControls()) }
 
   val toneShadow = duotone.shadow
   val toneHighlight = duotone.highlight
   val toneAmount = amount
+  val chromaticControls = chromatic
+  val specularControls = specular
 
   CollapsingAppBarScaffold(
     title = "Mirage (sky backdrop)",
@@ -123,7 +127,15 @@ fun MirageSkyScreen(onBackClick: () -> Unit) {
               .height(180.dp)
               .clip(RoundedCornerShape(Dimens.cardCornerRadius))
               .mirage(sky = sky, enabled = effectEnabled) {
-                with(pick) { declare(toneShadow, toneHighlight, toneAmount) }
+                with(pick) {
+                  declare(
+                    toneShadow,
+                    toneHighlight,
+                    toneAmount,
+                    chromaticControls,
+                    specularControls,
+                  )
+                }
               }
               .border(
                 width = 2.dp,
@@ -154,6 +166,10 @@ fun MirageSkyScreen(onBackClick: () -> Unit) {
           onDuotoneChange = { duotone = it },
           amount = amount,
           onAmountChange = { amount = it },
+          chromatic = chromatic,
+          onChromaticChange = { chromatic = it },
+          specular = specular,
+          onSpecularChange = { specular = it },
         )
       }
     }
@@ -163,19 +179,58 @@ fun MirageSkyScreen(onBackClick: () -> Unit) {
 private const val BACKDROP_ITEM_COUNT = 40
 
 /**
+ * Per-draw values the Chromatic pick feeds its uniforms, snapshotted outside the modifier lambda like
+ * the tone controls. Defaults match [MirageOptics.Chromatic]'s own defaults, so the sliders start at
+ * the preset look. `poolFrac` scales the light pool off the lens' half-min dimension — on a wide card
+ * the default 0.7 reads as a small patch, so the slider range goes well past it.
+ */
+private data class ChromaticControls(
+  val intensity: Float = 0.6f,
+  val modulate: Float = 1f,
+  val poolFrac: Float = 0.7f,
+)
+
+/**
+ * Per-draw values the Specular pick feeds its uniforms; defaults match [MirageOptics.Specular]'s
+ * GlowTuning schema. The glass model keeps refraction at the rim by design (a flat interior bends
+ * nothing), so these drive the *face* terms: `rimMix` crossfades body pool (0) vs rim glint (1) and
+ * `poolFrac` spreads the moving hotspot the same way the chromatic pool slider does.
+ */
+private data class SpecularControls(
+  val strength: Float = 0.7f,
+  val rimMix: Float = 0.4f,
+  val poolFrac: Float = 0.7f,
+)
+
+/**
  * A backdrop look the card can apply. Each keeps a typed optic so its `declare` sets that optic's own
  * uniforms with no cast, mirroring the self-content [MirageScreen]'s pick model.
  */
 private sealed interface BackdropPick {
   val label: String
 
-  /** Declares this pick's filter stage into the plan; only [Duotone] reads the tone/amount controls. */
-  fun MirageScope.declare(shadow: Color, highlight: Color, amount: Float)
+  /**
+   * Declares this pick's filter stage into the plan; [Duotone] reads the tone/amount controls,
+   * [Chromatic] the chromatic sliders, and [Specular] the specular sliders.
+   */
+  fun MirageScope.declare(
+    shadow: Color,
+    highlight: Color,
+    amount: Float,
+    chromatic: ChromaticControls,
+    specular: SpecularControls,
+  )
 
   /** The headline colorize material: maps backdrop luminance onto a shadow -> highlight duotone. */
   data object Duotone : BackdropPick {
     override val label = "Duotone"
-    override fun MirageScope.declare(shadow: Color, highlight: Color, amount: Float) {
+    override fun MirageScope.declare(
+      shadow: Color,
+      highlight: Color,
+      amount: Float,
+      chromatic: ChromaticControls,
+      specular: SpecularControls,
+    ) {
       filter(MirageOptics.Duotone) {
         shadow(shadow)
         highlight(highlight)
@@ -187,16 +242,36 @@ private sealed interface BackdropPick {
   /** A content-sampling thin-film look, proving the overload carries any filter optic over a backdrop. */
   data object Chromatic : BackdropPick {
     override val label = "Chromatic"
-    override fun MirageScope.declare(shadow: Color, highlight: Color, amount: Float) {
-      filter(MirageOptics.Chromatic)
+    override fun MirageScope.declare(
+      shadow: Color,
+      highlight: Color,
+      amount: Float,
+      chromatic: ChromaticControls,
+      specular: SpecularControls,
+    ) {
+      filter(MirageOptics.Chromatic) {
+        chromaticIntensity(chromatic.intensity)
+        chromaticModulate(chromatic.modulate)
+        chromaticPoolFrac(chromatic.poolFrac)
+      }
     }
   }
 
   /** The liquid-glass specular glint, also content-sampling, over the backdrop. */
   data object Specular : BackdropPick {
     override val label = "Specular"
-    override fun MirageScope.declare(shadow: Color, highlight: Color, amount: Float) {
-      filter(MirageOptics.Specular)
+    override fun MirageScope.declare(
+      shadow: Color,
+      highlight: Color,
+      amount: Float,
+      chromatic: ChromaticControls,
+      specular: SpecularControls,
+    ) {
+      filter(MirageOptics.Specular) {
+        specStrength(specular.strength)
+        specRimMix(specular.rimMix)
+        specPoolFrac(specular.poolFrac)
+      }
     }
   }
 }
@@ -222,6 +297,10 @@ private fun ControlsCard(
   onDuotoneChange: (DuotonePreset) -> Unit,
   amount: Float,
   onAmountChange: (Float) -> Unit,
+  chromatic: ChromaticControls,
+  onChromaticChange: (ChromaticControls) -> Unit,
+  specular: SpecularControls,
+  onSpecularChange: (SpecularControls) -> Unit,
 ) {
   Card(
     modifier = modifier.fillMaxWidth(),
@@ -268,6 +347,61 @@ private fun ControlsCard(
         Slider(value = amount, onValueChange = onAmountChange, valueRange = 0f..1f)
       }
 
+      if (pick == BackdropPick.Chromatic) {
+        Spacer(modifier = Modifier.height(12.dp))
+        SectionLabel("Intensity ${chromatic.intensity.asLabel()}")
+        Slider(
+          value = chromatic.intensity,
+          onValueChange = { onChromaticChange(chromatic.copy(intensity = it)) },
+          valueRange = 0f..1f,
+        )
+
+        // 0 = uniform film over the whole card, 1 = rainbow confined to the light pool.
+        SectionLabel("Pool follow ${chromatic.modulate.asLabel()}")
+        Slider(
+          value = chromatic.modulate,
+          onValueChange = { onChromaticChange(chromatic.copy(modulate = it)) },
+          valueRange = 0f..1f,
+        )
+
+        // Pool radius as a fraction of the lens' half-min dimension; past ~1.5 the pool spans a
+        // wide card whose short side would otherwise confine it to a small patch.
+        SectionLabel("Pool size ${chromatic.poolFrac.asLabel()}")
+        Slider(
+          value = chromatic.poolFrac,
+          onValueChange = { onChromaticChange(chromatic.copy(poolFrac = it)) },
+          valueRange = 0.3f..2.5f,
+        )
+      }
+
+      if (pick == BackdropPick.Specular) {
+        Spacer(modifier = Modifier.height(12.dp))
+        SectionLabel("Strength ${specular.strength.asLabel()}")
+        Slider(
+          value = specular.strength,
+          onValueChange = { onSpecularChange(specular.copy(strength = it)) },
+          valueRange = 0f..1f,
+        )
+
+        // 0 = face terms only (moving pool + body sheen), 1 = the thin rim glint only — isolates
+        // which term is on screen when judging the effect.
+        SectionLabel("Rim mix ${specular.rimMix.asLabel()}")
+        Slider(
+          value = specular.rimMix,
+          onValueChange = { onSpecularChange(specular.copy(rimMix = it)) },
+          valueRange = 0f..1f,
+        )
+
+        // Pool radius as a fraction of the lens' half-min dimension; past ~1.5 the pool spans a
+        // wide card whose short side would otherwise confine it to a small patch.
+        SectionLabel("Pool size ${specular.poolFrac.asLabel()}")
+        Slider(
+          value = specular.poolFrac,
+          onValueChange = { onSpecularChange(specular.copy(poolFrac = it)) },
+          valueRange = 0.3f..2.5f,
+        )
+      }
+
       Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
         Text(
           text = "Effect enabled",
@@ -280,6 +414,9 @@ private fun ControlsCard(
     }
   }
 }
+
+/** Two-decimal slider value label; KMP-safe (no JVM String.format in commonMain). */
+private fun Float.asLabel(): String = ((this * 100).toInt() / 100f).toString()
 
 @Composable
 private fun SectionLabel(text: String) {

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/MirageOptics.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/MirageOptics.kt
@@ -38,11 +38,14 @@ import com.skydoves.cloudy.internal.SPECULAR_KERNEL_SKSL
  *
  * Each value is a process-wide singleton, so applying one in a plan never reallocates the optic.
  *
- * Shared lens geometry ([MirageLensParams.lensCenter] / [lensSize][MirageLensParams.lensSize] /
- * [cornerRadius][MirageLensParams.cornerRadius]) and the specular light ([MirageLensParams.iLight])
- * default to the built-in liquid-glass framing, so a preset applied with no `params` block reproduces
- * that built-in look. Override them per draw from a `filter { … }` / `overlay { … }` block (e.g.
- * feed `iLight` a `rememberGyroLightSource` direction for motion lighting).
+ * Shared lens geometry ([MirageLensParams.lensCenter] / [lensSize][MirageLensParams.lensSize])
+ * defaults to **auto framing**: left unspecified, it resolves at bind time to the node's center and
+ * full size, so a preset applied with no `params` block covers the node it decorates — content or
+ * backdrop — instead of pinning a fixed lens at the origin. [cornerRadius]
+ * [MirageLensParams.cornerRadius] and the specular light ([MirageLensParams.iLight]) keep the built-in
+ * liquid-glass values. Override any of them per draw from a `filter { … }` / `overlay { … }` block
+ * (e.g. a pointer-tracked `lensCenter` with a fixed `lensSize` for an interactive lens, or feed
+ * `iLight` a `rememberGyroLightSource` direction for motion lighting).
  */
 @ExperimentalMirage
 public object MirageOptics {
@@ -174,18 +177,25 @@ public object MirageOptics {
 /**
  * Lens-geometry + specular-light uniforms shared by the lens-shaped presets ([MirageOptics.Specular],
  * the thin-film family, [MirageOptics.Foil]). The property names *are* the uniform identifiers the
- * kernels read; defaults mirror the built-in liquid-glass framing.
+ * kernels read.
  *
- * @property lensCenter the lens center in local px. Default [Offset.Zero] (the content origin — an
- *   interactive lens should feed a pointer-tracked value).
- * @property lensSize the lens size in px. Default `350 x 350` (the liquid-glass default).
+ * Lens framing defaults to **auto**: an [Offset.Unspecified] [lensCenter] / [Size.Unspecified]
+ * [lensSize] resolves at bind time to the node's center / full size, so a bare preset frames the node
+ * it is attached to. A fixed default would instead pin the lens at the content origin, leaving
+ * everything outside it as the kernels' `content.eval(xy)` passthrough — on a backdrop card that reads
+ * as "the effect draws behind the content".
+ *
+ * @property lensCenter the lens center in local px. Default [Offset.Unspecified] (auto: the node
+ *   center at draw time — an interactive lens should feed a pointer-tracked value).
+ * @property lensSize the lens size in px. Default [Size.Unspecified] (auto: the node size, so the
+ *   lens covers the node full-bleed).
  * @property cornerRadius the lens corner radius in px. Default `50`.
  * @property iLight the specular light direction (unnormalized). Default `(-1, -1)`.
  */
 @ExperimentalMirage
 public abstract class MirageLensParams : MirageParams() {
-  public val lensCenter: UOffset by uniform(Offset.Zero)
-  public val lensSize: USize by uniform(Size(350f, 350f))
+  public val lensCenter: UOffset by uniform(Offset.Unspecified)
+  public val lensSize: USize by uniform(Size.Unspecified)
   public val cornerRadius: UFloat by uniform(50f)
   public val iLight: UOffset by uniform(Offset(-1f, -1f))
 }

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/MirageOptics.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/MirageOptics.kt
@@ -227,6 +227,13 @@ public class SpecularParams : MirageLensParams() {
  *
  * `chromaticKRGB` is declared `float4` because the shader reads `.xyz` and the backends require a
  * write arity that matches the declared size; the `.w` component is unused.
+ *
+ * `chromaticPoolFrac` scales the light focal pool radius as a fraction of the lens' half-min
+ * dimension (the same basis as [SpecularParams.specPoolFrac]). The default `0.7` matches the
+ * specular pool; raise it (e.g. `1.5`–`2`) so the pool spans a wide lens whose short side would
+ * otherwise confine the rainbow to a small patch. It shapes the pool that
+ * [chromaticModulate][ChromaticParams.chromaticModulate] blends in, so it has no effect at
+ * `modulate = 0`.
  */
 @ExperimentalMirage
 public class ChromaticParams internal constructor(
@@ -245,6 +252,7 @@ public class ChromaticParams internal constructor(
   public val chromaticWashout: UFloat by uniform(washout)
   public val chromaticModulate: UFloat by uniform(modulate)
   public val chromaticRimBoost: UFloat by uniform(rimBoost)
+  public val chromaticPoolFrac: UFloat by uniform(0.7f)
 }
 
 /** Params for [MirageOptics.Foil] — the 5 foil/sparkle uniforms plus the shared lens framing. */

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/internal/MirageKernels.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/internal/MirageKernels.kt
@@ -403,7 +403,7 @@ half4 main(float2 xy) {
 
     // --- focal-pool modulation: drive rainbow strength by the raw pool^2 (mirrors specular) ---
     float2 cFocal  = cLightVec * (minHalf * 0.55);              // specFocalK default
-    float  cPoolR  = max(minHalf * 0.7, 1.0);                   // specPoolFrac default; zero-width guard
+    float  cPoolR  = max(minHalf * chromaticPoolFrac, 1.0);     // pool radius scale; zero-width guard
     float  cPool   = 1.0 - smoothstep(0.0, cPoolR, length(p - cFocal)); // edge0<edge1
     float  poolNorm = clamp(cPool * cPool, 0.0, 1.0);
     float  chroma  = chromaticIntensity * mix(1.0, poolNorm, clamp(chromaticModulate, 0.0, 1.0));
@@ -488,7 +488,7 @@ half4 main(float2 xy) {
 
     // --- focal-pool modulation: drive rainbow strength by the raw pool^2 (mirrors specular) ---
     float2 cFocal  = cLightVec * (minHalf * 0.55);              // specFocalK default
-    float  cPoolR  = max(minHalf * 0.7, 1.0);                   // specPoolFrac default; zero-width guard
+    float  cPoolR  = max(minHalf * chromaticPoolFrac, 1.0);     // pool radius scale; zero-width guard
     float  cPool   = 1.0 - smoothstep(0.0, cPoolR, length(p - cFocal)); // edge0<edge1
     float  poolNorm = clamp(cPool * cPool, 0.0, 1.0);
     float  chroma  = chromaticIntensity * mix(1.0, poolNorm, clamp(chromaticModulate, 0.0, 1.0));

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/internal/MirageUniformBinding.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/internal/MirageUniformBinding.kt
@@ -19,9 +19,11 @@ package com.skydoves.cloudy.internal
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.isUnspecified
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import com.skydoves.cloudy.ExperimentalMirage
+import com.skydoves.cloudy.MirageLensParams
 import com.skydoves.cloudy.MirageParams
 import com.skydoves.cloudy.UColor
 import com.skydoves.cloudy.UFloat
@@ -50,6 +52,11 @@ internal const val STD_DENSITY = "mirageDensity"
  * the standard uniforms + every schema slot through the sink in declaration order. A pure function of
  * (cached, params, block, w, h, density, time) — no clock, no lifecycle — so both mirage nodes share
  * it as the `bind` closure they hand to [MirageFilterChain].
+ *
+ * The shared [MirageLensParams] framing auto-resolves here: a `lensCenter` / `lensSize` still
+ * unspecified after [paramsBlock] binds as the node's center / full size (the only place both the
+ * final values and the canvas size are in scope). Only those two handles get the substitution — every
+ * other Offset/Size uniform must be specified.
  */
 internal fun bindUniforms(
   cached: CachedProgram,
@@ -74,6 +81,10 @@ internal fun bindUniforms(
   if (compiled.usesTime) sink.float(STD_TIME, time)
   if (compiled.usesDensity) sink.float(STD_DENSITY, density)
 
+  // Non-null only for lens-shaped optics; identity-compared below against this specific instance's
+  // lensCenter/lensSize handles.
+  val lensParams = params as? MirageLensParams
+
   // Schema uniforms in declaration (= bind) order: the params' live handles and the compiled schema
   // entries share the same slot index, so entries[handle.slot] names each write.
   val entries = cached.compiled.schema.entries
@@ -81,13 +92,37 @@ internal fun bindUniforms(
     val name = entries[handle.slot].name
     when (handle) {
       is UFloat -> sink.float(name, handle.value)
-      is UOffset -> sink.float2(name, handle.value.x, handle.value.y)
-      is USize -> sink.float2(name, handle.value.width, handle.value.height)
+
+      is UOffset -> {
+        // Identity (not type) match: an unrelated Offset uniform on a custom optic must never fall
+        // into the auto-frame substitution just because it happens to be left Unspecified too.
+        val value = handle.value
+        if (value.isUnspecified && handle === lensParams?.lensCenter) {
+          sink.float2(name, width * 0.5f, height * 0.5f)
+        } else {
+          sink.float2(name, value.x, value.y)
+        }
+      }
+
+      is USize -> {
+        val value = handle.value
+        if (value.isUnspecified && handle === lensParams?.lensSize) {
+          sink.float2(name, width, height)
+        } else {
+          sink.float2(name, value.width, value.height)
+        }
+      }
+
       is UInt1 -> sink.int(name, handle.value)
+
       is UVec3 -> sink.floatArray(name, handle.value)
+
       is UVec4 -> sink.floatArray(name, handle.value)
+
       is UFloatArray -> sink.floatArray(name, handle.value)
+
       is UColor -> sink.color(name, handle.value)
+
       is UTexture -> sink.texture(name, handle.value, handle.tileMode)
     }
   }

--- a/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/MiragePresetTest.kt
+++ b/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/MiragePresetTest.kt
@@ -90,6 +90,8 @@ internal class MiragePresetTest :
         params.chromaticWashout.value.shouldBe(washout)
         params.chromaticModulate.value.shouldBe(modulate)
         params.chromaticRimBoost.value.shouldBe(rimBoost)
+        // Not a per-look factory argument: every look shares the specular pool framing (0.7).
+        params.chromaticPoolFrac.value.shouldBe(0.7f)
       }
 
       test("Chromatic equals the factory defaults (no regression)") {

--- a/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/MiragePresetTest.kt
+++ b/cloudy/src/commonTest/kotlin/com/skydoves/cloudy/MiragePresetTest.kt
@@ -35,17 +35,19 @@ import io.kotest.matchers.shouldBe
 internal class MiragePresetTest :
   FunSpec({
 
-    context("shared lens framing defaults (built-in liquid-glass framing)") {
-      // Every lens-shaped preset starts from the same lens framing, so callers can apply it with no
-      // params block and match the built-in look.
+    context("shared lens framing defaults (auto: node-framed at bind time)") {
+      // Every lens-shaped preset starts unframed: Unspecified lens geometry resolves to the node's
+      // center / full size when bound (see bindUniforms), so a bare preset covers the node it is
+      // attached to. A fixed default would pin the lens at the origin and leave the rest of the node
+      // as kernel passthrough. cornerRadius / iLight keep the built-in liquid-glass values.
       fun assertLensDefaults(params: MirageLensParams) {
-        params.lensCenter.value.shouldBe(Offset.Zero)
-        params.lensSize.value.shouldBe(Size(350f, 350f))
+        params.lensCenter.value.shouldBe(Offset.Unspecified)
+        params.lensSize.value.shouldBe(Size.Unspecified)
         params.cornerRadius.value.shouldBe(50f)
         params.iLight.value.shouldBe(Offset(-1f, -1f))
       }
 
-      test("Specular / Chromatic / Foil share the liquid-glass lens defaults") {
+      test("Specular / Chromatic / Foil share the auto lens framing defaults") {
         assertLensDefaults(MirageOptics.Specular.paramsFactory())
         assertLensDefaults(MirageOptics.Chromatic.paramsFactory())
         assertLensDefaults(MirageOptics.Foil.paramsFactory())

--- a/cloudy/src/desktopTest/kotlin/com/skydoves/cloudy/MirageChromaticRasterTest.kt
+++ b/cloudy/src/desktopTest/kotlin/com/skydoves/cloudy/MirageChromaticRasterTest.kt
@@ -94,6 +94,20 @@ internal class MirageChromaticRasterTest :
       meanAbsDiff(auto, originPinned).shouldBeGreaterThan(1.0)
     }
 
+    // chromaticPoolFrac regression: OilSlick-vs-Pearl distinctness above doesn't exercise it (the
+    // chromatic effect differs regardless of pool radius), so this pins that the uniform actually
+    // reaches the shader through the real binder. Chromatic's default modulate is 1, so the pool
+    // fraction shapes the rainbow — a widened pool must change the render.
+    test("chromaticPoolFrac changes the render when the pool modulates the effect") {
+      val size = 512
+      val defaultPool = renderThroughLibraryBinder(MirageOptics.Chromatic, size)
+      val widePool = renderThroughLibraryBinder(MirageOptics.Chromatic, size) {
+        chromaticPoolFrac(1.5f)
+      }
+
+      meanAbsDiff(defaultPool, widePool).shouldBeGreaterThan(1.0)
+    }
+
     // Full-bleed / max-intensity X guard. At cornerRadius 0 + whole-pane lens + chromaticIntensity
     // 1.0, the dominant diagonal structure is the box depth field: `depthIn = -sdf` of a rounded box
     // is the distance to the nearest edge, whose ridge lines lie exactly on the diagonals, so the

--- a/cloudy/src/desktopTest/kotlin/com/skydoves/cloudy/MirageChromaticRasterTest.kt
+++ b/cloudy/src/desktopTest/kotlin/com/skydoves/cloudy/MirageChromaticRasterTest.kt
@@ -26,6 +26,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.doubles.shouldBeGreaterThan
 import io.kotest.matchers.doubles.shouldBeLessThan
 import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import org.jetbrains.skia.Bitmap
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skia.ColorAlphaType
@@ -38,6 +39,7 @@ import org.jetbrains.skia.Shader
 import org.jetbrains.skia.Surface
 import kotlin.math.abs
 import kotlin.math.hypot
+import com.skydoves.cloudy.internal.bindUniforms as bindLibraryUniforms
 
 private const val RASTER = 64
 
@@ -67,6 +69,29 @@ internal class MirageChromaticRasterTest :
       meanAbsDiff(oil, baseline).shouldBeGreaterThan(1.0)
       meanAbsDiff(pearl, baseline).shouldBeGreaterThan(1.0)
       meanAbsDiff(oil, pearl).shouldBeGreaterThan(1.0)
+    }
+
+    // Regression for the origin-pinned lens default. MirageLensParams used to default lensCenter to
+    // Offset.Zero with a fixed 350x350 lensSize, so a bare `filter(Chromatic)` on any node larger than
+    // the lens graded only the origin quadrant and passed the rest through — on a backdrop card the
+    // rainbow showed only in the corner, reading as "chromatic draws behind the content". These renders
+    // go through the REAL library binder (bindUniforms), the exact path both mirage nodes take.
+    test("unset lens framing auto-binds as the full node frame, not an origin-pinned lens") {
+      val size = 512
+      val auto = renderThroughLibraryBinder(MirageOptics.Chromatic, size)
+      val explicitFullBleed = renderThroughLibraryBinder(MirageOptics.Chromatic, size) {
+        lensCenter(Offset(size / 2f, size / 2f))
+        lensSize(Size(size.toFloat(), size.toFloat()))
+      }
+      val originPinned = renderThroughLibraryBinder(MirageOptics.Chromatic, size) {
+        lensCenter(Offset.Zero)
+        lensSize(Size(350f, 350f))
+      }
+
+      // The substitution contract: an unset frame IS the explicit node frame, bit-for-bit.
+      meanAbsDiff(auto, explicitFullBleed).shouldBe(0.0)
+      // And it is no longer the old fixed default that graded only the origin quadrant.
+      meanAbsDiff(auto, originPinned).shouldBeGreaterThan(1.0)
     }
 
     // Full-bleed / max-intensity X guard. At cornerRadius 0 + whole-pane lens + chromaticIntensity
@@ -162,6 +187,34 @@ private fun renderChromatic(optic: CompositeOptic<ChromaticParams>): ByteArray {
   builder.child("content", contentShader())
 
   return rasterize(builder.makeShader())
+}
+
+/**
+ * Renders [optic] over the gradient content through the REAL library binder — reset-to-defaults, the
+ * per-draw [frame] block, then the auto lens-frame substitution — exactly as [com.skydoves.cloudy.
+ * internal.MirageNode] and the backdrop node bind each draw. [frame] left `null` exercises the bare
+ * preset (the auto framing path).
+ */
+@OptIn(ExperimentalMirage::class)
+private fun renderThroughLibraryBinder(
+  optic: CompositeOptic<ChromaticParams>,
+  size: Int,
+  frame: (ChromaticParams.() -> Unit)? = null,
+): ByteArray {
+  val cached = MirageProgramCache.obtain(optic, Dialect.Sksl).shouldNotBeNull()
+  val params = optic.paramsFactory()
+  bindLibraryUniforms(
+    cached = cached,
+    params = params,
+    paramsBlock = frame?.let { block -> { (this as ChromaticParams).block() } },
+    width = size.toFloat(),
+    height = size.toFloat(),
+    density = 1f,
+    time = 0f,
+  )
+  val builder = cached.backend.builder
+  builder.child("content", contentShaderAt(size))
+  return rasterize(builder.makeShader(), size)
 }
 
 /**


### PR DESCRIPTION
## Summary
- `MirageLensParams.lensCenter` / `lensSize` defaulted to `Offset.Zero` / `350x350`, so a bare `filter(Chromatic)` / `filter(Specular)` on the mirage backdrop demo graded only a small origin-pinned quadrant of the node and passed the rest through as raw content — on a backdrop card the rainbow only showed in the gaps between list items, reading as "drawn behind the content".
- Lens framing now defaults to `Offset.Unspecified` / `Size.Unspecified` and `bindUniforms` resolves an unset frame to the node's center / full size at draw time, so a bare preset covers whatever node it's attached to.
- Added `ChromaticParams.chromaticPoolFrac` (default `0.7`, matching the existing hardcoded constant) so the light-pool radius is tunable like specular's `specPoolFrac` — useful on wide nodes where the old fixed radius read as a small patch.
- Extended the Mirage Backdrop demo with sliders (Chromatic: intensity / pool follow / pool size; Specular: strength / rim mix / pool size) to make each term visually verifiable.

## Test plan
- [x] `:cloudy:desktopTest` (new regression: unset lens frame binds bit-identical to the explicit full-bleed frame, and differs from the old origin-pinned default)
- [x] `:cloudy:testAndroidHostTest` (42 tests, Robolectric SDK 36 / JDK 21+)
- [x] `:cloudy:checkKotlinAbi` (no ABI change — `@ExperimentalMirage` API is excluded from the dump)
- [x] `spotlessCheck`
- [x] Manual verification on an API 34 emulator: Chromatic/Specular now frame the full card instead of a corner quadrant; new sliders confirmed on all three optics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added adjustable Chromatic and Specular effect controls (including chromatic/specular intensities, modulation/strength, rim mix, and pool settings).
  * Updated the controls UI with new, conditionally shown slider groups and formatted value labels.
  * Enhanced rendering optics with automatic lens framing when center/size are left unspecified.
  * Made chromatic light-pool sizing tunable via a dedicated pool fraction setting.
* **Bug Fixes**
  * Improved uniform binding so lens framing only auto-resolves when still unspecified after parameter selection, with consistent pool scaling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->