### PR TITLE
Fix RenderThread crash when capturing a blurred backdrop (captureToImage / PixelCopy)

### DIFF
--- a/cloudy/build.gradle.kts
+++ b/cloudy/build.gradle.kts
@@ -230,6 +230,9 @@ kotlin {
       implementation(libs.androidx.compose.runtime)
       implementation(libs.androidx.compose.ui.test)
       implementation(libs.androidx.compose.ui.test.junit4)
+      // Merges the empty ComponentActivity into the test manifest that createComposeRule() launches;
+      // without it the instrumented screenshot/regression specs fail with "Unable to resolve activity".
+      implementation(libs.androidx.compose.ui.test.manifest)
       implementation(libs.androidx.test.runner)
       implementation(libs.androidx.test.junit)
       implementation(libs.junit4)

--- a/cloudy/src/androidDeviceTest/kotlin/com/skydoves/cloudy/MainPixelCopyCrashReproTest.kt
+++ b/cloudy/src/androidDeviceTest/kotlin/com/skydoves/cloudy/MainPixelCopyCrashReproTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.cloudy
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Regression coverage for the backdrop `captureToImage()` / `PixelCopy` crash: capturing a
+ * `Modifier.sky` tree with a descendant `Modifier.cloudy(sky = ...)` backdrop node used to SIGSEGV the
+ * RenderThread with an unbounded `prepareTreeImpl` recursion (a cyclic RenderNode graph formed by
+ * `drawLayer(sky.backgroundLayer)`). Each variant below reproduced the crash on unmodified `main`; a
+ * green run of this class is the proof `BackdropClearBlurMachine`'s rasterized-snapshot fix breaks the
+ * cycle.
+ */
+internal class MainPixelCopyCrashReproTest {
+
+  @get:Rule
+  val composeTestRule = createComposeRule()
+
+  private var radiusState by mutableStateOf(0)
+  private var tintState by mutableStateOf(Color.Transparent)
+
+  @Composable
+  private fun Fixture() {
+    val sky = rememberSky()
+    Box(
+      modifier = Modifier.testTag("root").size(240.dp).sky(sky),
+      contentAlignment = Alignment.Center,
+    ) {
+      Box(modifier = Modifier.fillMaxSize().background(Color(0xFF222244)))
+      Canvas(modifier = Modifier.fillMaxSize()) {
+        val stripe = size.height / 24f
+        var y = 0f
+        var on = true
+        while (y < size.height) {
+          if (on) {
+            drawRect(color = Color.White, topLeft = Offset(0f, y), size = Size(size.width, stripe))
+          }
+          y += stripe
+          on = !on
+        }
+      }
+      Box(
+        modifier = Modifier
+          .size(width = 120.dp, height = 80.dp)
+          .clip(RoundedCornerShape(16.dp))
+          .testTag("card")
+          .cloudy(sky = sky, radius = radiusState, tint = tintState),
+      )
+    }
+  }
+
+  /** A radius > 0 blur capture: the blur layer's `drawLayer(backgroundLayer)` back-edge was the cycle. */
+  @Test
+  fun rootCapture_singleBlur() {
+    composeTestRule.setContent { Fixture() }
+    radiusState = 20
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithTag("root").captureToImage()
+  }
+
+  /** Capturing radius 0 first, then swapping to a blur and re-capturing (re-keys the cached effect). */
+  @Test
+  fun rootCapture_swapZeroThenBlur() {
+    composeTestRule.setContent { Fixture() }
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithTag("root").captureToImage()
+    radiusState = 20
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithTag("root").captureToImage()
+  }
+
+  /** Radius 0 + a non-transparent tint: the over-draw composites the sampled region back into the tree. */
+  @Test
+  fun rootCapture_tintOnly() {
+    composeTestRule.setContent { Fixture() }
+    tintState = Color(0x66FFFFFF)
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithTag("root").captureToImage()
+  }
+
+  /** Capturing the blurred card sub-node directly (an isolated PixelCopy tree that used to cycle). */
+  @Test
+  fun cardSubNodeCapture_blur() {
+    composeTestRule.setContent { Fixture() }
+    radiusState = 20
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithTag("card").captureToImage()
+  }
+}

--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/CloudyBackground.android.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.toSize
 import androidx.tracing.trace
+import com.skydoves.cloudy.internal.BackdropClearBlurMachine
 import com.skydoves.cloudy.internals.SkySnapshot
 import com.skydoves.cloudy.internals.render.RenderScriptToolkit
 import kotlinx.coroutines.Dispatchers
@@ -296,6 +297,10 @@ private class CloudyBackgroundModifierNode(
   private var cachedBlurEffect: ComposeRenderEffect? = null
   private var cachedBlurRadius: Float = -1f
 
+  // Rasterized sky-layer snapshot all backdrop draw paths sample from; see BackdropClearBlurMachine's
+  // KDoc for why they don't draw the live layer directly (issues/112, PixelCopy variant).
+  private val backdropSnapshot = BackdropClearBlurMachine()
+
   // Reusable Path for the shape clip, rebuilt only when shape/size/layoutDirection change.
   private var clipPathCache: Path? = null
 
@@ -327,9 +332,14 @@ private class CloudyBackgroundModifierNode(
       this.cpuBlurEnabled != cpuBlurEnabled ||
       this.shape != shape
 
-    if (this.sky != sky && isAttached) {
-      this.sky.frameDriver.removeOverlay(reblur)
-      sky.frameDriver.addOverlay(reblur)
+    if (this.sky != sky) {
+      if (isAttached) {
+        this.sky.frameDriver.removeOverlay(reblur)
+        sky.frameDriver.addOverlay(reblur)
+      }
+      // The cached snapshot was captured from the OLD sky's layer; a new sky's contentVersion could
+      // coincidentally match and serve a stale bitmap of the wrong backdrop.
+      backdropSnapshot.dispose()
     }
 
     this.sky = sky
@@ -380,14 +390,24 @@ private class CloudyBackgroundModifierNode(
       return
     }
 
+    // Keep the acyclic snapshot fresh for whichever path below samples it (every path except the
+    // API < 31 CPU blur, which already snapshots on its own cadence).
+    with(backdropSnapshot) {
+      requestIfStale(
+        graphicsContext = requireGraphicsContext(),
+        coroutineScope = coroutineScope,
+        layer = backgroundLayer,
+        contentVersion = sky.contentVersion,
+        invalidate = { if (isAttached) invalidateDraw() },
+      )
+    }
+
     if (radius <= 0) {
-      // No blur, draw the background region directly
       drawBackgroundRegion(backgroundLayer)
       drawContent()
       return
     }
 
-    // Calculate offset relative to sky
     val skyBounds = sky.sourceBounds
     val offsetX = positionInRoot.x - skyBounds.left
     val offsetY = positionInRoot.y - skyBounds.top
@@ -421,13 +441,17 @@ private class CloudyBackgroundModifierNode(
 
   private fun ContentDrawScope.drawBackgroundRegion(layer: GraphicsLayer) {
     val skyBounds = sky.sourceBounds
-    val offsetX = positionInRoot.x - skyBounds.left
-    val offsetY = positionInRoot.y - skyBounds.top
+    val offset = Offset(positionInRoot.x - skyBounds.left, positionInRoot.y - skyBounds.top)
 
-    drawContext.canvas.save()
-    drawContext.canvas.translate(-offsetX, -offsetY)
-    drawLayer(layer)
-    drawContext.canvas.restore()
+    // Sample the rasterized snapshot instead of `drawLayer(layer)`: the live layer reference is the
+    // cyclic-RenderNode edge that crashes captureToImage/PixelCopy (issues/112). See
+    // BackdropClearBlurMachine's KDoc for the full explanation; every other drawSampledRegion call
+    // below is the same substitution.
+    //
+    // Node's IntSize field, qualified so it isn't shadowed by DrawScope.size (canvas Size).
+    with(backdropSnapshot) {
+      drawSampledRegion(offset, this@CloudyBackgroundModifierNode.size)
+    }
 
     // Apply tint if specified
     if (tint != Color.Transparent) {
@@ -500,10 +524,13 @@ private class CloudyBackgroundModifierNode(
     // Clip both backdrop and scrim: otherwise a rounded shape leaks the unblurred rectangular
     // backdrop outside the corners (only the scrim would be clipped).
     clipToShape {
-      drawContext.canvas.save()
-      drawContext.canvas.translate(-snapshot.offsetX, -snapshot.offsetY)
-      drawLayer(layer)
-      drawContext.canvas.restore()
+      // See drawBackgroundRegion: sample the snapshot, not `drawLayer(layer)`.
+      with(backdropSnapshot) {
+        drawSampledRegion(
+          Offset(snapshot.offsetX, snapshot.offsetY),
+          IntSize(snapshot.childWidth.toInt(), snapshot.childHeight.toInt()),
+        )
+      }
 
       drawRect(color = scrimColor, blendMode = BlendMode.SrcOver)
     }
@@ -541,11 +568,14 @@ private class CloudyBackgroundModifierNode(
       cachedBlurEffect
     }
 
+    // See drawBackgroundRegion: record the snapshot into the blur layer, not `drawLayer(layer)`.
     blurLayer.record {
-      drawContext.canvas.save()
-      drawContext.canvas.translate(-snapshot.offsetX, -snapshot.offsetY)
-      drawLayer(layer)
-      drawContext.canvas.restore()
+      with(backdropSnapshot) {
+        drawSampledRegion(
+          Offset(snapshot.offsetX, snapshot.offsetY),
+          IntSize(snapshot.childWidth.toInt(), snapshot.childHeight.toInt()),
+        )
+      }
     }
 
     if (blurLayer.renderEffect != blurEffect) {
@@ -776,6 +806,7 @@ private class CloudyBackgroundModifierNode(
 
   override fun onDetach() {
     sky.frameDriver.removeOverlay(reblur)
+    backdropSnapshot.dispose()
     blurLayer?.let { requireGraphicsContext().releaseGraphicsLayer(it) }
     blurLayer = null
     cachedBlurEffect = null

--- a/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/internal/BackdropClearBlurMachine.kt
+++ b/cloudy/src/androidMain/kotlin/com/skydoves/cloudy/internal/BackdropClearBlurMachine.kt
@@ -1,0 +1,147 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.cloudy.internal
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.GraphicsContext
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+/**
+ * Samples the sky's captured [GraphicsLayer] through a rasterized snapshot instead of a live
+ * `drawLayer(sky.backgroundLayer)`.
+ *
+ * ## Why a snapshot (the captureToImage / PixelCopy crash)
+ * The backdrop node is a DESCENDANT of the sky recorder, so `sky.backgroundLayer`'s displaylist embeds
+ * this node's own RenderNode by pointer. If this node's draw records `drawLayer(sky.backgroundLayer)` —
+ * directly for the radius-0/scrim paths, or into a blur layer for the RenderEffect path — that closes a
+ * cyclic RenderNode graph: `skyLayer -> (this node's layer) -> skyLayer`.
+ *
+ * On-screen HWUI walks `prepareTreeImpl` damage-scoped and survives the cycle, but `captureToImage()` /
+ * `PixelCopy` forces a full-tree re-walk with no cycle guard, overflowing the RenderThread stack
+ * (https://github.com/skydoves/Cloudy/issues/112, PixelCopy variant). The frame-time `Sky.isCapturing`
+ * guard cannot fix it: it only skips this node's draw during the sky's OWN capture pass, but the
+ * back-edge is re-recorded on every normal draw afterward and stays live for any later capture of the
+ * window.
+ *
+ * Drawing a **bitmap** (`drawImage`) instead of `drawLayer` embeds pixels, not a RenderNode — no
+ * back-edge, no cycle. This is structurally what the API < 31 CPU path (`drawWithBitmap`, already
+ * `toImageBitmap()`-based) does, which is why it never crashed. This machine gives the API 31+ path the
+ * same acyclic shape while keeping the GPU blur: it async-captures the sky layer to an [ImageBitmap]
+ * (coalesced on the sky's `contentVersion`, the same key `drawWithBitmap` uses), then draws the sampled
+ * sub-region of that bitmap wherever the caller used to `drawLayer` the live sky layer.
+ *
+ * ## Cost
+ * - Idle (content static): the cached bitmap is reused; each frame just `drawImage`s the sampled region
+ *   — cheaper than re-walking the sky subtree through a live `drawLayer`.
+ * - Content changing (scroll / animation): one `toImageBitmap()` readback per content version, the same
+ *   cadence and cost `drawWithBitmap` already pays. One frame of staleness on a content change
+ *   (invisible for a backdrop blur), never a stale draw while idle.
+ */
+internal class BackdropClearBlurMachine {
+
+  private var snapshot: ImageBitmap? = null
+  private var cachedContentVersion: Long = -1L
+
+  // In-flight capture coalescing: never cancel a running capture; queue the newest version instead.
+  private var isCapturing: Boolean = false
+  private var captureJob: Job? = null
+  private var queuedVersion: Long = -1L
+
+  /**
+   * Refreshes the cached snapshot when [contentVersion] changed (async, coalesced); the previously
+   * cached bitmap keeps being returned via [current] until the new capture lands.
+   */
+  fun requestIfStale(
+    graphicsContext: GraphicsContext,
+    coroutineScope: CoroutineScope,
+    layer: GraphicsLayer,
+    contentVersion: Long,
+    invalidate: () -> Unit,
+  ) {
+    if (contentVersion == cachedContentVersion) return
+    requestCapture(coroutineScope, layer, contentVersion, invalidate)
+  }
+
+  private fun requestCapture(
+    coroutineScope: CoroutineScope,
+    layer: GraphicsLayer,
+    contentVersion: Long,
+    invalidate: () -> Unit,
+  ) {
+    if (isCapturing) {
+      queuedVersion = contentVersion
+      return
+    }
+    isCapturing = true
+    captureJob = coroutineScope.launch(Dispatchers.Main) {
+      try {
+        // toImageBitmap() rasterizes the sky layer to a detached bitmap (a Picture-backed hardware
+        // bitmap on API 31+): reference-free pixels, the whole point of this path.
+        snapshot = layer.toImageBitmap()
+        cachedContentVersion = contentVersion
+        invalidate()
+      } catch (e: CancellationException) {
+        throw e
+      } catch (e: Exception) {
+        // Leave the previous snapshot in place; the caller's normal Error state handling elsewhere
+        // covers the "no snapshot at all" cold-start case.
+        invalidate()
+      } finally {
+        isCapturing = false
+        captureJob = null
+        val queued = queuedVersion
+        queuedVersion = -1L
+        if (queued != -1L && queued != cachedContentVersion) {
+          requestCapture(coroutineScope, layer, queued, invalidate)
+        }
+      }
+    }
+  }
+
+  /** Samples [offset]..[offset]+size out of the cached snapshot into the current draw target. */
+  fun DrawScope.drawSampledRegion(offset: Offset, size: IntSize) {
+    val bitmap = snapshot ?: return
+    val srcW = size.width.coerceAtMost(bitmap.width)
+    val srcH = size.height.coerceAtMost(bitmap.height)
+    val srcX = offset.x.toInt().coerceIn(0, (bitmap.width - srcW).coerceAtLeast(0))
+    val srcY = offset.y.toInt().coerceIn(0, (bitmap.height - srcH).coerceAtLeast(0))
+    drawImage(
+      image = bitmap,
+      srcOffset = IntOffset(srcX, srcY),
+      srcSize = IntSize(srcW, srcH),
+      dstOffset = IntOffset.Zero,
+      dstSize = size,
+    )
+  }
+
+  fun dispose() {
+    captureJob?.cancel()
+    captureJob = null
+    isCapturing = false
+    queuedVersion = -1L
+    snapshot = null
+    cachedContentVersion = -1L
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -83,6 +83,7 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 junit4 = { module = "junit:junit", version.ref = "junit4" }
 androidx-compose-ui-test = { group = "androidx.compose.ui", name = "ui-test", version.ref = "androidxCompose" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "androidxCompose" }
+androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest", version.ref = "androidxCompose" }
 mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockito-inline" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }


### PR DESCRIPTION
## Summary
- `captureToImage()` / `PixelCopy` of a `Modifier.sky` tree with a descendant `Modifier.cloudy(sky = ...)` backdrop node crashes the RenderThread with an unbounded `RenderNode::prepareTreeImpl` recursion (SIGSEGV, stack overflow). Reproduced on emulator API 27, API 34, and a real device on API 36.
- Root cause: the backdrop blur records `drawLayer(sky.backgroundLayer)` (directly for the radius-0/scrim paths, or into the blur layer for the RenderEffect path). Since the backdrop node is a descendant of the sky recorder, this closes a cyclic RenderNode reference (`skyLayer -> card (+ blurLayer) -> skyLayer`). On-screen HWUI walks `prepareTreeImpl` damage-scoped and survives it, but `captureToImage`'s forced full-tree invalidate triggers an unguarded full re-walk that recurses into the cycle forever. The existing `Sky.isCapturing` guard (#112) only protects the sky's own capture pass. It can't clear this node's own stale back-edge afterward.
- Fix: sample the sky through a rasterized snapshot (`drawImage`) instead of a live `drawLayer(sky.backgroundLayer)`. A bitmap draw embeds pixels, not a RenderNode, so no cycle can form. This mirrors the structure the API < 31 CPU blur path already uses (`drawWithBitmap`), which never crashed for the same reason. New `BackdropClearBlurMachine` async-captures the sky layer to an `ImageBitmap`, coalesced on `sky.contentVersion`, and all three call sites (`drawBackgroundRegion`, `drawScrimFallback`, `drawWithRenderEffect`) sample the cached bitmap region instead of the live layer.
- Cost: idle/static backdrop is zero-to-negative cost (cached bitmap reused, no layer re-walk). A changing backdrop (scroll/animation) pays one `toImageBitmap()` readback per content version (the same cadence the CPU path already ships), with one frame of staleness on a content change, invisible for a backdrop blur.
- No public API changes.

## Verification

<img width="630" height="630" alt="image" src="https://github.com/user-attachments/assets/b8b7d955-10f6-45cd-9b25-ffde6c609712" />

### Before

https://github.com/user-attachments/assets/3aa306e0-091e-4c4b-954f-c7702a9c20bf

### After

https://github.com/user-attachments/assets/7565815f-7471-4eae-959e-6ae6e16bf4ec


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes when capturing blurred/tinted Compose visuals as images.
  * Improved backdrop rendering by using an updated cached snapshot for GPU/non-CPU blur paths.
  * Ensured backdrop snapshots are refreshed when sky content changes and are disposed when no longer needed.

* **Tests**
  * Added an Android instrumentation regression test covering blur + tint + screenshot capture scenarios.
  * Resolved instrumented test failures by adding the missing Compose UI test manifest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->