### PR TITLE
ci: fix the screenshot comment pipeline and post device render captures

### DIFF
--- a/.github/workflows/screenshot-comment.yml
+++ b/.github/workflows/screenshot-comment.yml
@@ -84,45 +84,77 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
 
-      # --- Are there any valid *_compare.png diff images? ---
+      # Instrumented render captures from the device-screenshots matrix (screenshot-test.yml). One
+      # artifact per API band; `pattern` + `merge-multiple` folds both into ./device-screenshots.
+      # continue-on-error: the emulator job may not have run (older producer) or a band may have
+      # produced nothing -- a missing/empty artifact must NOT fail this job. The device gallery step
+      # below simply renders no rows when the dir is empty.
+      - name: Download device screenshot artifacts
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          pattern: device-screenshots-api*
+          merge-multiple: true
+          path: device-screenshots
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      # --- Is there anything to push to the companion branch? ---
+      # `diff`  = valid *_compare.png Roborazzi diff images exist (a regression).
+      # `device` = instrumented render captures exist (present on every emulator run, not just diffs).
+      # `any`   = either -- the push + companion branch run when EITHER is true.
       - id: check
-        name: Check for diff images
+        name: Check for images to publish
         shell: bash
         run: |
-          mapfile -t files < <(find . -type f -name "*_compare.png")
-          exist="false"
-          for f in "${files[@]}"; do
+          # Roborazzi diff images (only exist on a mismatch).
+          diff="false"
+          while IFS= read -r f; do
             # Reject any path with characters outside the safe set before we touch git / build URLs.
-            if [[ "$f" =~ ^[a-zA-Z0-9_./-]+$ ]]; then
-              exist="true"
-              break
-            fi
-          done
-          echo "exist=$exist" >> "$GITHUB_OUTPUT"
+            [[ "$f" =~ ^[a-zA-Z0-9_./-]+$ ]] && { diff="true"; break; }
+          done < <(find . -type f -name "*_compare.png")
 
-      # --- Push diff images to an orphan companion branch (only when there are diffs) ---
+          # Device render captures (band_api<SDK>_<case>_{actual,expected}.png) under device-screenshots/.
+          device="false"
+          if [[ -d device-screenshots ]]; then
+            while IFS= read -r f; do
+              [[ "$f" =~ ^[a-zA-Z0-9_./-]+$ ]] && { device="true"; break; }
+            done < <(find device-screenshots -type f -name "*.png")
+          fi
+
+          any="false"
+          [[ "$diff" == "true" || "$device" == "true" ]] && any="true"
+          {
+            echo "diff=$diff"
+            echo "device=$device"
+            echo "any=$any"
+          } >> "$GITHUB_OUTPUT"
+
+      # --- Push images to an orphan companion branch (diff images and/or device captures) ---
       - id: push
-        name: Push diffs to companion branch
-        if: steps.check.outputs.exist == 'true'
+        name: Push images to companion branch
+        if: steps.check.outputs.any == 'true'
         shell: bash
         env:
           # Keyed by PR number (integer-guarded above), not head_branch -- two fork PRs can share a
           # branch name and would otherwise overwrite each other's companion branch / gallery.
           BRANCH_NAME: companion_pr-${{ steps.pr.outputs.number }}
         run: |
-          # Orphan branch: no history, just the diff images for this PR head.
+          # Orphan branch: no history, just the images for this PR head.
           git branch -D "$BRANCH_NAME" || true
           git checkout --orphan "$BRANCH_NAME"
           git rm -rf . > /dev/null
 
-          for f in $(find . -type f -name "*_compare.png"); do
+          # Roborazzi diff images (roborazzi/...) + device render captures (device-screenshots/...).
+          # Same safe-set path filter as everywhere else before staging fork-run-produced files.
+          while IFS= read -r f; do
             if [[ "$f" =~ ^[a-zA-Z0-9_./-]+$ ]]; then
               git add "$f"
             fi
-          done
+          done < <(find . -type f \( -name "*_compare.png" -o -path "./device-screenshots/*.png" \))
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -m "Add screenshot diff for PR #${{ steps.pr.outputs.number }}"
+          git commit -m "Add screenshots for PR #${{ steps.pr.outputs.number }}"
           git push origin "HEAD:$BRANCH_NAME" -f
 
       # --- Summary report (ALWAYS): parse results-summary.json into a counts table + verdict line ---
