### PR TITLE
feat(demo): enable edge-to-edge with transparent system bars

### DIFF
--- a/app-android/src/main/kotlin/com/skydoves/cloudydemo/MainActivity.kt
+++ b/app-android/src/main/kotlin/com/skydoves/cloudydemo/MainActivity.kt
@@ -18,10 +18,16 @@ package com.skydoves.cloudydemo
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import demo.CloudyDemoApp
 
 class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
+    // Draw behind the transparent system bars so the full-bleed sky background reaches the screen
+    // edges; inner content is inset by WindowInsets.safeDrawing in CollapsingAppBarScaffold. Default
+    // SystemBarStyle.auto flips bar-icon contrast with the system light/dark theme, matching
+    // PosterTheme's isSystemInDarkTheme() palette.
+    enableEdgeToEdge()
     super.onCreate(savedInstanceState)
 
     setContent { CloudyDemoApp() }

--- a/app-android/src/main/res/values-night/themes.xml
+++ b/app-android/src/main/res/values-night/themes.xml
@@ -9,8 +9,10 @@
         <item name="colorSecondary">@color/teal_200</item>
         <item name="colorSecondaryVariant">@color/teal_200</item>
         <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
+        <!-- Transparent system bars: enableEdgeToEdge() draws the full-bleed sky behind them and owns
+             bar-icon contrast, so no opaque theme scrim should fight it (pre-API 35 honors these). -->
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
         <!-- Customize your theme here. -->
     </style>
 </resources>

--- a/app-android/src/main/res/values/themes.xml
+++ b/app-android/src/main/res/values/themes.xml
@@ -9,8 +9,10 @@
         <item name="colorSecondary">@color/teal_200</item>
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
+        <!-- Transparent system bars: enableEdgeToEdge() draws the full-bleed sky behind them and owns
+             bar-icon contrast, so no opaque theme scrim should fight it (pre-API 35 honors these). -->
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
         <!-- Customize your theme here. -->
     </style>
 </resources>


### PR DESCRIPTION
## Summary

The demo app ran without edge-to-edge, so the system status bar stayed opaque (`?attr/colorPrimaryVariant`, purple) and sat as a hard bar above the full-bleed sky background. This enables edge-to-edge so the sky reaches the screen edges and the bars blend in.

## Changes

- `MainActivity`: call `enableEdgeToEdge()` before `super.onCreate()`.
- `values/themes.xml` and `values-night/themes.xml`: set `statusBarColor` and `navigationBarColor` to transparent so no opaque theme scrim fights the edge-to-edge bars (pre-API 35 still honors these attributes).

The Compose side was already inset-safe: `CollapsingAppBarScaffold` paints `skyBrush` full-bleed on the outer `Box` and insets only the inner `Scaffold` with `WindowInsets.safeDrawing`. So the background extends behind the bars while titles and the back arrow stay clear of them. Status-bar icon contrast follows `SystemBarStyle.auto`, which tracks the same `isSystemInDarkTheme()` signal `PosterTheme` uses.

## Testing

Built `:app-android:assembleDebug`, installed on an API 34 emulator, and opened the Mirage and Mirage-sky demo screens. The status bar is transparent over the sky gradient with dark icons on the light background; content is inset correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled edge-to-edge display on Android, allowing the app’s background to extend behind the system bars.
  * Updated light and dark themes with transparent status and navigation bars for a more immersive full-screen appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->