### PR TITLE
feat(cloudy): read float[N] uniform elements by constant index in the mirage eDSL

### DIFF
--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/MirageParams.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/MirageParams.kt
@@ -246,7 +246,11 @@ public class UVec4 internal constructor(override val slot: Int, public var value
   }
 }
 
-/** A fixed-length `float[N]` uniform slot. */
+/**
+ * A fixed-length `float[N]` uniform slot. Inside a traced body, each element reads as a [Float1] via
+ * the constant-index `get` operator (`weights[3]`) declared in the eDSL surface
+ * ([com.skydoves.cloudy.edsl] ShaderValues.kt).
+ */
 @ExperimentalMirage
 public class UFloatArray internal constructor(
   override val slot: Int,

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/MirageParams.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/MirageParams.kt
@@ -252,16 +252,20 @@ public class UVec4 internal constructor(override val slot: Int, public var value
  * ([com.skydoves.cloudy.edsl] ShaderValues.kt).
  */
 @ExperimentalMirage
-public class UFloatArray internal constructor(
-  override val slot: Int,
-  public var value: FloatArray,
-) : UniformHandle {
-  /** The declared `N` in `float[N]` — fixed at declaration; a later [invoke] cannot resize it. */
+public class UFloatArray internal constructor(override val slot: Int, value: FloatArray) :
+  UniformHandle {
+  /** The declared `N` in `float[N]` — fixed at declaration; a later write cannot resize it. */
   public val size: Int = value.size
 
+  /** The current elements. Every write is length-checked against [size] and stored as a copy. */
+  public var value: FloatArray = value
+    set(v) {
+      require(v.size == size) { "UFloatArray value must have size $size, was ${v.size}" }
+      field = v.copyOf()
+    }
+
   public operator fun invoke(v: FloatArray) {
-    require(v.size == size) { "UFloatArray value must have size $size, was ${v.size}" }
-    value = v.copyOf()
+    value = v
   }
 }
 

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/MirageParams.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/MirageParams.kt
@@ -252,7 +252,11 @@ public class UFloatArray internal constructor(
   override val slot: Int,
   public var value: FloatArray,
 ) : UniformHandle {
+  /** The declared `N` in `float[N]` — fixed at declaration; a later [invoke] cannot resize it. */
+  public val size: Int = value.size
+
   public operator fun invoke(v: FloatArray) {
+    require(v.size == size) { "UFloatArray value must have size $size, was ${v.size}" }
     value = v.copyOf()
   }
 }

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/edsl/Expression.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/edsl/Expression.kt
@@ -61,6 +61,16 @@ internal data class Literal(val value: Float, override val type: ShaderType = Sh
 internal data class UniformRef(val slot: Int, override val type: ShaderType) : Expression
 
 /**
+ * A constant-index element read of a `float[N]` uniform, e.g. `weights[3]`. The index is a Kotlin
+ * `Int` fixed at trace time, so the emitted subscript is always a constant — the one array-access
+ * shape AGSL/SkSL's ES2-restricted profile accepts unconditionally. Element type is always `float`
+ * ([com.skydoves.cloudy.UFloatArray] is the only array uniform kind).
+ */
+internal data class UniformIndexRef(val slot: Int, val index: Int) : Expression {
+  override val type: ShaderType get() = ShaderType.Float1
+}
+
+/**
  * A reference to a standard, name-gated uniform the compiler declares on demand (`mirageTime` /
  * `mirageResolution` / `mirageDensity`) — see MirageCompiler.kt's STD_* constants. Not a [UniformRef]
  * because it has no [com.skydoves.cloudy.MirageParams] slot; referencing this node is itself what

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/edsl/RuntimeEffectEmitter.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/edsl/RuntimeEffectEmitter.kt
@@ -184,7 +184,7 @@ private fun substituteStatement(node: Statement, names: Map<Expression, String>)
 
 /** Trivial leaves and position-dependent nodes (`content.eval`, mutable locals) are never lifted. */
 private fun isLiftable(node: Expression): Boolean = when (node) {
-  is Literal, is Argument, is UniformRef, is StandardUniform, is VarRef -> false
+  is Literal, is Argument, is UniformRef, is UniformIndexRef, is StandardUniform, is VarRef -> false
   else -> !containsPositionDependent(node)
 }
 
@@ -194,14 +194,23 @@ private fun containsPositionDependent(node: Expression): Boolean = when (node) {
 }
 
 private fun children(node: Expression): List<Expression> = when (node) {
-  is Literal, is Argument, is UniformRef, is StandardUniform, is VarRef -> emptyList()
+  is Literal, is Argument, is UniformRef, is UniformIndexRef, is StandardUniform, is VarRef ->
+    emptyList()
+
   is Unary -> listOf(node.operand)
+
   is Binary -> listOf(node.left, node.right)
+
   is Comparison -> listOf(node.left, node.right)
+
   is Swizzle -> listOf(node.base)
+
   is SampleContent -> listOf(node.coord)
+
   is SampleTexture -> listOf(node.texture, node.coord)
+
   is Select -> listOf(node.condition, node.ifTrue, node.ifFalse)
+
   is Call -> node.args
 }
 
@@ -210,7 +219,8 @@ private fun nodeCount(node: Expression): Int = 1 + children(node).sumOf { nodeCo
 /** Rebuilds [node] with each child mapped through [transform], preserving its type. */
 private fun withChildren(node: Expression, transform: (Expression) -> Expression): Expression =
   when (node) {
-    is Literal, is Argument, is UniformRef, is StandardUniform, is VarRef -> node
+    is Literal, is Argument, is UniformRef, is UniformIndexRef, is StandardUniform, is VarRef ->
+      node
 
     is Unary -> node.copy(operand = transform(node.operand))
 
@@ -289,6 +299,8 @@ private fun emit(node: Expression, uniformNames: List<String>): String = when (n
   is Argument -> node.name
 
   is UniformRef -> uniformNames[node.slot]
+
+  is UniformIndexRef -> "${uniformNames[node.slot]}[${node.index}]"
 
   is StandardUniform -> node.name
 

--- a/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/edsl/ShaderValues.kt
+++ b/cloudy/src/commonMain/kotlin/com/skydoves/cloudy/edsl/ShaderValues.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import com.skydoves.cloudy.ExperimentalMirage
+import com.skydoves.cloudy.UFloatArray
 import com.skydoves.cloudy.UTexture
 
 /**
@@ -697,6 +698,20 @@ public fun mix(a: Half4, b: Color, t: Float1): Half4 = mix(a, color(b), t)
 @ExperimentalMirage
 public fun UTexture.eval(coord: Float2): Half4 =
   Half4(SampleTexture(UniformRef(slot, ShaderType.Half4), coord.e))
+
+/**
+ * `<array>[index]` — reads one element of a `float[N]` uniform as a [Float1] (`weights[3]`). The index
+ * is a Kotlin `Int`, so it is baked into the source as a constant — the array-access shape AGSL/SkSL's
+ * ES2-restricted profile always accepts. Pair with [unroll] to walk all elements (its trace-time `Int`
+ * index makes every subscript constant). A *dynamic* subscript ([loop]'s [Float1] index) is deliberately
+ * unsupported: ES2 constant-index-expression rules make it dialect-dependent, so a kernel that needs one
+ * stays a raw-string kernel. Bounds are checked against the declared [UFloatArray.size] at trace time.
+ */
+@ExperimentalMirage
+public operator fun UFloatArray.get(index: Int): Float1 {
+  require(index in 0 until size) { "index $index out of bounds for float[$size]" }
+  return Float1(UniformIndexRef(slot, index))
+}
 
 // --- Builtins / operators / swizzles the RainyWindow ("Heartfelt") port needs, added one-per-line in
 // the same factory style as the block above. Each mirrors an AGSL/SkSL builtin or GLSL operator the

--- a/cloudy/src/desktopTest/kotlin/com/skydoves/cloudy/edsl/MirageArrayUniformTest.kt
+++ b/cloudy/src/desktopTest/kotlin/com/skydoves/cloudy/edsl/MirageArrayUniformTest.kt
@@ -73,6 +73,10 @@ internal class MirageArrayUniformTest :
       shouldThrow<IllegalArgumentException> {
         ArrayWeightParams().weights(floatArrayOf(1f, 2f))
       }
+      // The property setter enforces the same invariant, so a direct write cannot bypass it.
+      shouldThrow<IllegalArgumentException> {
+        ArrayWeightParams().weights.value = floatArrayOf(1f, 2f)
+      }
     }
 
     test("the compiled program declares the array and rasterizes like a hand-written kernel") {

--- a/cloudy/src/desktopTest/kotlin/com/skydoves/cloudy/edsl/MirageArrayUniformTest.kt
+++ b/cloudy/src/desktopTest/kotlin/com/skydoves/cloudy/edsl/MirageArrayUniformTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalMirage::class)
+
+package com.skydoves.cloudy.edsl
+
+import com.skydoves.cloudy.ExperimentalMirage
+import com.skydoves.cloudy.MirageParams
+import com.skydoves.cloudy.MirageShader
+import com.skydoves.cloudy.internal.Dialect
+import com.skydoves.cloudy.internal.MirageProgramCache
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.shouldBeLessThanOrEqual
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.string.shouldContain
+import org.jetbrains.skia.RuntimeEffect
+import org.jetbrains.skia.RuntimeShaderBuilder
+import org.jetbrains.skia.Shader
+
+private const val RASTER = 32
+
+private val WEIGHTS = floatArrayOf(0.4f, 0.3f, 0.2f, 0.1f)
+
+private class ArrayWeightParams : MirageParams() {
+  val weights by uniform(WEIGHTS)
+}
+
+/**
+ * Constant-index reads of a `float[N]` uniform ([UFloatArray.get]). The subscript is a Kotlin `Int`
+ * baked in at trace time, so [unroll] walks the whole array with every access constant — checked on
+ * the emitted text, proven end-to-end by compiling the full assembled source (array declaration
+ * included) through the real skiko [RuntimeEffect] against a hand-written equivalent, and guarded by
+ * trace-time bounds / declared-length checks.
+ */
+internal class MirageArrayUniformTest :
+  FunSpec({
+
+    test("unroll reads each element with a constant subscript") {
+      val kernel = MirageShader.composite("arrayRead", ::ArrayWeightParams) { xy ->
+        var acc by local(half4(0f))
+        unroll(4) { i ->
+          acc = acc + sampleContent(xy + float2(i.toFloat() * 2f, 0f)) * half(weights[i])
+        }
+        acc
+      }.agsl
+
+      for (i in 0..3) kernel shouldContain "weights[$i]"
+    }
+
+    test("an out-of-bounds index fails at trace time") {
+      shouldThrow<IllegalArgumentException> {
+        MirageShader.composite("arrayOob", ::ArrayWeightParams) { xy ->
+          sampleContent(xy) * half(weights[4])
+        }
+      }
+    }
+
+    test("assigning a value of the wrong length fails loudly") {
+      shouldThrow<IllegalArgumentException> {
+        ArrayWeightParams().weights(floatArrayOf(1f, 2f))
+      }
+    }
+
+    test("the compiled program declares the array and rasterizes like a hand-written kernel") {
+      val shader = MirageShader.composite("arrayRaster", ::ArrayWeightParams) { xy ->
+        var acc by local(half4(0f))
+        unroll(4) { i ->
+          acc = acc + sampleContent(xy + float2(i.toFloat() * 2f, 0f)) * half(weights[i])
+        }
+        acc
+      }
+      val cached = MirageProgramCache.obtain(shader, Dialect.Sksl).shouldNotBeNull()
+      cached.compiled.source shouldContain "uniform float[4] weights;"
+
+      meanAbsDiff(
+        rasterize(bindWeights(cached.compiled.source), RASTER),
+        rasterize(bindWeights(handRolledSource()), RASTER),
+      ).shouldBeLessThanOrEqual(0.5)
+    }
+  })
+
+/** The same weighted 4-tap accumulation with the subscripts spelled by hand. */
+private fun handRolledSource(): String = """
+  uniform float[4] weights;
+  uniform shader content;
+  half4 main(float2 xy) {
+    half4 acc = half4(0.0);
+    acc = acc + content.eval(xy + float2(0.0, 0.0)) * half(weights[0]);
+    acc = acc + content.eval(xy + float2(2.0, 0.0)) * half(weights[1]);
+    acc = acc + content.eval(xy + float2(4.0, 0.0)) * half(weights[2]);
+    acc = acc + content.eval(xy + float2(6.0, 0.0)) * half(weights[3]);
+    return acc;
+  }
+""".trimIndent()
+
+private fun bindWeights(source: String): Shader {
+  val builder = RuntimeShaderBuilder(RuntimeEffect.makeForShader(source))
+  builder.uniform("weights", WEIGHTS)
+  builder.child("content", contentShader())
+  return builder.makeShader()
+}
+
+private fun contentShader(): Shader = RuntimeEffect.makeForShader(
+  """
+  half4 main(float2 xy) {
+    float2 uv = xy / float2($RASTER.0, $RASTER.0);
+    return half4(half(uv.x), half(uv.y), half(1.0 - uv.x), 1.0);
+  }
+  """.trimIndent(),
+).let { RuntimeShaderBuilder(it).makeShader() }


### PR DESCRIPTION
## What

`UFloatArray` implemented only `UniformHandle`, so a `float[N]` uniform could be declared and bound but never read inside a traced body. Kernels that need per-element data (a metaball field over N blobs, weight tables) had to split the array into N scalar uniforms.

## How

- `operator fun UFloatArray.get(index: Int): Float1` in the eDSL surface, following the `UTexture.eval` precedent. The subscript is a Kotlin `Int` fixed at trace time, so the emitted access (`weights[3]`) is always a constant, which the ES2-restricted AGSL/SkSL profile accepts unconditionally. Paired with `unroll`, a body walks a whole array with every subscript constant.
- New `UniformIndexRef` leaf node plus emitter support. Like `UniformRef` it is a trivial leaf: never CSE-hoisted, prints as `name[index]`.
- Dynamic subscripts (a `Float1` index from `loop`) stay unsupported on purpose: under ES2 constant-index-expression rules they are dialect dependent, so a kernel that needs one remains a raw-string kernel. Documented on `get`.
- `UFloatArray` now records its declared size and rejects wrong-length assignments in `invoke`, matching the existing `UVec3`/`UVec4` checks. Previously a mismatched length surfaced only as a cryptic failure at draw time.

## Tests

`MirageArrayUniformTest` covers the emitted text (`unroll` produces `weights[0]`..`weights[3]`), trace-time bounds, wrong-length assignment, and full-path raster parity: the program cache compiles the assembled source (including the `uniform float[4] weights;` declaration) through the real skiko `RuntimeEffect` and matches a hand-written equivalent. The full desktop suite, spotless, and `checkKotlinAbi` pass; the committed ABI dumps are unchanged since `@ExperimentalMirage` declarations are excluded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for constant-index access to fixed-length `float[N]` uniform arrays in shader expressions.
  * Exposed a new `size` property for float uniform arrays.
  * Added an experimental `UFloatArray[index]` helper with trace-time index validation.

* **Bug Fixes**
  * Improved shader emission and rendering to correctly preserve and output indexed uniform reads.
  * Added validation to catch out-of-bounds accesses and mismatched uniform array lengths earlier.

* **Tests**
  * Added desktop test coverage for constant-index uniform array reads, shader output, and runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->