@@ -194,7 +226,7 @@ jobs:
       # comment shows BOTH the counts AND the images in one sticky comment.
       - id: gallery
         name: Generate diff gallery
-        if: steps.check.outputs.exist == 'true'
+        if: steps.check.outputs.diff == 'true'
         shell: bash
         env:
           # Must match the push step's branch key (PR number, not head_branch).
@@ -222,6 +254,77 @@ jobs:
           done
           echo "${delimiter}" >> "$GITHUB_OUTPUT"
 
+      # --- Device render gallery (ALWAYS, whenever captures exist): the actual pixels each API band
+      # drew on the emulator. This is NOT a regression diff -- it is render evidence, so it shows on
+      # every run that produced captures, independent of the Roborazzi diff above. One row per (band,
+      # case): actual, and expected beside it if the spec wrote one. Filenames are
+      # band_api<SDK>_<case>_{actual,expected}.png (see MirageBandScreenshotTest); they arrive from a
+      # fork-triggered run's artifact, so parse them as UNTRUSTED -- same ^[a-zA-Z0-9_./-]+$ safe-set
+      # filter as the diff gallery, and pull SDK/case/kind out with pure bash (no eval).
+      - id: device_gallery
+        name: Generate device render gallery
+        if: steps.check.outputs.device == 'true'
+        shell: bash
+        env:
+          # Must match the push step's branch key (PR number, not head_branch).
+          BRANCH_NAME: companion_pr-${{ steps.pr.outputs.number }}
+        run: |
+          delimiter="$(openssl rand -hex 8)"
+          {
+            echo "body<<${delimiter}"
+            echo ""
+            echo "### Device rendering"
+            echo ""
+            echo "Actual pixels captured on the emulator per API band (API 30 = GLES mirage + legacy blur, API 34 = AGSL + RenderEffect). Render evidence, not a golden diff."
+            echo ""
+            echo "| Band | Case | Actual | Expected |"
+            echo "|------|------|--------|----------|"
+          } >> "$GITHUB_OUTPUT"
+
+          # Collect one logical row per api+case, then emit actual|expected columns for each.
+          # Assoc arrays keyed by "<api>|<case>"; value is the safe repo-relative path to that PNG.
+          declare -A actual expected
+          declare -A seen
+          while IFS= read -r f; do
+            # Safe-set gate FIRST (path is fork-run-produced). Skip anything with odd chars.
+            [[ "$f" =~ ^[a-zA-Z0-9_./-]+$ ]] || continue
+            bn=$(basename "$f" .png)
+            # Expect band_api<SDK>_<case>_<kind>. Enforce the shape with a regex; ignore non-matching.
+            [[ "$bn" =~ ^band_api([0-9]+)_(.+)_(actual|expected)$ ]] || continue
+            api="${BASH_REMATCH[1]}"
+            case="${BASH_REMATCH[2]}"
+            kind="${BASH_REMATCH[3]}"
+            key="${api}|${case}"
+            seen["$key"]=1
+            if [[ "$kind" == "actual" ]]; then
+              actual["$key"]="$f"
+            else
+              expected["$key"]="$f"
+            fi
+          done < <(find device-screenshots -type f -name "*.png")
+
+          # Stable order: sort the composite keys (api numeric-ish then case).
+          for key in $(printf '%s\n' "${!seen[@]}" | sort); do
+            api="${key%%|*}"
+            case="${key#*|}"
+            a="${actual[$key]:-}"
+            e="${expected[$key]:-}"
+            if [[ -n "$a" ]]; then
+              aurl="https://github.com/${{ github.repository }}/blob/$BRANCH_NAME/$a?raw=true"
+              acell="![]($aurl)"
+            else
+              acell="_(none)_"
+            fi
+            if [[ -n "$e" ]]; then
+              eurl="https://github.com/${{ github.repository }}/blob/$BRANCH_NAME/$e?raw=true"
+              ecell="![]($eurl)"
+            else
+              ecell="_(none)_"
+            fi
+            echo "| API ${api} | \`${case}\` | ${acell} | ${ecell} |" >> "$GITHUB_OUTPUT"
+          done
+          echo "${delimiter}" >> "$GITHUB_OUTPUT"
+
       # --- Sticky comment: find the bot's previous comment (if any) by marker text ---
       - name: Find existing comment
         uses: peter-evans/find-comment@v3
