### PR TITLE
Prepare for release 1.0.0-alpha01

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'docs/**'
       - 'cloudy/**'
+      - 'buildSrc/**'
       - '.github/workflows/docs.yml'
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If you're using Version Catalog, you can configure the dependency by adding it t
 ```toml
 [versions]
 #...
-cloudy = "0.7.1"
+cloudy = "1.0.0-alpha01"
 
 [libraries]
 #...
@@ -73,7 +73,7 @@ Add the dependency below to your **module**'s `build.gradle.kts` file:
 
 ```gradle
 dependencies {
-    implementation("com.github.skydoves:cloudy:0.7.1")
+    implementation("com.github.skydoves:cloudy:1.0.0-alpha01")
     
     // if you're using Version Catalog
     implementation(libs.compose.cloudy)

--- a/buildSrc/src/main/kotlin/com/skydoves/cloudy/Configuration.kt
+++ b/buildSrc/src/main/kotlin/com/skydoves/cloudy/Configuration.kt
@@ -4,11 +4,12 @@ object Configuration {
   const val compileSdk = 37
   const val targetSdk = 37
   const val minSdk = 23
-  const val majorVersion = 0
-  const val minorVersion = 7
-  const val patchVersion = 1
-  const val versionName = "$majorVersion.$minorVersion.$patchVersion"
-  const val versionCode = 18
-  const val snapshotVersionName = "$majorVersion.$minorVersion.${patchVersion + 1}-SNAPSHOT"
+  const val majorVersion = 1
+  const val minorVersion = 0
+  const val patchVersion = 0
+  const val preRelease = "-alpha01"
+  const val versionName = "$majorVersion.$minorVersion.$patchVersion$preRelease"
+  const val versionCode = 19
+  const val snapshotVersionName = "$majorVersion.$minorVersion.$patchVersion$preRelease-SNAPSHOT"
   const val artifactGroup = "com.github.skydoves"
 }


### PR DESCRIPTION
Prepare for release 1.0.0-alpha01.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the project version to **1.0.0-alpha01**.
  * Updated Maven and Gradle dependency examples in the README to use the new version.

* **Documentation**
  * Documentation deployments now also run when build configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->