### PR TITLE
fix(ci): publish cloudy-native alongside cloudy on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,11 +20,11 @@ jobs:
           java-version: 21
 
       - name: Release build
-        run: ./gradlew :cloudy:assemble --scan
+        run: ./gradlew :cloudy:assemble :cloudy-native:assemble --scan
 
       - name: Publish to MavenCentral
         run: |
-          ./gradlew :cloudy:publishAllPublicationsToMavenCentral --no-configuration-cache
+          ./gradlew :cloudy:publishAllPublicationsToMavenCentral :cloudy-native:publishAllPublicationsToMavenCentral --no-configuration-cache
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}


### PR DESCRIPTION
## Summary
- Fixes #157 — `cloudy-native:0.7.0` is missing on Maven Central, breaking consumer builds with `Could not find com.github.skydoves:cloudy-native:0.7.0`
- `cloudy-native` was split into its own module as part of the AGP 9 upgrade, and `cloudy`'s androidMain now depends on it via `implementation(project(":cloudy-native"))`, which surfaces as a `com.github.skydoves:cloudy-native` runtime dependency in the published `cloudy-android` POM
- `publish.yml` only ever ran `:cloudy:publishAllPublicationsToMavenCentral`, so `cloudy-native` (which already has its own `mavenPublishing` config) was never actually published
- This updates the release workflow to build and publish `:cloudy-native` alongside `:cloudy`

## Test plan
- [ ] `actionlint` passes on the updated workflow (verified locally)
- [ ] Next release run publishes both `cloudy` and `cloudy-native` artifacts to Maven Central
- [ ] `cloudy-native:0.7.0` needs to be backfilled separately (e.g. `./gradlew :cloudy-native:publishAllPublicationsToMavenCentral --no-configuration-cache` from the `0.7.0` tag) since this fix only covers future releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cloudy Native artifacts are now included in release builds and published alongside Cloudy artifacts.
* **Chores**
  * Updated the release workflow to assemble and publish both available modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->