@@ -231,9 +334,10 @@ jobs:
           comment-author: 'github-actions[bot]'
           body-includes: '<!-- roborazzi-screenshot-diff -->'
 
-      # --- Single sticky comment, ALWAYS posted on pull_request runs: summary + optional gallery.
-      # steps.gallery.outputs.body is empty on clean runs (the step was skipped), so the comment is
-      # just the summary; on a regression it appends the inline image gallery.
+      # --- Single sticky comment, ALWAYS posted on pull_request runs: summary + optional galleries.
+      # Both gallery outputs are empty when their step was skipped (steps.gallery on a clean Roborazzi
+      # pass, steps.device_gallery when no emulator captures), so the comment degrades to just the
+      # summary; each gallery is appended only when it has content.
       - name: Comment screenshot report
         uses: peter-evans/create-or-update-comment@v4
         with:
@@ -244,6 +348,7 @@ jobs:
             <!-- roborazzi-screenshot-diff -->
             ${{ steps.summary.outputs.body }}
             ${{ steps.gallery.outputs.body }}
+            ${{ steps.device_gallery.outputs.body }}
 
       # --- Housekeeping: prune companion_* branches older than 30 days so they don't pile up ---
       - name: Cleanup outdated companion branches

--- a/.github/workflows/screenshot-comment.yml
+++ b/.github/workflows/screenshot-comment.yml
@@ -138,7 +138,10 @@ jobs:
           # unzipped HTML cannot be deep-linked; the run page exposes the artifact downloads).
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
         run: |
-          summary_json="$(find screenshot-summary -type f -name 'results-summary.json' 2>/dev/null | head -n1)"
+          # `|| true`: the artifact is absent whenever the producing run failed before writing the
+          # summary; under `set -e -o pipefail` a bare failing find kills this step before the
+          # "summary unavailable" fallback below can run.
+          summary_json="$(find screenshot-summary -type f -name 'results-summary.json' 2>/dev/null | head -n1 || true)"
           delimiter="$(openssl rand -hex 8)"
           {
             echo "body<<${delimiter}"

--- a/.github/workflows/screenshot-comment.yml
+++ b/.github/workflows/screenshot-comment.yml
@@ -99,10 +99,23 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
 
+      # The committed goldens, uploaded on every run. continue-on-error: an older producer run (before
+      # this artifact existed) or a download hiccup must NOT fail the job -- the goldens gallery step
+      # below simply renders nothing when the dir is empty.
+      - name: Download screenshot goldens artifact
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: screenshot-goldens
+          path: goldens
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
       # --- Is there anything to push to the companion branch? ---
-      # `diff`  = valid *_compare.png Roborazzi diff images exist (a regression).
+      # `diff`   = valid *_compare.png Roborazzi diff images exist (a regression).
       # `device` = instrumented render captures exist (present on every emulator run, not just diffs).
-      # `any`   = either -- the push + companion branch run when EITHER is true.
+      # `golden` = committed goldens downloaded (present on every run -> gallery is always-on).
+      # `any`    = any of the three -- the push + companion branch run when ANY is true.
       - id: check
         name: Check for images to publish
         shell: bash
@@ -122,11 +135,20 @@ jobs:
             done < <(find device-screenshots -type f -name "*.png")
           fi
 
+          # Committed goldens under goldens/.
+          golden="false"
+          if [[ -d goldens ]]; then
+            while IFS= read -r f; do
+              [[ "$f" =~ ^[a-zA-Z0-9_./-]+$ ]] && { golden="true"; break; }
+            done < <(find goldens -type f -name "*.png")
+          fi
+
           any="false"
-          [[ "$diff" == "true" || "$device" == "true" ]] && any="true"
+          [[ "$diff" == "true" || "$device" == "true" || "$golden" == "true" ]] && any="true"
           {
             echo "diff=$diff"
             echo "device=$device"
+            echo "golden=$golden"
             echo "any=$any"
           } >> "$GITHUB_OUTPUT"
 
@@ -145,13 +167,14 @@ jobs:
           git checkout --orphan "$BRANCH_NAME"
           git rm -rf . > /dev/null
 
-          # Roborazzi diff images (roborazzi/...) + device render captures (device-screenshots/...).
-          # Same safe-set path filter as everywhere else before staging fork-run-produced files.
+          # Roborazzi diff images (roborazzi/...) + device render captures (device-screenshots/...) +
+          # committed goldens (goldens/...). Same safe-set path filter as everywhere else before
+          # staging fork-run-produced files.
           while IFS= read -r f; do
             if [[ "$f" =~ ^[a-zA-Z0-9_./-]+$ ]]; then
               git add "$f"
             fi
-          done < <(find . -type f \( -name "*_compare.png" -o -path "./device-screenshots/*.png" \))
+          done < <(find . -type f \( -name "*_compare.png" -o -path "./device-screenshots/*.png" -o -path "./goldens/*.png" \))
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -m "Add screenshots for PR #${{ steps.pr.outputs.number }}"
@@ -219,6 +242,38 @@ jobs:
             echo ""
             echo "[Full screenshot report (artifact)](${RUN_URL})"
           } >> "$GITHUB_OUTPUT"
