### PR TITLE
Prepare for release 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If you're using Version Catalog, you can configure the dependency by adding it t
 ```toml
 [versions]
 #...
-cloudy = "0.6.1"
+cloudy = "0.7.0"
 
 [libraries]
 #...
@@ -73,7 +73,7 @@ Add the dependency below to your **module**'s `build.gradle.kts` file:
 
 ```gradle
 dependencies {
-    implementation("com.github.skydoves:cloudy:0.6.1")
+    implementation("com.github.skydoves:cloudy:0.7.0")
     
     // if you're using Version Catalog
     implementation(libs.compose.cloudy)

--- a/buildSrc/src/main/kotlin/com/skydoves/cloudy/Configuration.kt
+++ b/buildSrc/src/main/kotlin/com/skydoves/cloudy/Configuration.kt
@@ -5,10 +5,10 @@ object Configuration {
   const val targetSdk = 37
   const val minSdk = 23
   const val majorVersion = 0
-  const val minorVersion = 6
-  const val patchVersion = 1
+  const val minorVersion = 7
+  const val patchVersion = 0
   const val versionName = "$majorVersion.$minorVersion.$patchVersion"
-  const val versionCode = 16
+  const val versionCode = 17
   const val snapshotVersionName = "$majorVersion.$minorVersion.${patchVersion + 1}-SNAPSHOT"
   const val artifactGroup = "com.github.skydoves"
 }


### PR DESCRIPTION
Prepare for release 0.7.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Cloudy dependency examples to version 0.7.0.

* **Release**
  * Published version 0.7.0 with an updated internal build number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->