+          echo "${delimiter}" >> "$GITHUB_OUTPUT"
+
+      # --- Goldens gallery (ALWAYS, whenever goldens were downloaded): the committed reference PNGs each
+      # spec asserts against, inlined from the companion branch. This is NOT a diff -- it shows the
+      # current expected state so a reviewer sees the actual screenshots in the PR even on a clean pass
+      # (the whole point of this section). goldens/ came from our own upload-artifact, but apply the
+      # same ^[a-zA-Z0-9_./-]+$ safe-set filter as the other galleries before building any URL.
+      - id: goldens
+        name: Generate goldens gallery
+        if: steps.check.outputs.golden == 'true'
+        shell: bash
+        env:
+          # Must match the push step's branch key (PR number, not head_branch).
+          BRANCH_NAME: companion_pr-${{ steps.pr.outputs.number }}
+        run: |
+          files=$(find goldens -type f -name "*.png" | grep -E "^[a-zA-Z0-9_./-]+$" || true)
+          delimiter="$(openssl rand -hex 8)"
+          {
+            echo "body<<${delimiter}"
+            echo ""
+            echo "### Screenshots"
+            echo ""
+            echo "Committed reference screenshots each spec verifies against (current expected state)."
+            echo ""
+            echo "| File name | Image |"
+            echo "|-----------|-------|"
+          } >> "$GITHUB_OUTPUT"
+          for f in $files; do
+            name=$(basename "$f")
+            url="https://github.com/${{ github.repository }}/blob/$BRANCH_NAME/$f"
+            echo "| \`$name\` | ![]($url?raw=true) |" >> "$GITHUB_OUTPUT"
+          done
           echo "${delimiter}" >> "$GITHUB_OUTPUT"
 
       # --- Gallery (ONLY when there are diffs): inline before/after/diff images from companion branch.
@@ -335,9 +390,9 @@ jobs:
           body-includes: '<!-- roborazzi-screenshot-diff -->'
 
       # --- Single sticky comment, ALWAYS posted on pull_request runs: summary + optional galleries.
-      # Both gallery outputs are empty when their step was skipped (steps.gallery on a clean Roborazzi
-      # pass, steps.device_gallery when no emulator captures), so the comment degrades to just the
-      # summary; each gallery is appended only when it has content.
+      # Order: summary -> goldens (always, the committed reference shots) -> diff gallery (regression
+      # only) -> device gallery (emulator captures only). Each gallery output is empty when its step
+      # was skipped, so the comment degrades to just the summary and whatever galleries have content.
       - name: Comment screenshot report
         uses: peter-evans/create-or-update-comment@v4
         with:
@@ -347,6 +402,7 @@ jobs:
           body: |
             <!-- roborazzi-screenshot-diff -->
             ${{ steps.summary.outputs.body }}
+            ${{ steps.goldens.outputs.body }}
             ${{ steps.gallery.outputs.body }}
             ${{ steps.device_gallery.outputs.body }}
 

--- a/.github/workflows/screenshot-test.yml
+++ b/.github/workflows/screenshot-test.yml
@@ -97,6 +97,20 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
+      # The committed goldens themselves (checked in under androidHostTest/assets/screenshots/). verify
+      # only writes PNGs to build/ on a mismatch, so a clean PR had no images to show; uploading the
+      # goldens gives the comment workflow an ALWAYS-ON "Screenshots" gallery -- the current state each
+      # spec asserts against, visible in the PR regardless of diff. Just checked-out files (~8 small
+      # PNGs), so this is a plain copy with no extra Gradle task.
+      - name: Upload screenshot goldens
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshot-goldens
+          path: cloudy/src/androidHostTest/assets/screenshots/*.png
+          if-no-files-found: warn
+          retention-days: 7
+
       # Stash the PR number so the privileged workflow_run job can resolve which PR to comment on
       # (workflow_run payload does not carry it directly).
       # always() so the PR number is still stashed when the verify step above FAILS (a regression) --

--- a/.github/workflows/screenshot-test.yml
+++ b/.github/workflows/screenshot-test.yml
@@ -91,7 +91,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: screenshot-summary
-          path: cloudy/build/test-results/roborazzi/debug/results-summary.json
+          # The KMP android host test writes under .../roborazzi/androidHostTest/ (not .../debug/);
+          # glob the variant segment so a task rename cannot silently drop the artifact again.
+          path: cloudy/build/test-results/roborazzi/**/results-summary.json
           if-no-files-found: warn
           retention-days: 7
 


### PR DESCRIPTION
## Problem

The screenshot comment workflow has failed on every run since it landed (see the run history of `screenshot-comment.yml`). Two independent causes:

1. `screenshot-test.yml` uploads the summary from `cloudy/build/test-results/roborazzi/debug/results-summary.json`, but the KMP Android host test writes it under `.../roborazzi/androidHostTest/`. With `if-no-files-found: warn`, the `screenshot-summary` artifact silently never exists.
2. `screenshot-comment.yml` has a fallback body for a missing summary, but the line above it, `summary_json="$(find screenshot-summary ... | head -n1)"`, exits 1 under `set -e -o pipefail` when the directory is absent, killing the step before the fallback can run. That is the message-less `exit code 1` in every failed run.

## Fix

- Upload the summary via a variant glob (`roborazzi/**/results-summary.json`) so a task rename cannot silently drop the artifact again.
- Append `|| true` to the `find` so a missing artifact takes the existing "summary unavailable" path instead of killing the step.

## Also included: always-on golden gallery

The comment now inlines the committed reference screenshots (`cloudy/src/androidHostTest/assets/screenshots/*.png`) on every run, not just on a regression. `verifyRoborazziAndroidHostTest` writes no images on a clean pass, so previously a clean PR comment had nothing visual to show; the producer now uploads the checked-in goldens as a `screenshot-goldens` artifact and the comment renders them as a "Screenshots" table via the companion branch.

## Also included: device render gallery

The comment workflow gains a "Device rendering" section that posts per-band emulator captures (`band_api<SDK>_<case>_{actual,expected}.png`) from `device-screenshots-api*` artifacts, next to the existing Roborazzi diff gallery. The section skips cleanly when no such artifacts exist, so runs from `main` and unrelated PRs are unaffected.

The producer side (an emulator matrix job and the instrumented test that writes those captures) lives in #152. Since `workflow_run` workflows always execute the default-branch file, that gallery can only take effect once this lands on `main`; #152 then exercises it end to end. This also fixes the `SC2044` find-in-for-loop actionlint warning in the push step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull requests now publish emulator/device screenshot galleries together with visual diffs in a single sticky comment.
  * Galleries are shown in a consistent order (goldens → Roborazzi diffs → device captures), with device images grouped by API level and test case (actual and optional expected).

* **Bug Fixes**
  * Improved screenshot summary artifact handling to avoid failures when artifacts are missing.
  * Updated diff/gallery publishing logic and made screenshot summary uploads resilient to test variant path differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->